### PR TITLE
fix: Windows compatibility for ESM entry point, venv path, and Content-Disposition parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -781,8 +781,9 @@ async function start(
   }
 }
 
-// Auto-start logic
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Auto-start logic (Windows-compatible path comparison)
+const _entryPoint = process.argv[1];
+if (_entryPoint && fileURLToPath(import.meta.url) === path.resolve(_entryPoint)) {
   start().catch((err) => {
     console.error('Fatal error starting server:', err);
     process.exit(1);

--- a/src/lib/venv-manager.ts
+++ b/src/lib/venv-manager.ts
@@ -34,7 +34,10 @@ const __dirname = path.dirname(__filename);
  */
 export async function getManagedPythonPath(): Promise<string> {
   const projectRoot = path.resolve(__dirname, '..', '..');
-  const uvVenvPython = path.join(projectRoot, '.venv', 'bin', 'python');
+  const isWindows = process.platform === 'win32';
+  const uvVenvPython = isWindows
+    ? path.join(projectRoot, '.venv', 'Scripts', 'python.exe')
+    : path.join(projectRoot, '.venv', 'bin', 'python');
 
   // Check if UV venv exists
   if (!existsSync(uvVenvPython)) {

--- a/src/lib/venv-manager.ts
+++ b/src/lib/venv-manager.ts
@@ -50,7 +50,9 @@ export async function getManagedPythonPath(): Promise<string> {
       '  2. Install all dependencies from pyproject.toml\n' +
       '  3. Generate uv.lock for reproducibility\n\n' +
       'First time setup? Install UV:\n' +
-      '  curl -LsSf https://astral.sh/uv/install.sh | sh\n' +
+      (isWindows
+        ? '  powershell -c "irm https://astral.sh/uv/install.ps1 | iex"\n'
+        : '  curl -LsSf https://astral.sh/uv/install.sh | sh\n') +
       '  # Or: pip install uv\n\n' +
       'See: https://docs.astral.sh/uv/getting-started/installation/'
     );
@@ -69,7 +71,7 @@ export async function getManagedPythonPath(): Promise<string> {
     throw new Error(
       `Python at ${uvVenvPython} is not executable.\n` +
       `This usually means .venv is corrupted. Try:\n` +
-      `  rm -rf .venv\n` +
+      (isWindows ? `  rmdir /s /q .venv\n` : `  rm -rf .venv\n`) +
       `  uv sync`,
       { cause: error }
     );

--- a/zlibrary/src/zlibrary/eapi.py
+++ b/zlibrary/src/zlibrary/eapi.py
@@ -5,11 +5,13 @@ Bypasses Cloudflare by using POST/GET to /eapi/* endpoints
 with cookie-based authentication.
 """
 
+import re
 import httpx
 import aiofiles
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import unquote
 
 
 EAPI_HEADERS = {
@@ -225,11 +227,18 @@ class EAPIClient:
                 if not filename:
                     # Try Content-Disposition header
                     cd = response.headers.get("content-disposition", "")
-                    if "filename=" in cd:
-                        # Extract filename from header
-                        parts = cd.split("filename=")
-                        if len(parts) > 1:
-                            filename = parts[1].strip().strip('"').strip("'")
+                    if "filename" in cd:
+                        m = re.search(
+                            r"filename\*\s*=\s*UTF-8''([^;\s]+)", cd, re.IGNORECASE
+                        )
+                        if m:
+                            filename = unquote(m.group(1))
+                        else:
+                            m = re.search(r'filename\s*=\s*"([^"]+)"', cd)
+                            if not m:
+                                m = re.search(r'filename\s*=\s*([^;"\s]+)', cd)
+                            if m:
+                                filename = m.group(1).strip()
                     if not filename:
                         # Derive from URL path
                         url_path = str(response.url).split("?")[0]

--- a/zlibrary/src/zlibrary/eapi.py
+++ b/zlibrary/src/zlibrary/eapi.py
@@ -244,6 +244,9 @@ class EAPIClient:
                         url_path = str(response.url).split("?")[0]
                         filename = url_path.split("/")[-1] or f"{book_id}.bin"
 
+                # Sanitize: strip directory components to prevent path traversal
+                filename = os.path.basename(filename) or f"{book_id}.bin"
+
                 output_path = Path(output_dir) / filename
 
                 async with aiofiles.open(output_path, "wb") as f:


### PR DESCRIPTION
## Summary

Fix three Windows-specific bugs that prevent the MCP server from running on Windows.

## Changes

### `src/index.ts` — ESM auto-start guard broken on Windows
The original check compared `import.meta.url` to a bare `` `file://${process.argv[1]}` `` string. On Windows, `process.argv[1]` uses backslashes while `import.meta.url` uses forward slashes, so the comparison always failed and the server never auto-started.

**Fix:** Use `fileURLToPath(import.meta.url)` and `path.resolve()` to normalize both sides before comparing.

### `src/lib/venv-manager.ts` — Python venv path hardcoded to `bin/python`
On Windows, `uv`-created venvs place the Python executable at `.venv\Scripts\python.exe`, not `.venv/bin/python`. The hardcoded Unix path meant the venv was never detected and every invocation failed.

**Fix:** Check `process.platform === 'win32'` and use the correct path for each platform.

### `zlibrary/src/zlibrary/eapi.py` — Content-Disposition filename parsing
The original `split('filename=')` approach broke on RFC 6266 extended notation (`filename*=UTF-8''...`) and percent-encoded filenames common on Windows file downloads.

**Fix:** Replace with a three-tier regex matching priority:
1. `filename*=UTF-8''<percent-encoded>` → `urllib.parse.unquote()`
2. `filename="<quoted>"`
3. `filename=<bare>`

## Testing
Verified locally on Windows 11 with Node.js 22 + Python 3.11 + UV.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes three Windows-specific issues that blocked the MCP server from running and downloading correctly on Windows.

It changes the ESM auto-start guard in `src/index.ts` to compare normalized filesystem paths (`fileURLToPath(import.meta.url)` vs `path.resolve(process.argv[1])`) instead of mixing a `file://` URL with a raw path string. This removes the path-format mismatch that could prevent startup on Windows.

It updates `src/lib/venv-manager.ts` so the managed Python executable path is chosen by platform: `.venv\\Scripts\\python.exe` on `win32`, and the existing `.venv/bin/python` path elsewhere. This changes the runtime expectation for how the UV-managed venv is located on Windows.

It also improves `zlibrary/src/zlibrary/eapi.py` filename extraction from `Content-Disposition` headers. The download flow now handles RFC 6266/RFC 5987 extended filenames, quoted values, and bare `filename=` values instead of relying on a simple string split.

Verification was reported locally on Windows 11 with Node.js 22, Python 3.11, and UV, but the new parsing and path-handling changes appear to be unaccompanied by dedicated tests in this PR, so those areas deserve review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->