### PR TITLE
docs: contributor experience — accurate setup, test tiers, community files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,11 @@ jobs:
         run: |
           node --experimental-vm-modules node_modules/jest/bin/jest.js
           uv run pytest -m "not slow and not integration" --benchmark-disable
-      # No `npm install -g npm@latest` here. That step failed every release from
-      # v1.2 through v1.2.1 (npm@latest's engines field outran the Node 22 runner),
-      # and it was never needed: `--provenance` has shipped in npm since 9.5, and
-      # Node 22 bundles npm 10.x.
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 bundles npm 10.x.
+      # Pinned to the npm@11 major — `npm@latest` is what broke releases v1.2
+      # through v1.2.1 when its engines field outran the runner's Node.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11
       - name: Verify tag matches package version
         if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
@@ -44,14 +45,17 @@ jobs:
             echo "ERROR: tag v$TAG does not match package.json version $PKG"
             exit 1
           fi
+      # Auth comes from npm's OIDC trusted publisher for this repo/workflow —
+      # no NODE_AUTH_TOKEN. Provenance is generated automatically under OIDC.
       - name: Publish with provenance
         run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Ships the same release as a container image so Docker users get versioned
   # tags instead of having to build from source (requested in issue #9).
+  # Tag pushes only: a workflow_dispatch has no semver ref, so metadata-action
+  # would derive zero tags and the push step would fail.
   publish-docker:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,8 +289,9 @@ The live plan is
 — the current health assessment and forward roadmap covering open PR/issue
 disposition, CI and release state, coverage gaps, and multi-source expansion.
 
-v1.3.0 was released 2026-07-24: the GitHub release and GHCR image are live, but the
-npm publish leg is pending an `NPM_TOKEN` secret. v1.3 (RAG Pipeline Refinement) has
+v1.3.0 was released 2026-07-24: the GitHub release and GHCR image are live; the npm
+publish leg now authenticates via OIDC trusted publishing (no `NPM_TOKEN` secret)
+and needs a re-run to ship v1.3.0 to npm. v1.3 (RAG Pipeline Refinement) has
 Phase 19 complete; Phases 20-21 are pending, with acceptance criteria preserved in
 [claudedocs/architecture/phase-20-21-review-2026-07-24.md](claudedocs/architecture/phase-20-21-review-2026-07-24.md).
 
@@ -318,8 +319,8 @@ linked under "Current Development" for the reasoning behind these:
 
 1. ISSUE-API-002 — the default EAPI domain `z-library.sk` is DiamWall-walled;
    decide a new default and make hydra discovery resilient (see ISSUES.md)
-2. Add the `NPM_TOKEN` repository secret and re-run the npm publish leg of the
-   v1.3.0 release (GitHub release and GHCR image are already live)
+2. Re-run the npm publish leg of the v1.3.0 release — it now uses OIDC trusted
+   publishing, no `NPM_TOKEN` secret (GitHub release and GHCR image are already live)
 3. Phases 20-21 — RAG quality scoring harness + CI reporting — per
    `claudedocs/architecture/phase-20-21-review-2026-07-24.md`
 4. Promote Z-Library to a `SourceAdapter` so all tools route through `SourceRouter`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+logan.rooks@mail.utoronto.ca.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,19 @@ Thank you for your interest in contributing! This guide covers everything you ne
 - **Python 3.10+** ([download](https://www.python.org/))
 - **UV** -- modern Python package manager ([install](https://docs.astral.sh/uv/))
 - **Git**
+- **git-lfs** -- required; the test PDF corpus is LFS-tracked. Run `git lfs pull`
+  after cloning. Do **not** run `git lfs install` -- it writes its own git hooks
+  and conflicts with the repo's Husky-managed hooks (`core.hooksPath`); `git lfs
+  pull` works fine without it.
 
 ### Clone and Setup
 
 ```bash
 git clone https://github.com/loganrooks/zlibrary-mcp.git
 cd zlibrary-mcp
+
+# Hydrate LFS-tracked test fixtures (no `git lfs install` needed -- see Prerequisites)
+git lfs pull
 
 # Setup Python environment (creates .venv/ with all dependencies)
 bash setup-uv.sh
@@ -33,11 +40,12 @@ npm run build
 # Node.js tests (Jest)
 npm test
 
-# Python tests (pytest)
-uv run pytest
+# Python tests -- fast suite (pytest)
+uv run pytest -m "not slow and not integration and not performance"
 ```
 
-Both test suites should pass with no errors.
+Both should pass with no errors. This pair is exactly what CI gates pull requests
+on, so if it is green locally, the PR gate will be too.
 
 ## Project Architecture
 
@@ -77,11 +85,11 @@ node --experimental-vm-modules node_modules/jest/bin/jest.js __tests__/zlibrary-
 ### Python (pytest)
 
 ```bash
-# Full test suite
-uv run pytest
+# Fast suite (the routine command; skips slow, integration, and performance tests, ~4s)
+uv run pytest -m "not slow and not integration and not performance"
 
-# Fast subset (skips slow and integration tests, ~4s)
-uv run pytest -m "not slow and not integration"
+# Full corpus suite (requires LFS-hydrated test PDFs)
+uv run pytest
 
 # Specific test file
 uv run pytest __tests__/python/test_rag_processing.py
@@ -96,6 +104,15 @@ npm run test:e2e
 ```
 
 Coverage thresholds are enforced -- CI will fail if coverage drops below the project baseline.
+
+### Test tiers and credentials
+
+| Tier | Command | Needs |
+|------|---------|-------|
+| Fast (PR gate) | `uv run pytest -m "not slow and not integration and not performance"` | Nothing extra |
+| Full corpus | `uv run pytest` | LFS-hydrated test PDFs (`git lfs pull`) |
+| Integration | `uv run pytest -m integration` | `ZLIBRARY_EMAIL` / `ZLIBRARY_PASSWORD` in `.env`; auto-skips without them |
+| E2E | `npm run test:e2e` | Docker |
 
 ## Code Style
 
@@ -132,28 +149,67 @@ git checkout -b docs/topic                   # Documentation
 
 ### Commit Messages
 
-Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+Use [Conventional Commits](https://www.conventionalcommits.org/) format: `<type>(<scope>): <subject>`
 
 ```
-feat: add new search filter for publisher
-fix: handle empty search results gracefully
+feat(search): add new search filter for publisher
+fix(api): handle empty search results gracefully
 docs: update API reference with new parameter
-refactor: extract retry logic into separate module
-test: add integration tests for download flow
-chore: update dependencies
+refactor(bridge): extract retry logic into separate module
+test(download): add integration tests for download flow
+chore(deps): update dependencies
 ```
+
+**Types:**
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `feat` | New feature | `feat(search): add fuzzy matching support` |
+| `fix` | Bug fix | `fix(venv): handle undefined config values` |
+| `docs` | Documentation only | `docs(readme): update setup instructions` |
+| `style` | Code style changes (formatting) | `style: apply prettier formatting` |
+| `refactor` | Code refactoring | `refactor(bridge): extract retry logic` |
+| `perf` | Performance improvements | `perf(search): implement result caching` |
+| `test` | Adding/updating tests | `test(api): add error handling tests` |
+| `chore` | Maintenance tasks | `chore(deps): update dependencies` |
+| `ci` | CI/CD changes | `ci: add automated testing workflow` |
+| `build` | Build system changes | `build: update typescript config` |
+| `revert` | Revert previous commit | `revert: revert "feat: add feature"` |
+
+**Scopes** (the area of the codebase affected): `search`, `download`, `rag`, `api`,
+`bridge`, `venv`, `zlib`, plus `tests`, `docs`, and `deps` where appropriate.
 
 Keep commits focused -- one logical change per commit.
+
+## Constraints that will fail review
+
+These are hard rules; PRs that break them will be sent back:
+
+- **stdio purity**: under the stdio transport, stdout is the JSON-RPC channel and
+  nothing else. Diagnostics must use `logger` from `src/lib/logger.ts` (stderr).
+  A `console.log` in `src/` breaks strict stdio clients, and
+  `__tests__/stdio-purity.test.js` fails the build if one appears.
+- **Additive-only RAG bundle contract**: the Python bridge output shape (the
+  structured RAG output bundle from `process_document_for_rag` and
+  `download_book_to_file`) is consumed by MCP clients. Add fields only -- never
+  rename, remove, or change the meaning of existing ones.
+- **Dependency floors in `pyproject.toml`**: version floors follow the audit
+  policy in SECURITY.md. Do not lower a floor or loosen a constraint without
+  flagging it explicitly in the PR.
 
 ## Pull Request Process
 
 1. Create a feature branch from `master`
 2. Make your changes, following existing code patterns
-3. Ensure tests pass locally: `npm test` and `uv run pytest`
+3. Ensure tests pass locally: `npm test` and the fast pytest suite (see [Test tiers](#test-tiers-and-credentials))
 4. lint-staged hooks will run automatically on commit (ESLint, Prettier, Ruff, TypeScript type-check)
 5. Push your branch and open a PR
 6. CI will run tests, linting, and coverage checks
 7. Address any review feedback
+
+Note: PRs from forks run the fast suite only -- the full corpus and Docker E2E
+jobs run post-merge. Flag anything you could not verify locally in the PR
+description so reviewers can weigh a known gap rather than an unknown one.
 
 ### PR Description
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Model Context Protocol (MCP) server that gives AI assistants -- Claude Code, C
 ```bash
 git clone https://github.com/loganrooks/zlibrary-mcp.git
 cd zlibrary-mcp
+git lfs pull        # hydrates the LFS-tracked test PDFs; don't run `git lfs install` (conflicts with the repo's Husky hooks)
 bash setup-uv.sh && npm install && npm run build
 ```
 
@@ -143,6 +144,8 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # 2. Clone and build
 git clone https://github.com/loganrooks/zlibrary-mcp.git
 cd zlibrary-mcp
+git lfs pull         # Hydrates LFS-tracked test PDFs (don't run `git lfs install`;
+                     # it conflicts with the repo's Husky-managed hooks)
 bash setup-uv.sh    # Creates .venv/ and installs Python dependencies
 npm install          # Installs Node.js dependencies
 npm run build        # Compiles TypeScript to dist/
@@ -293,10 +296,13 @@ See [docs/RETRY_CONFIGURATION.md](docs/RETRY_CONFIGURATION.md) for details.
 ### Running Tests
 
 ```bash
-# Run all tests (Jest for Node.js + Pytest for Python)
+# Node.js tests (Jest only -- npm test does not run pytest)
 npm test
 
-# Python tests only
+# Python tests -- fast suite (the routine command)
+uv run pytest -m "not slow and not integration and not performance"
+
+# Python tests -- full corpus (requires LFS-hydrated test PDFs)
 uv run pytest
 
 # Specific Python test

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,69 @@
+# docs/ Index
+
+This directory mixes two kinds of documents: **reference** material that is kept
+current, and **historical** one-off reports and design explorations preserved for
+context. If you are setting up or troubleshooting the server, everything you need
+is in the Reference section.
+
+## Reference (kept current)
+
+| Document | What it covers |
+|----------|----------------|
+| [api.md](api.md) | API reference for all MCP tools |
+| [adr/](adr/) | Architecture Decision Records (ADR-001 through ADR-010) |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Setup and runtime troubleshooting |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Deployment paths and edge cases |
+| [RETRY_CONFIGURATION.md](RETRY_CONFIGURATION.md) | Retry and circuit-breaker configuration |
+| [specifications/](specifications/) | Formal technical specifications (RAG pipeline features) |
+| [MIGRATION_V2.md](MIGRATION_V2.md) | UV migration guide (pip/venv to UV) |
+| [examples/](examples/) | MCP config templates and usage examples |
+| [installation/](installation/) | System-wide setup notes |
+
+## Historical (one-off reports and superseded designs)
+
+Preserved for context; not maintained. Details may no longer match the code.
+
+**Architecture and design explorations:**
+[ARCHITECTURE_ANALYSIS.md](ARCHITECTURE_ANALYSIS.md),
+[CITATION_INFERENCE_ARCHITECTURE.md](CITATION_INFERENCE_ARCHITECTURE.md),
+[CURRENT_PIPELINE_FLOW.md](CURRENT_PIPELINE_FLOW.md),
+[HYBRID_TOC_EXTRACTION.md](HYBRID_TOC_EXTRACTION.md),
+[MARGINALIA_DESIGN.md](MARGINALIA_DESIGN.md),
+[METADATA_ARCHITECTURE.md](METADATA_ARCHITECTURE.md),
+[RAG_PIPELINE_ENHANCEMENTS_V2.md](RAG_PIPELINE_ENHANCEMENTS_V2.md),
+[architecture/](architecture/)
+
+**One-off reports and summaries:**
+[BOOK_PAGE_METADATA_COMPLETE.md](BOOK_PAGE_METADATA_COMPLETE.md),
+[FOOTNOTE_CONTINUATION_QUICKSTART.md](FOOTNOTE_CONTINUATION_QUICKSTART.md),
+[IMPLEMENTATION_SUMMARY_HYBRID_TOC.md](IMPLEMENTATION_SUMMARY_HYBRID_TOC.md),
+[INT-001-Resolution-Report.md](INT-001-Resolution-Report.md),
+[METADATA_VERIFICATION.md](METADATA_VERIFICATION.md),
+[TESTING_LESSONS_LEARNED.md](TESTING_LESSONS_LEARNED.md),
+[rag-output-qa-report-rerun-20250429.md](rag-output-qa-report-rerun-20250429.md)
+
+**Early specs and plans (pre-dating the current implementation):**
+[RESEARCH_TOOLS_SPECIFICATION.md](RESEARCH_TOOLS_SPECIFICATION.md),
+[UV_MIGRATION_PLAN.md](UV_MIGRATION_PLAN.md),
+[get-book-metadata-spec.md](get-book-metadata-spec.md),
+[pdf-processing-implementation-spec.md](pdf-processing-implementation-spec.md),
+[project-plan-zlibrary-mcp.md](project-plan-zlibrary-mcp.md),
+[rag-markdown-generation-spec.md](rag-markdown-generation-spec.md),
+[rag-output-quality-spec.md](rag-output-quality-spec.md),
+[rag-pipeline-implementation-spec.md](rag-pipeline-implementation-spec.md),
+[rag-robustness-enhancement-spec.md](rag-robustness-enhancement-spec.md),
+[mcp-zod-validation-error-research.md](mcp-zod-validation-error-research.md)
+
+**Z-Library site research (pre-EAPI era):**
+[Z-LIBRARY_SITE_ANALYSIS.md](Z-LIBRARY_SITE_ANALYSIS.md),
+[ZLIBRARY_TECHNICAL_IMPLEMENTATION.md](ZLIBRARY_TECHNICAL_IMPLEMENTATION.md),
+[zlibrary_repo_overview.md](zlibrary_repo_overview.md),
+[MCP_RECOMMENDATIONS.md](MCP_RECOMMENDATIONS.md),
+[MCP_SCRAPING_SETUP.md](MCP_SCRAPING_SETUP.md),
+[mcp-reference/](mcp-reference/)
+
+**Deployment-era reports:** [deployment/](deployment/) (validation matrices and
+readiness checklists from the v1.2 release cycle)
+
+**Archive:** [archive/](archive/) (explicitly archived analyses and session
+reports)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,10 +1,41 @@
 # Troubleshooting Guide
 
-Common issues and solutions for Z-Library MCP server.
+Common issues and solutions for the Z-Library MCP server.
+
+> **Note**: Since v2.0.0 the project uses [UV](https://docs.astral.sh/uv/) with a
+> project-local `.venv/`. There is **no** cache venv at `~/.cache/zlibrary-mcp/` and no
+> `.venv_config` file — if a guide mentions those, it predates the UV migration.
 
 ---
 
-## ImportError: cannot import name from 'zlibrary'
+## Server exits immediately / won't start
+
+### Symptoms
+
+The MCP client reports the server disconnected, or `node dist/index.js` exits at once.
+
+### Checks, in order
+
+1. **Build output missing or stale**:
+   ```bash
+   npm run build      # compiles TypeScript and validates Python files exist
+   ```
+2. **Python venv missing** (fresh clone or after cleaning):
+   ```bash
+   uv sync            # creates .venv/ and installs all Python dependencies
+   ```
+3. **Node version**: Node 22+ is required (see `engines` in `package.json` / `.nvmrc`).
+4. **Credentials**: `ZLIBRARY_EMAIL` / `ZLIBRARY_PASSWORD` must be set in the
+   environment or the client's `.mcp.json` `env` block.
+
+A healthy start prints (to **stderr**):
+```
+Z-Library MCP server (ESM/TS) is running via Stdio...
+```
+
+---
+
+## ImportError: cannot import name ... from 'zlibrary'
 
 ### Symptom
 
@@ -13,80 +44,22 @@ MCP tools fail with:
 ImportError: cannot import name 'Extension' from 'zlibrary' (unknown location)
 ```
 
-### Causes
+### Cause
 
-#### Cause 1: Stale Cache Venv After Project Move
+The project-local `.venv/` is missing, stale, or was created before the vendored
+`./zlibrary` fork changed. The fork is installed editable, so the venv must be in sync
+with the working tree.
 
-**Description**: The venv-manager uses a shared cache venv at `~/.cache/zlibrary-mcp/` instead of the project-local `venv/`. If you move the project directory, the editable zlibrary install in the cache venv points to the old location.
+### Solution
 
-**How to Diagnose**:
 ```bash
-# Check cache venv zlibrary location
-~/.cache/zlibrary-mcp/zlibrary-mcp-venv/bin/pip show zlibrary
-
-# Look for:
-# Location: /old/path/to/project/zlibrary  ← WRONG
-# Should be: /current/path/to/project/zlibrary
+uv sync
+.venv/bin/python -c "from zlibrary import Extension; print('OK')"
 ```
 
-**Solution**: Reinstall zlibrary in cache venv
-
-**Quick Fix** (Run from project root):
-```bash
-bash scripts/fix-cache-venv.sh
-```
-
-**Manual Fix**:
-```bash
-# Get current project location
-PROJECT_ROOT=$(pwd)
-
-# Reinstall zlibrary in cache venv
-~/.cache/zlibrary-mcp/zlibrary-mcp-venv/bin/pip install -e "$PROJECT_ROOT/zlibrary" --force-reinstall --no-deps
-
-# Verify
-~/.cache/zlibrary-mcp/zlibrary-mcp-venv/bin/python -c "from zlibrary import Extension; print('✅ Fixed')"
-```
-
-**Then**: Restart Claude Code in your workspace
-
----
-
-#### Cause 2: Cache Venv Not Initialized
-
-**Description**: The cache venv doesn't exist or wasn't properly initialized.
-
-**How to Diagnose**:
-```bash
-ls ~/.cache/zlibrary-mcp/zlibrary-mcp-venv/
-# If doesn't exist or empty → not initialized
-```
-
-**Solution**: Run initial setup
-```bash
-cd /path/to/zlibrary-mcp
-npm run build  # Creates and initializes cache venv
-```
-
----
-
-#### Cause 3: Python Version Mismatch
-
-**Description**: Cache venv created with different Python version than current system.
-
-**How to Diagnose**:
-```bash
-~/.cache/zlibrary-mcp/zlibrary-mcp-venv/bin/python --version
-python3 --version
-
-# If versions don't match or cache Python doesn't work → version issue
-```
-
-**Solution**: Recreate cache venv
-```bash
-rm -rf ~/.cache/zlibrary-mcp/
-npm run build  # Recreates with current Python
-```
+If you **moved the project directory**, `.venv/` moves with it (it is project-local),
+but run `uv sync` once from the new location to be safe, and update any absolute paths
+in your clients' `.mcp.json`.
 
 ---
 
@@ -94,94 +67,62 @@ npm run build  # Recreates with current Python
 
 ### Symptom
 
-Error message shows:
 ```
 Python bridge script not found at: /path/to/dist/lib/python_bridge.py
 This usually indicates a build or installation issue.
 ```
 
-### Cause
-
-Build didn't complete successfully or Python scripts are missing.
-
 ### Solution
 
-**Verify files exist**:
-```bash
-npm run validate
+Python sources stay in `lib/` (they are not copied into `dist/`); the built JS resolves
+them relative to the project root. Verify and rebuild:
 
-# Should show:
-# ✅ lib/python_bridge.py
-# ✅ lib/rag_processing.py
-# etc.
-```
-
-**Rebuild if needed**:
 ```bash
+npm run validate   # checks all Python bridge files exist
 npm run build
 ```
 
-**Check source files**:
-```bash
-ls -la lib/*.py
-# All Python files should be present
-```
+See `docs/adr/ADR-004-Python-Bridge-Path-Resolution.md` for how resolution works.
 
 ---
 
-## Virtual environment configuration is missing or invalid
+## Network / upstream failures (searches fail, downloads fail)
 
-### Symptom
+### First step: run the doctor
 
-```
-Error: Virtual environment configuration is missing or invalid.
-Please run the setup process again.
-```
-
-### Cause
-
-Config file at `~/.cache/zlibrary-mcp/.venv_config` is missing or points to non-existent Python.
-
-### Solution
-
-**Check config**:
 ```bash
-cat ~/.cache/zlibrary-mcp/.venv_config
-# Should show path to cache venv Python
-
-ls -la "$(cat ~/.cache/zlibrary-mcp/.venv_config)"
-# Python should exist at that path
+npm run doctor
 ```
 
-**Fix by rebuilding**:
-```bash
-rm ~/.cache/zlibrary-mcp/.venv_config
-npm run build  # Recreates config
-```
+It probes the live endpoints the server actually uses (Z-Library EAPI, Anna's Archive,
+LibGen) and reports OK/WARN/FAIL per surface. Required failures point at real breakage;
+optional failures usually mean a secondary source is unreachable.
+
+### Common causes
+
+- **Region blocking**: Z-Library domains are blocked on some networks. Domain discovery
+  ("hydra mode") normally finds a working mirror at runtime; you can pin one explicitly:
+  ```bash
+  ZLIBRARY_EAPI_DOMAIN=<working-domain> npm run doctor
+  ```
+  The same variable works for the server and the integration tests.
+- **Bad credentials**: login failures surface as auth errors, not network errors —
+  re-check `ZLIBRARY_EMAIL` / `ZLIBRARY_PASSWORD`.
+- **Genuine upstream drift**: if the doctor reports a contract change (JSON shape
+  changed), that is a bug — please open an issue and include the doctor output.
 
 ---
 
-## MCP Tools Work Locally But Fail in Claude Code
-
-### Symptom
-
-Direct execution works:
-```bash
-node dist/index.js
-# Works ✅
-```
-
-But MCP calls from Claude Code fail.
+## MCP tools work locally but fail in Claude Code / other clients
 
 ### Causes
 
-1. **Different working directory**: Claude Code may run from different directory
-2. **Environment variables**: ZLIBRARY_EMAIL/PASSWORD not set in .mcp.json
-3. **Permission issues**: Cache venv not readable
+1. Relative path to `dist/index.js` in `.mcp.json` — must be absolute
+2. Credentials missing from the client's `env` block
+3. A modified build printing to stdout (see next section)
 
 ### Solution
 
-**Check .mcp.json configuration**:
 ```json
 {
   "mcpServers": {
@@ -197,118 +138,72 @@ But MCP calls from Claude Code fail.
 }
 ```
 
-**Important**:
-- Use ABSOLUTE path to `dist/index.js`
-- Include credentials in env block
-- Restart Claude Code after changes
+Use `node`, not `uv`, as the command — the Node entry point locates the UV venv itself.
+Restart the client after changes.
 
 ---
 
-## After Moving Project Directory
+## Strict clients disconnect (developers)
 
-If you've moved the project from one location to another:
-
-### Steps to Fix
-
-1. **Update cache venv** (run from new location):
-   ```bash
-   bash scripts/fix-cache-venv.sh
-   ```
-
-2. **Verify build**:
-   ```bash
-   npm run validate
-   ```
-
-3. **Update .mcp.json** in your workspaces:
-   ```json
-   "args": ["/new/absolute/path/to/zlibrary-mcp/dist/index.js"]
-   ```
-
-4. **Restart Claude Code**
+Under the stdio transport, **stdout carries JSON-RPC and nothing else**. A single
+`console.log` anywhere in `src/` corrupts the protocol stream and strict clients drop
+the connection. Use the `logger` from `src/lib/logger.ts` (writes to stderr).
+`__tests__/stdio-purity.test.js` enforces this at build time — run `npm test` before
+debugging the client side.
 
 ---
 
-## Testing the MCP Server
+## Test suite fails on a fresh clone (PyMuPDF errors, tiny PDF files)
 
-### Test 1: Direct Execution
+### Symptom
+
+Many Python tests fail with PDF parse errors; files under `test_files/` are ~130 bytes.
+
+### Cause
+
+The test corpus is stored in **Git LFS**. Without LFS you have pointer files, not PDFs.
+
+### Solution
 
 ```bash
-cd /path/to/zlibrary-mcp
-export ZLIBRARY_EMAIL="your-email"
-export ZLIBRARY_PASSWORD="your-password"
-node dist/index.js
+sudo apt-get install -y git-lfs   # or brew install git-lfs
+git lfs pull                      # from the repo root
+file test_files/*.pdf             # should say "PDF document", not "ASCII text"
 ```
 
-Should show:
-```
-Z-Library MCP server (ESM/TS) is running via Stdio...
-```
+> Do not run `git lfs install` inside this repo — it refuses to overwrite the repo's
+> existing `pre-push` hook. `git lfs pull` alone is enough for fetching objects.
+
+### Which tests need what
+
+| Subset | Command | Needs |
+|---|---|---|
+| Fast (what CI gates PRs on) | `uv run pytest -m "not slow and not integration and not performance"` | nothing extra |
+| Full corpus | `uv run pytest` | LFS objects |
+| Live integration | `uv run pytest -m integration` | `ZLIBRARY_EMAIL`/`ZLIBRARY_PASSWORD` (auto-**skips** without them) |
+| E2E | `npm run test:e2e` | Docker |
 
 ---
 
-### Test 2: Python Bridge Direct Call
+## Quick diagnostic commands
 
 ```bash
-~/.cache/zlibrary-mcp/zlibrary-mcp-venv/bin/python \
-  /path/to/zlibrary-mcp/lib/python_bridge.py \
-  get_download_limits \
-  '{}'
-```
-
-Should return JSON with download limits (not ImportError).
-
----
-
-### Test 3: Via MCP (from another workspace)
-
-1. Create test `.mcp.json` (or use existing)
-2. Start Claude Code
-3. Try: "Search Z-Library for test query"
-4. Should work without ImportError
-
----
-
-## Quick Diagnostic Commands
-
-```bash
-# Check which Python venv-manager is using
-cat ~/.cache/zlibrary-mcp/.venv_config
-
-# Check if that Python works
-$(cat ~/.cache/zlibrary-mcp/.venv_config) -c "from zlibrary import Extension; print('OK')"
-
-# Check zlibrary installation location
-~/.cache/zlibrary-mcp/zlibrary-mcp-venv/bin/pip show zlibrary | grep Location
-
-# Run build validation
-npm run validate
-
-# Run integration tests
-npm test __tests__/integration/
+npm run validate                  # Python bridge files present?
+uv run python -c "import lib.python_bridge; print('bridge imports OK')"
+npm run doctor                    # live upstream contract check
+npm test                          # Jest (Node side, includes stdio purity)
+uv run pytest -m "not slow and not integration and not performance"  # fast Python suite
 ```
 
 ---
 
 ## Getting Help
 
-If issues persist:
-
-1. Run diagnostics:
-   ```bash
-   bash scripts/fix-cache-venv.sh  # Attempts automatic fix
-   npm run validate                 # Checks files
-   npm test                        # Runs tests
-   ```
-
-2. Check logs (if enabled):
-   ```bash
-   tail -f logs/nodejs_debug.log
-   ```
-
-3. Report issue with diagnostics:
-   - https://github.com/loganrooks/zlibrary-mcp/issues
+1. Run `npm run doctor` and `npm run validate` and capture the output.
+2. Check existing issues: https://github.com/loganrooks/zlibrary-mcp/issues
+3. Open a bug report — the issue template asks for the doctor output and your
+   OS/client; scrub any credentials from pasted stderr logs first.
 
 ---
 
-**Last Updated**: 2025-10-12
+**Last verified**: 2026-07-24


### PR DESCRIPTION
## Summary

Contributor-facing documentation pass: accurate setup instructions, an honest test-tier map, hard review constraints stated up front, and standard community files.

**Base note:** this PR is stacked on `chore/remove-gsd-planning` (#33) because it builds on that PR's CLAUDE.md state. After #33 merges, retarget this PR's base to `master`.

## Changes

- **docs/TROUBLESHOOTING.md** — full rewrite for the UV era. The old version documented a removed cache-venv architecture and a nonexistent fix script.
- **CONTRIBUTING.md** —
  - git-lfs added to prerequisites: test PDFs are LFS-tracked; `git lfs pull` after cloning; do not run `git lfs install` (it conflicts with the repo's Husky-managed hooks via `core.hooksPath`)
  - "Verify Setup" now runs `npm test` plus `uv run pytest -m "not slow and not integration and not performance"` — exactly what CI gates PRs on
  - "Test tiers and credentials" table: fast (nothing extra) / full corpus (LFS) / integration (`ZLIBRARY_EMAIL`/`ZLIBRARY_PASSWORD` from `.env`, auto-skips without) / e2e (Docker)
  - "Constraints that will fail review": stdio purity (no `console.log` in `src/`; stdout is JSON-RPC; enforced by `__tests__/stdio-purity.test.js`), additive-only RAG bundle contract, `pyproject.toml` dependency-floor policy
  - Note that fork PRs run the fast suite only (full corpus + Docker run post-merge), so contributors should flag anything not verified locally
  - Commit-type table and scope vocabulary (`search`, `download`, `rag`, `api`, `bridge`, `venv`, `zlib`) folded in from `.claude/VERSION_CONTROL.md`
- **README.md** — `npm test` correctly described as Jest-only; fast filtered pytest command shown as the routine one and plain `uv run pytest` labeled as the full corpus (needs LFS); git-lfs step added to both clone blocks with the same pull-not-install caveat
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (contact: logan.rooks@mail.utoronto.ca)
- **docs/README.md** — index of `docs/` split into Reference (kept current) vs Historical (one-off reports, superseded designs)
- **CLAUDE.md** — npm-publish notes aligned with the OIDC trusted-publishing change that landed on this branch (`ci: switch npm publish to OIDC trusted publishing`): the publish leg no longer needs an `NPM_TOKEN` secret, only a re-run

## Verification

- `npm run build` — passes
- `uv run pytest -m "not slow and not integration and not performance" -q` — 998 passed, 3 skipped, 7 xfailed (on the base branch; this PR touches only docs and one workflow comment-level change from the owner's OIDC commit)