### PR TITLE
fix: resilient EAPI domain fallback and probing (ISSUE-API-002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Resilient EAPI domain fallback and probing** (ISSUE-API-002): the single default
+  EAPI domain `z-library.sk` is fronted by the DiamWall anti-bot wall (HTTP 307
+  self-redirect setting a `__diamwall` cookie, then 513/517 Access Denied), which
+  killed login and every tool with default settings. The default is now a probed
+  fallback list (`z-library.ec`, `z-library.sk`, `1lib.sk`): each candidate is
+  validated with a cheap unauthenticated `GET /eapi/info/domains` — never the
+  rate-limited login endpoint — and the first healthy one is used. Hydra-mode
+  domain discovery also probes advertised domains before switching, since
+  `/eapi/info/domains` still advertises the walled domain first; if nothing
+  advertised is usable the client keeps its working domain. An explicit
+  `ZLIBRARY_EAPI_DOMAIN` is honoured verbatim with no probing and no silent
+  switching. DiamWall HTML where JSON was expected now raises a dedicated
+  `DiamWallError` naming the wall and the remedy; the health check classifies it
+  as `diamwall_blocked` and `npm run doctor` reports it explicitly.
+
 ## [1.3.0] - 2026-07-24
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,14 +317,14 @@ The `.claude` folder contains comprehensive documentation for development:
 Check `ISSUES.md` (project root) for the full list, and the health assessment
 linked under "Current Development" for the reasoning behind these:
 
-1. ISSUE-API-002 — the default EAPI domain `z-library.sk` is DiamWall-walled;
-   decide a new default and make hydra discovery resilient (see ISSUES.md)
-2. Phases 20-21 — RAG quality scoring harness + CI reporting — per
+1. Phases 20-21 — RAG quality scoring harness + CI reporting — per
    `claudedocs/architecture/phase-20-21-review-2026-07-24.md`
-3. Promote Z-Library to a `SourceAdapter` so all tools route through `SourceRouter`
+2. Promote Z-Library to a `SourceAdapter` so all tools route through `SourceRouter`
 
 Done and no longer priorities: the v1.3.0 release shipped 2026-07-24 (modulo the
-npm token above), and Windows support (PR #13) shipped in v1.3.0.
+npm token above), Windows support (PR #13) shipped in v1.3.0, and ISSUE-API-002
+(DiamWall-walled default domain) is fixed by the probed EAPI domain fallback list
+with probe-guarded hydra discovery (see ISSUES.md).
 
 Resolved and no longer priorities, despite older docs saying otherwise: ISSUE-002
 (closed by the UV migration), ISSUE-005 (closed by `src/lib/retry-manager.ts` and

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -119,7 +119,7 @@ or password"}` even for valid credentials, recovering after a cooldown. The
 integration suite logs in once per module (shared `zlib_client` fixture) to stay
 under this limit — and the domain probe deliberately uses `GET /eapi/info/domains`,
 never login, for the same reason.
-**Resolution** (2026-07-24, PR "fix: resilient EAPI domain fallback and probing"):
+**Resolution** (2026-07-24, PR #36 "fix: resilient EAPI domain fallback and probing"):
 (1) single default replaced by the probed fallback list
 `DEFAULT_EAPI_DOMAINS = ["z-library.ec", "z-library.sk", "1lib.sk"]` in
 `zlibrary/src/zlibrary/eapi.py`; an explicit `ZLIBRARY_EAPI_DOMAIN` is honoured

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -101,6 +101,36 @@ skips with the cause and the fix (`git lfs pull`).
 **Resolution**: EAPI migration (Phase 7, Feb 2026). All API calls now use EAPI JSON endpoints which bypass Cloudflare browser challenges. Health check with Cloudflare detection added.
 **ADR**: [ADR-005-EAPI-Migration](docs/adr/ADR-005-EAPI-Migration.md)
 
+### ISSUE-API-002: Default EAPI Domain (z-library.sk) Fronted by DiamWall Anti-Bot [RESOLVED]
+**Severity**: Was High
+**Discovered**: 2026-07-24, first automated run of the credentialed integration suite
+**Impact**: The default EAPI domain `z-library.sk` no longer serves `/eapi/*` to
+programmatic clients. All requests get an HTTP 307 self-redirect from "DiamWall"
+that sets a `__diamwall` cookie, then 513/517 "Access Denied" on retry — including
+with the EAPIClient's browser User-Agent. `1lib.sk` shows the same wall. With the
+old defaults, `initialize_eapi_client()` failed at login and every tool was dead.
+**Evidence** (2026-07-24, unrestricted network):
+- `POST https://z-library.sk/eapi/user/login` → 307 → `Set-Cookie: __diamwall=…` → retry → 517 Access Denied (DiamWall-branded page, cdn.diamwall.com assets)
+- Same request against `z-library.ec` → normal EAPI JSON (`{"success":0,"error":"Incorrect email or password"}` for bad creds; real login succeeds)
+- `/eapi/info/domains` (queried via z-library.ec) still advertises `z-library.sk` FIRST, so Hydra-mode domain discovery in `initialize_eapi_client()` would actively switch a working client back to the walled domain.
+**Related finding**: `/eapi/user/login` rate-limits repeated logins from one IP —
+after ~10 logins in an hour it returns 400 `{"success":0,"error":"Incorrect email
+or password"}` even for valid credentials, recovering after a cooldown. The
+integration suite logs in once per module (shared `zlib_client` fixture) to stay
+under this limit — and the domain probe deliberately uses `GET /eapi/info/domains`,
+never login, for the same reason.
+**Resolution** (2026-07-24, PR "fix: resilient EAPI domain fallback and probing"):
+(1) single default replaced by the probed fallback list
+`DEFAULT_EAPI_DOMAINS = ["z-library.ec", "z-library.sk", "1lib.sk"]` in
+`zlibrary/src/zlibrary/eapi.py`; an explicit `ZLIBRARY_EAPI_DOMAIN` is honoured
+verbatim with no probing and no silent switching; (2) hydra discovery
+(`select_advertised_domain()` / `discover_eapi_domain()`) probes each advertised
+domain and skips walled ones, keeping the current working domain when nothing
+advertised is usable; (3) DiamWall HTML-where-JSON-expected now raises
+`DiamWallError`, classified as `diamwall_blocked` by the health check and reported
+explicitly by `npm run doctor`, with the `export ZLIBRARY_EAPI_DOMAIN=<working-domain>`
+remedy in the message. Covered by `__tests__/python/test_eapi_domain_resilience.py`.
+
 ### ISSUE-002: Venv Manager Test Failures [CLOSED]
 **Severity**: Was High
 **Resolution**: UV migration (Phase 2, Jan 2026) eliminated the entire venv manager complexity. Code reduced 77% (406 to 92 lines), tests reduced 90% (833 to 85 lines). The undefined `.trim()` error and venv creation failures no longer occur.
@@ -144,29 +174,6 @@ skips with the cause and the fix (`git lfs pull`).
 **Impact**: Domain discovery and session management
 **Status**: Handled by vendored zlibrary fork with EAPI client
 **Note**: EAPI endpoints appear more stable than HTML pages for Hydra mode domains.
-
-### ISSUE-API-002: Default EAPI Domain (z-library.sk) Fronted by DiamWall Anti-Bot
-**Severity**: High
-**Discovered**: 2026-07-24, first automated run of the credentialed integration suite
-**Impact**: The default EAPI domain `z-library.sk` no longer serves `/eapi/*` to
-programmatic clients. All requests get an HTTP 307 self-redirect from "DiamWall"
-that sets a `__diamwall` cookie, then 513/517 "Access Denied" on retry — including
-with the EAPIClient's browser User-Agent. `1lib.sk` shows the same wall. With
-defaults, `initialize_eapi_client()` fails at login and every tool is dead.
-**Evidence** (2026-07-24, unrestricted network):
-- `POST https://z-library.sk/eapi/user/login` → 307 → `Set-Cookie: __diamwall=…` → retry → 517 Access Denied (DiamWall-branded page, cdn.diamwall.com assets)
-- Same request against `z-library.ec` → normal EAPI JSON (`{"success":0,"error":"Incorrect email or password"}` for bad creds; real login succeeds)
-- `/eapi/info/domains` (queried via z-library.ec) still advertises `z-library.sk` FIRST, so Hydra-mode domain discovery in `initialize_eapi_client()` would actively switch a working client back to the walled domain.
-**Workaround**: `export ZLIBRARY_EAPI_DOMAIN=z-library.ec` (verified working 2026-07-24).
-**Related finding**: `/eapi/user/login` rate-limits repeated logins from one IP —
-after ~10 logins in an hour it returns 400 `{"success":0,"error":"Incorrect email
-or password"}` even for valid credentials, recovering after a cooldown. The
-integration suite now logs in once per module (shared `zlib_client` fixture)
-instead of per test to stay under this limit.
-**Direction**: (1) Consider changing the default domain or trying a fallback list
-at login; (2) make domain discovery validate a candidate domain with a probe
-request before switching to it; (3) surface a clearer error when DiamWall HTML
-appears where JSON was expected (extend `_classify_health_error`).
 
 ### ISSUE-008: Performance Optimizations Needed
 **Severity**: Low

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -95,9 +95,13 @@ def test_probe_targets_match_runtime_defaults(check_upstream):
     """
     from lib.sources.config import get_source_config
 
+    from zlibrary.eapi import DEFAULT_EAPI_DOMAINS
+
     runtime = get_source_config()
+    # The runtime resolves a domain from ZLIBRARY_EAPI_DOMAIN or (by probing)
+    # DEFAULT_EAPI_DOMAINS; the doctor mirrors that by importing the same list.
     assert check_upstream.ZLIB_DOMAIN == os.environ.get(
-        "ZLIBRARY_EAPI_DOMAIN", "z-library.sk"
+        "ZLIBRARY_EAPI_DOMAIN", DEFAULT_EAPI_DOMAINS[0]
     )
     assert check_upstream.ANNAS_BASE_URL == runtime.annas_base_url
     # LibgenAdapter passes the mirror suffix to LibgenSearch, which builds

--- a/__tests__/python/test_eapi_domain_resilience.py
+++ b/__tests__/python/test_eapi_domain_resilience.py
@@ -1,0 +1,438 @@
+# Tests for ISSUE-API-002: resilient EAPI domain fallback and probing.
+#
+# The default domain z-library.sk is fronted by the DiamWall anti-bot wall
+# (HTTP 307 self-redirect setting a __diamwall cookie, then 513/517 Access
+# Denied), and /eapi/info/domains still advertises it first. These tests pin
+# the defensive behaviour: probe-before-use fallback at login, env override
+# with no silent switching, probe-guarded hydra discovery, and explicit
+# DiamWall diagnosis in the health check. All HTTP is mocked via
+# httpx.MockTransport — no real requests, and never a login.
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+)
+
+import python_bridge
+from python_bridge import _classify_health_error, eapi_health_check
+
+from zlibrary.eapi import (
+    DEFAULT_EAPI_DOMAINS,
+    DiamWallError,
+    EAPIClient,
+    decode_eapi_json,
+    probe_eapi_domain,
+    resolve_eapi_domain,
+    select_advertised_domain,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --- Canned responses -------------------------------------------------------
+
+DIAMWALL_HTML = (
+    "<html><head><script src='https://cdn.diamwall.com/protect.js'></script>"
+    "</head><body><h1>Access Denied</h1></body></html>"
+)
+
+
+def healthy_response(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, json={"domains": ["z-library.ec", "z-library.sk"]})
+
+
+def diamwall_redirect(request: httpx.Request) -> httpx.Response:
+    """The wall's first move: a 307 self-redirect setting the __diamwall cookie."""
+    return httpx.Response(
+        307,
+        headers={
+            "location": str(request.url),
+            "set-cookie": "__diamwall=abc123; path=/",
+        },
+    )
+
+
+def diamwall_denied(request: httpx.Request) -> httpx.Response:
+    """The wall's second move: 517 Access Denied with DiamWall-branded HTML."""
+    return httpx.Response(517, text=DIAMWALL_HTML)
+
+
+def transport_by_host(routes: dict) -> httpx.MockTransport:
+    """Route requests by hostname; unrouted hosts raise a connect error."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fn = routes.get(request.url.host)
+        if fn is None:
+            raise httpx.ConnectError("no route to host", request=request)
+        return fn(request)
+
+    return httpx.MockTransport(handler)
+
+
+class RecordingTransport(httpx.MockTransport):
+    """MockTransport that records which hosts were probed, in order."""
+
+    def __init__(self, routes: dict):
+        self.hosts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.hosts.append(request.url.host)
+            fn = routes.get(request.url.host)
+            if fn is None:
+                raise httpx.ConnectError("no route to host", request=request)
+            return fn(request)
+
+        super().__init__(handler)
+
+
+@pytest.fixture
+def no_domain_override(monkeypatch):
+    monkeypatch.delenv("ZLIBRARY_EAPI_DOMAIN", raising=False)
+
+
+# --- Probe discrimination ---------------------------------------------------
+
+
+class TestProbeEAPIDomain:
+    async def test_healthy_domain_passes(self):
+        transport = transport_by_host({"z-library.ec": healthy_response})
+        assert await probe_eapi_domain("z-library.ec", transport=transport) is True
+
+    async def test_diamwall_307_redirect_fails(self):
+        """Redirects are not followed: the 307 self-redirect IS the walled signal."""
+        transport = transport_by_host({"z-library.sk": diamwall_redirect})
+        assert await probe_eapi_domain("z-library.sk", transport=transport) is False
+
+    async def test_diamwall_denied_page_fails(self):
+        transport = transport_by_host({"z-library.sk": diamwall_denied})
+        assert await probe_eapi_domain("z-library.sk", transport=transport) is False
+
+    async def test_html_where_json_expected_fails(self):
+        transport = transport_by_host(
+            {
+                "z-library.sk": lambda r: httpx.Response(
+                    200, text="<html>maintenance</html>"
+                )
+            }
+        )
+        assert await probe_eapi_domain("z-library.sk", transport=transport) is False
+
+    async def test_diamwall_marker_in_200_body_fails(self):
+        transport = transport_by_host(
+            {"z-library.sk": lambda r: httpx.Response(200, text=DIAMWALL_HTML)}
+        )
+        assert await probe_eapi_domain("z-library.sk", transport=transport) is False
+
+    async def test_network_error_fails(self):
+        transport = transport_by_host({})  # every host unreachable
+        assert await probe_eapi_domain("z-library.sk", transport=transport) is False
+
+    async def test_json_without_domains_payload_fails(self):
+        transport = transport_by_host(
+            {"z-library.sk": lambda r: httpx.Response(200, json={"success": 0})}
+        )
+        assert await probe_eapi_domain("z-library.sk", transport=transport) is False
+
+    async def test_probe_targets_info_domains_not_login(self):
+        """Probing must never touch /eapi/user/login (rate-limited ~10/hour/IP)."""
+        seen = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request.url.path)
+            return healthy_response(request)
+
+        await probe_eapi_domain("z-library.ec", transport=httpx.MockTransport(handler))
+        assert seen == ["/eapi/info/domains"]
+
+
+# --- Fallback ordering at login --------------------------------------------
+
+
+class TestResolveEAPIDomain:
+    async def test_first_healthy_candidate_wins(self, no_domain_override):
+        transport = RecordingTransport({"z-library.ec": healthy_response})
+        assert await resolve_eapi_domain(transport=transport) == "z-library.ec"
+        # Later candidates must not even be probed.
+        assert transport.hosts == ["z-library.ec"]
+
+    async def test_walled_first_candidate_falls_through_to_second(
+        self, no_domain_override
+    ):
+        transport = RecordingTransport(
+            {
+                "z-library.ec": diamwall_denied,
+                "z-library.sk": healthy_response,
+            }
+        )
+        assert await resolve_eapi_domain(transport=transport) == "z-library.sk"
+        assert transport.hosts == ["z-library.ec", "z-library.sk"]
+
+    async def test_all_candidates_walled_falls_back_to_first(self, no_domain_override):
+        transport = RecordingTransport(
+            {
+                "z-library.ec": diamwall_denied,
+                "z-library.sk": diamwall_denied,
+                "1lib.sk": diamwall_redirect,
+            }
+        )
+        # Nothing passed the probe: return the first candidate so login can
+        # surface the real error rather than failing with no domain at all.
+        assert await resolve_eapi_domain(transport=transport) == DEFAULT_EAPI_DOMAINS[0]
+        assert transport.hosts == DEFAULT_EAPI_DOMAINS
+
+    async def test_candidate_order_matches_issue_api_002(self):
+        assert DEFAULT_EAPI_DOMAINS == ["z-library.ec", "z-library.sk", "1lib.sk"]
+
+    async def test_env_override_bypasses_probing(self, monkeypatch):
+        """An explicit ZLIBRARY_EAPI_DOMAIN means no probing and no fallback."""
+        monkeypatch.setenv("ZLIBRARY_EAPI_DOMAIN", "my-pinned.example")
+        transport = RecordingTransport({})  # any request would raise/record
+        assert await resolve_eapi_domain(transport=transport) == "my-pinned.example"
+        assert transport.hosts == []
+
+    async def test_env_override_wins_even_if_it_would_fail_probe(self, monkeypatch):
+        """The override is honoured verbatim — even for a domain the probe
+        would reject. Explicit configuration is never second-guessed."""
+        monkeypatch.setenv("ZLIBRARY_EAPI_DOMAIN", "z-library.sk")
+        transport = RecordingTransport({"z-library.sk": diamwall_denied})
+        assert await resolve_eapi_domain(transport=transport) == "z-library.sk"
+        assert transport.hosts == []
+
+
+# --- Probe-guarded hydra discovery ------------------------------------------
+
+
+class TestSelectAdvertisedDomain:
+    async def test_skips_walled_advertised_domain(self):
+        """/eapi/info/domains advertises the walled z-library.sk first; the
+        discovery step must skip it instead of switching onto it."""
+        transport = RecordingTransport(
+            {
+                "z-library.sk": diamwall_denied,
+                "z-library.mx": healthy_response,
+            }
+        )
+        picked = await select_advertised_domain(
+            ["z-library.sk", "z-library.mx"], "z-library.ec", transport=transport
+        )
+        assert picked == "z-library.mx"
+        assert transport.hosts == ["z-library.sk", "z-library.mx"]
+
+    async def test_all_advertised_walled_keeps_current(self):
+        transport = transport_by_host(
+            {
+                "z-library.sk": diamwall_denied,
+                "1lib.sk": diamwall_redirect,
+            }
+        )
+        picked = await select_advertised_domain(
+            ["z-library.sk", "1lib.sk"], "z-library.ec", transport=transport
+        )
+        assert picked is None  # caller keeps its current working domain
+
+    async def test_current_domain_in_list_needs_no_probe(self):
+        transport = RecordingTransport({})
+        picked = await select_advertised_domain(
+            ["z-library.ec", "z-library.sk"], "z-library.ec", transport=transport
+        )
+        assert picked == "z-library.ec"
+        assert transport.hosts == []
+
+    async def test_dict_entries_are_understood(self):
+        transport = transport_by_host({"z-library.mx": healthy_response})
+        picked = await select_advertised_domain(
+            [{"domain": "z-library.mx"}], "z-library.ec", transport=transport
+        )
+        assert picked == "z-library.mx"
+
+    async def test_empty_listing_keeps_current(self):
+        picked = await select_advertised_domain(
+            [], "z-library.ec", transport=transport_by_host({})
+        )
+        assert picked is None
+
+
+# --- initialize_eapi_client wiring ------------------------------------------
+
+
+@pytest.fixture
+def eapi_env(monkeypatch):
+    monkeypatch.setenv("ZLIBRARY_EMAIL", "test@example.com")
+    monkeypatch.setenv("ZLIBRARY_PASSWORD", "secret")
+
+
+@pytest.fixture
+def reset_bridge_client(mocker):
+    mocker.patch.object(python_bridge, "_eapi_client", None)
+
+
+def make_client_mock():
+    client = MagicMock()
+    client.login = AsyncMock(
+        return_value={"success": 1, "user": {"id": "1", "remix_userkey": "k"}}
+    )
+    client.get_domains = AsyncMock(
+        return_value={"domains": ["z-library.sk", "z-library.mx"]}
+    )
+    client.close = AsyncMock()
+    client.remix_userid = "1"
+    client.remix_userkey = "k"
+    return client
+
+
+class TestInitializeEAPIClient:
+    async def test_env_override_uses_only_that_domain_and_never_switches(
+        self, monkeypatch, eapi_env, reset_bridge_client, mocker
+    ):
+        monkeypatch.setenv("ZLIBRARY_EAPI_DOMAIN", "my-pinned.example")
+        client = make_client_mock()
+        client_cls = mocker.patch.object(
+            python_bridge, "EAPIClient", return_value=client
+        )
+
+        result = await python_bridge.initialize_eapi_client()
+
+        client_cls.assert_called_once_with("my-pinned.example")
+        # Pinned domain: hydra discovery must not even be consulted.
+        client.get_domains.assert_not_awaited()
+        assert result is client
+
+    async def test_walled_advertised_primary_is_not_adopted(
+        self, no_domain_override, eapi_env, reset_bridge_client, mocker
+    ):
+        """Discovery advertises the walled domain first; the client must keep
+        the working domain it logged in on."""
+        mocker.patch.object(
+            python_bridge, "resolve_eapi_domain", AsyncMock(return_value="z-library.ec")
+        )
+        # Every advertised domain fails the probe.
+        mocker.patch.object(
+            python_bridge, "select_advertised_domain", AsyncMock(return_value=None)
+        )
+        client = make_client_mock()
+        client_cls = mocker.patch.object(
+            python_bridge, "EAPIClient", return_value=client
+        )
+
+        result = await python_bridge.initialize_eapi_client()
+
+        client_cls.assert_called_once_with("z-library.ec")
+        client.close.assert_not_awaited()  # no switch happened
+        assert result is client
+
+    async def test_healthy_advertised_domain_is_adopted(
+        self, no_domain_override, eapi_env, reset_bridge_client, mocker
+    ):
+        mocker.patch.object(
+            python_bridge, "resolve_eapi_domain", AsyncMock(return_value="z-library.ec")
+        )
+        mocker.patch.object(
+            python_bridge,
+            "select_advertised_domain",
+            AsyncMock(return_value="z-library.mx"),
+        )
+        first, second = make_client_mock(), make_client_mock()
+        client_cls = mocker.patch.object(
+            python_bridge, "EAPIClient", side_effect=[first, second]
+        )
+
+        result = await python_bridge.initialize_eapi_client()
+
+        assert client_cls.call_count == 2
+        assert client_cls.call_args_list[1].args == ("z-library.mx",)
+        first.close.assert_awaited_once()
+        assert result is second
+
+
+# --- DiamWall diagnosis ------------------------------------------------------
+
+
+class TestDiamWallDiagnosis:
+    def test_classifier_names_diamwall(self):
+        err = DiamWallError(
+            "DiamWall anti-bot wall detected on z-library.sk (HTTP 517)"
+        )
+        assert _classify_health_error(err) == "diamwall_blocked"
+
+    def test_classifier_still_detects_cloudflare(self):
+        assert (
+            _classify_health_error(Exception("Checking your browser before accessing"))
+            == "cloudflare_blocked"
+        )
+
+    async def test_health_check_reports_diamwall_with_remedy(self, mocker):
+        """The health check must name the wall and suggest the env override."""
+        client = MagicMock()
+        client.search = AsyncMock(
+            side_effect=DiamWallError(
+                "DiamWall anti-bot wall detected on z-library.sk (HTTP 517): "
+                "the domain blocks programmatic /eapi access. Set "
+                "ZLIBRARY_EAPI_DOMAIN to a working domain "
+                "(e.g. export ZLIBRARY_EAPI_DOMAIN=z-library.ec)."
+            )
+        )
+        mocker.patch.object(python_bridge, "_eapi_client", client)
+
+        result = await eapi_health_check()
+
+        assert result["status"] == "unhealthy"
+        assert result["error_code"] == "diamwall_blocked"
+        assert "DiamWall" in result["error"]
+        assert "ZLIBRARY_EAPI_DOMAIN" in result["error"]
+
+    async def test_eapi_client_raises_diamwall_error_on_denied_page(self):
+        client = EAPIClient("z-library.sk")
+        client._client = httpx.AsyncClient(
+            transport=transport_by_host({"z-library.sk": diamwall_denied})
+        )
+        with pytest.raises(DiamWallError) as excinfo:
+            await client.get_domains()
+        msg = str(excinfo.value)
+        assert "DiamWall" in msg
+        assert "z-library.sk" in msg
+        assert "ZLIBRARY_EAPI_DOMAIN" in msg
+        await client.close()
+
+    async def test_eapi_client_raises_diamwall_error_on_html_200(self):
+        client = EAPIClient("z-library.sk")
+        client._client = httpx.AsyncClient(
+            transport=transport_by_host(
+                {"z-library.sk": lambda r: httpx.Response(200, text=DIAMWALL_HTML)}
+            )
+        )
+        with pytest.raises(DiamWallError):
+            await client.get_domains()
+        await client.close()
+
+    def test_decode_passes_healthy_json_through(self):
+        resp = httpx.Response(
+            200,
+            json={"domains": ["z-library.ec"]},
+            request=httpx.Request("GET", "https://z-library.ec/eapi/info/domains"),
+        )
+        assert decode_eapi_json(resp, "z-library.ec") == {"domains": ["z-library.ec"]}
+
+    def test_decode_preserves_plain_http_errors(self):
+        """Non-walled failures keep their httpx semantics (no false DiamWall)."""
+        resp = httpx.Response(
+            404,
+            text="not found",
+            request=httpx.Request("GET", "https://z-library.ec/eapi/info/domains"),
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            decode_eapi_json(resp, "z-library.ec")
+
+    def test_decode_flags_non_json_without_wall_marker(self):
+        resp = httpx.Response(
+            200,
+            text="<html>maintenance</html>",
+            request=httpx.Request("GET", "https://z-library.ec/eapi/info/domains"),
+        )
+        with pytest.raises(RuntimeError, match="non-JSON"):
+            decode_eapi_json(resp, "z-library.ec")

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -100,6 +100,20 @@ optional failures usually mean a secondary source is unreachable.
 
 ### Common causes
 
+- **Anti-bot wall on a Z-Library domain** (`diamwall_blocked` in the health check, or
+  the doctor reporting "DiamWall anti-bot wall"): some Z-Library domains (notably
+  `z-library.sk` and `1lib.sk` since 2026-07) block programmatic `/eapi` access with
+  the DiamWall wall — a 307 self-redirect, then 513/517 "Access Denied". The server
+  handles this automatically: it probes its candidate list (`z-library.ec` first)
+  with an unauthenticated `GET /eapi/info/domains` and logs in on the first healthy
+  domain, and hydra-mode discovery skips advertised domains that fail the same
+  probe. If every built-in candidate is walled on your network, pin a domain you
+  know works:
+  ```bash
+  export ZLIBRARY_EAPI_DOMAIN=<working-domain>
+  ```
+  A pinned domain is used exactly as given — no probing, no silent switching — so
+  unset it again to return to automatic fallback.
 - **Region blocking**: Z-Library domains are blocked on some networks. Domain discovery
   ("hydra mode") normally finds a working mirror at runtime; you can pin one explicitly:
   ```bash

--- a/lib/author_tools.py
+++ b/lib/author_tools.py
@@ -16,7 +16,11 @@ import re
 zlibrary_path = os.path.join(os.path.dirname(__file__), "..", "zlibrary", "src")
 sys.path.insert(0, zlibrary_path)
 
-from zlibrary.eapi import EAPIClient, normalize_eapi_search_response
+from zlibrary.eapi import (
+    EAPIClient,
+    normalize_eapi_search_response,
+    resolve_eapi_domain,
+)
 
 
 def validate_author_name(author: str) -> bool:
@@ -130,10 +134,11 @@ async def search_by_author(
     client = eapi_client
     should_close = False
     if client is None:
-        # discover_eapi_domain() requires an authenticated client, so before
-        # login we must start from a known domain (same default as
-        # booklist_tools and python_bridge).
-        domain = os.environ.get("ZLIBRARY_EAPI_DOMAIN", "z-library.sk")
+        # Resolve a healthy EAPI domain before login: honours an explicit
+        # ZLIBRARY_EAPI_DOMAIN override, otherwise probes the fallback list
+        # via GET /eapi/info/domains (ISSUE-API-002: the old z-library.sk
+        # default is DiamWall-walled).
+        domain = await resolve_eapi_domain()
         client = EAPIClient(domain)
         await client.login(email, password)
         should_close = True

--- a/lib/booklist_tools.py
+++ b/lib/booklist_tools.py
@@ -21,7 +21,11 @@ logger = logging.getLogger(__name__)
 zlibrary_path = os.path.join(os.path.dirname(__file__), "..", "zlibrary", "src")
 sys.path.insert(0, zlibrary_path)
 
-from zlibrary.eapi import EAPIClient, normalize_eapi_search_response
+from zlibrary.eapi import (
+    EAPIClient,
+    normalize_eapi_search_response,
+    resolve_eapi_domain,
+)
 
 
 async def fetch_booklist(
@@ -58,7 +62,9 @@ async def fetch_booklist(
     client = eapi_client
     should_close = False
     if client is None:
-        domain = os.environ.get("ZLIBRARY_EAPI_DOMAIN", "z-library.sk")
+        # Honours ZLIBRARY_EAPI_DOMAIN, otherwise probes the fallback
+        # list (ISSUE-API-002).
+        domain = await resolve_eapi_domain()
         client = EAPIClient(domain)
         await client.login(email, password)
         should_close = True

--- a/lib/enhanced_metadata.py
+++ b/lib/enhanced_metadata.py
@@ -19,7 +19,7 @@ import os
 zlibrary_path = os.path.join(os.path.dirname(__file__), "..", "zlibrary", "src")
 sys.path.insert(0, zlibrary_path)
 
-from zlibrary.eapi import EAPIClient
+from zlibrary.eapi import EAPIClient, resolve_eapi_domain
 
 logger = logging.getLogger(__name__)
 
@@ -112,10 +112,11 @@ async def get_enhanced_metadata(
     client = eapi_client
     should_close = False
     if client is None:
-        # discover_eapi_domain() requires an authenticated client, so before
-        # login we must start from a known domain (same default as
-        # booklist_tools and python_bridge).
-        domain = os.environ.get("ZLIBRARY_EAPI_DOMAIN", "z-library.sk")
+        # Resolve a healthy EAPI domain before login: honours an explicit
+        # ZLIBRARY_EAPI_DOMAIN override, otherwise probes the fallback list
+        # via GET /eapi/info/domains (ISSUE-API-002: the old z-library.sk
+        # default is DiamWall-walled).
+        domain = await resolve_eapi_domain()
         client = EAPIClient(domain)
         await client.login(email, password)
         should_close = True

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -32,6 +32,8 @@ from zlibrary.eapi import (
     EAPIClient,
     normalize_eapi_book,
     normalize_eapi_search_response,
+    resolve_eapi_domain,
+    select_advertised_domain,
 )
 
 logger = logging.getLogger("zlibrary")  # Get the 'zlibrary' logger instance
@@ -228,9 +230,13 @@ async def initialize_eapi_client() -> EAPIClient:
             "ZLIBRARY_EMAIL and ZLIBRARY_PASSWORD environment variables required"
         )
 
-    # Use a known EAPI domain for initial login
-    # Z-Library EAPI domains follow the pattern: z-library.sk, singlelogin.re, etc.
-    initial_domain = os.environ.get("ZLIBRARY_EAPI_DOMAIN", "z-library.sk")
+    # ISSUE-API-002: the old single default (z-library.sk) is fronted by the
+    # DiamWall anti-bot wall. resolve_eapi_domain() honours an explicit
+    # ZLIBRARY_EAPI_DOMAIN override without probing; otherwise it probes the
+    # fallback list (GET /eapi/info/domains — never login, which is
+    # rate-limited) and logs in on the first healthy candidate.
+    domain_pinned = bool(os.environ.get("ZLIBRARY_EAPI_DOMAIN", "").strip())
+    initial_domain = await resolve_eapi_domain()
 
     client = EAPIClient(initial_domain)
     login_result = await client.login(email, password)
@@ -240,28 +246,32 @@ async def initialize_eapi_client() -> EAPIClient:
 
     logger.info(f"EAPI client authenticated (userid={client.remix_userid})")
 
-    # Discover optimal domain
-    try:
-        domains_result = await client.get_domains()
-        domains = domains_result.get("domains", [])
-        if domains:
-            primary = (
-                domains[0]
-                if isinstance(domains[0], str)
-                else domains[0].get("domain", "")
-            )
-            if primary and primary != initial_domain:
-                logger.info(f"Switching EAPI domain: {initial_domain} -> {primary}")
+    # Discover optimal domain — skipped entirely when ZLIBRARY_EAPI_DOMAIN is
+    # set (an explicit override means no silent switching, ever). Advertised
+    # domains are probed before adoption: /eapi/info/domains still lists
+    # walled domains first, and switching blindly would kill a working client.
+    if not domain_pinned:
+        try:
+            domains_result = await client.get_domains()
+            domains = domains_result.get("domains", [])
+            target = await select_advertised_domain(domains, initial_domain)
+            if target and target != initial_domain:
+                logger.info(f"Switching EAPI domain: {initial_domain} -> {target}")
                 # Create new client on discovered domain with existing credentials
                 new_client = EAPIClient(
-                    primary,
+                    target,
                     remix_userid=client.remix_userid,
                     remix_userkey=client.remix_userkey,
                 )
                 await client.close()
                 client = new_client
-    except Exception as e:
-        logger.warning(f"Domain discovery failed, using initial domain: {e}")
+            elif not target and domains:
+                logger.warning(
+                    "No advertised EAPI domain passed the health probe; "
+                    f"keeping working domain {initial_domain}"
+                )
+        except Exception as e:
+            logger.warning(f"Domain discovery failed, using initial domain: {e}")
 
     _eapi_client = client
     return _eapi_client
@@ -270,11 +280,15 @@ async def initialize_eapi_client() -> EAPIClient:
 def _classify_health_error(error: Exception) -> str:
     """Classify a health check error into a specific error code.
 
-    Checks exception message for Cloudflare indicators first,
-    then falls back to exception type checking for network errors.
-    Uses only built-in Python exception types (no httpx imports).
+    Checks the exception message for anti-bot wall indicators first
+    (DiamWall, then Cloudflare), then falls back to exception type checking
+    for network errors. Uses only built-in Python exception types (no httpx
+    imports) — DiamWallError raised by the EAPI client is matched by its
+    message, which always names the wall.
     """
     msg = str(error).lower()
+    if "diamwall" in msg:
+        return "diamwall_blocked"
     cloudflare_patterns = ["checking your browser", "cloudflare", "cf-", "challenge"]
     for pattern in cloudflare_patterns:
         if pattern in msg:
@@ -296,6 +310,9 @@ async def eapi_health_check() -> dict:
         and optionally 'error' and 'error_code'.
 
     Error codes:
+        - diamwall_blocked: DiamWall anti-bot wall served HTML/Access Denied
+          where EAPI JSON was expected (fix: export ZLIBRARY_EAPI_DOMAIN to a
+          working domain, or unset it to use the built-in fallback list)
         - cloudflare_blocked: Cloudflare challenge detected in response
         - network_error: Connection or timeout failure
         - malformed_response: Non-JSON or unexpected response format

--- a/lib/term_tools.py
+++ b/lib/term_tools.py
@@ -15,7 +15,11 @@ import os
 zlibrary_path = os.path.join(os.path.dirname(__file__), "..", "zlibrary", "src")
 sys.path.insert(0, zlibrary_path)
 
-from zlibrary.eapi import EAPIClient, normalize_eapi_search_response
+from zlibrary.eapi import (
+    EAPIClient,
+    normalize_eapi_search_response,
+    resolve_eapi_domain,
+)
 
 
 async def search_by_term(
@@ -62,10 +66,11 @@ async def search_by_term(
     client = eapi_client
     should_close = False
     if client is None:
-        # discover_eapi_domain() requires an authenticated client, so before
-        # login we must start from a known domain (same default as
-        # booklist_tools and python_bridge).
-        domain = os.environ.get("ZLIBRARY_EAPI_DOMAIN", "z-library.sk")
+        # Resolve a healthy EAPI domain before login: honours an explicit
+        # ZLIBRARY_EAPI_DOMAIN override, otherwise probes the fallback list
+        # via GET /eapi/info/domains (ISSUE-API-002: the old z-library.sk
+        # default is DiamWall-walled).
+        domain = await resolve_eapi_domain()
         client = EAPIClient(domain)
         await client.login(email, password)
         should_close = True

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -32,14 +32,19 @@ import httpx
 # cannot drift from what the server actually contacts (it previously hardcoded
 # copies that went stale).
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "zlibrary" / "src"))
 from lib.sources.config import get_source_config  # noqa: E402
+from zlibrary.eapi import DEFAULT_EAPI_DOMAINS  # noqa: E402
 
 TIMEOUT = httpx.Timeout(20.0, connect=10.0)
 
 _source_config = get_source_config()
 
-# Mirrors the runtime default in lib/python_bridge.py.
-ZLIB_DOMAIN = os.environ.get("ZLIBRARY_EAPI_DOMAIN", "z-library.sk")
+# Mirrors the runtime resolution in lib/python_bridge.py: an explicit
+# ZLIBRARY_EAPI_DOMAIN wins; otherwise the runtime probes DEFAULT_EAPI_DOMAINS
+# in order and the doctor checks the first candidate (importing the list so
+# the probe cannot drift from what the server actually contacts).
+ZLIB_DOMAIN = os.environ.get("ZLIBRARY_EAPI_DOMAIN", DEFAULT_EAPI_DOMAINS[0])
 # get_source_config() already applies the ANNAS_BASE_URL / LIBGEN_MIRROR
 # environment overrides, same as the runtime adapters.
 ANNAS_BASE_URL = _source_config.annas_base_url
@@ -76,6 +81,23 @@ class ProbeResult:
         return "FAIL" if self.required else "WARN"
 
 
+def _diamwall_detail(resp: httpx.Response) -> Optional[str]:
+    """Detect the DiamWall anti-bot wall in a response, returning a report line.
+
+    Walled domains 307-redirect /eapi/* to themselves setting a `__diamwall`
+    cookie, then serve 513/517 "Access Denied" pages built from
+    cdn.diamwall.com assets (ISSUE-API-002).
+    """
+    if "diamwall" in resp.text.lower():
+        return (
+            f"DiamWall anti-bot wall (HTTP {resp.status_code}) — {ZLIB_DOMAIN} "
+            "blocks programmatic /eapi access; "
+            "export ZLIBRARY_EAPI_DOMAIN=<working-domain> "
+            "(e.g. z-library.ec) or unset it to use the fallback list"
+        )
+    return None
+
+
 async def probe_zlibrary_eapi(client: httpx.AsyncClient) -> list[ProbeResult]:
     """Check the EAPI domain-discovery endpoint and the search endpoint's shape."""
     results: list[ProbeResult] = []
@@ -83,22 +105,28 @@ async def probe_zlibrary_eapi(client: httpx.AsyncClient) -> list[ProbeResult]:
 
     try:
         resp = await client.get(f"{base}/eapi/info/domains")
-        resp.raise_for_status()
-        payload = resp.json()
-        domains = payload.get("domains") or []
-        results.append(
-            ProbeResult(
-                name="zlibrary:eapi/info/domains",
-                ok=bool(domains),
-                detail=(
-                    f"{len(domains)} domain(s) advertised: {', '.join(map(str, domains[:3]))}"
-                    if domains
-                    else "endpoint reachable but advertised no domains "
-                    "(contract change — domain discovery drives every later call)"
-                ),
-                extra={"domains": domains[:5]},
+        walled = _diamwall_detail(resp)
+        if walled:
+            results.append(
+                ProbeResult(name="zlibrary:eapi/info/domains", ok=False, detail=walled)
             )
-        )
+        else:
+            resp.raise_for_status()
+            payload = resp.json()
+            domains = payload.get("domains") or []
+            results.append(
+                ProbeResult(
+                    name="zlibrary:eapi/info/domains",
+                    ok=bool(domains),
+                    detail=(
+                        f"{len(domains)} domain(s) advertised: {', '.join(map(str, domains[:3]))}"
+                        if domains
+                        else "endpoint reachable but advertised no domains "
+                        "(contract change — domain discovery drives every later call)"
+                    ),
+                    extra={"domains": domains[:5]},
+                )
+            )
     except Exception as exc:  # noqa: BLE001 - any failure is a reportable signal
         results.append(
             ProbeResult(
@@ -115,6 +143,12 @@ async def probe_zlibrary_eapi(client: httpx.AsyncClient) -> list[ProbeResult]:
             f"{base}/eapi/book/search",
             data={"message": "philosophy", "limit": "1", "page": "1"},
         )
+        walled = _diamwall_detail(resp)
+        if walled:
+            results.append(
+                ProbeResult(name="zlibrary:eapi/book/search", ok=False, detail=walled)
+            )
+            return results
         resp.raise_for_status()
         payload = resp.json()
         has_shape = isinstance(payload, dict) and (

--- a/zlibrary/src/zlibrary/eapi.py
+++ b/zlibrary/src/zlibrary/eapi.py
@@ -12,8 +12,10 @@ import httpx
 import aiofiles
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Union
 from urllib.parse import unquote
+
+from .logger import logger
 
 
 EAPI_HEADERS = {
@@ -22,6 +24,167 @@ EAPI_HEADERS = {
     "Accept": "application/json, text/plain, */*",
     "Content-Type": "application/x-www-form-urlencoded",
 }
+
+# Candidate EAPI domains tried in order when ZLIBRARY_EAPI_DOMAIN is not set.
+# z-library.sk and 1lib.sk are fronted by the DiamWall anti-bot wall as of
+# 2026-07-24 (ISSUE-API-002) but stay listed in case the wall is lifted;
+# z-library.ec serves normal EAPI JSON and goes first.
+DEFAULT_EAPI_DOMAINS = ["z-library.ec", "z-library.sk", "1lib.sk"]
+
+# Status codes observed from DiamWall-fronted domains: a 307 self-redirect
+# setting a `__diamwall` cookie, then 513/517 "Access Denied" on retry.
+# 403 covers generic bot-blocking.
+WALLED_STATUS_CODES = (307, 403, 513, 517)
+
+
+class DiamWallError(RuntimeError):
+    """An /eapi request was intercepted by the DiamWall anti-bot wall.
+
+    Raised when a domain returns the DiamWall block page (or its status
+    codes) where EAPI JSON was expected. The message names the wall and the
+    remedy so it survives str(e) propagation through the health check.
+    """
+
+
+def _diamwall_error(domain: str, detail: str) -> DiamWallError:
+    return DiamWallError(
+        f"DiamWall anti-bot wall detected on {domain} ({detail}): the domain "
+        f"blocks programmatic /eapi access. Set ZLIBRARY_EAPI_DOMAIN to a "
+        f"working domain (e.g. export ZLIBRARY_EAPI_DOMAIN=z-library.ec) "
+        f"or unset it to let the built-in fallback list pick one."
+    )
+
+
+def decode_eapi_json(resp: httpx.Response, domain: str) -> dict:
+    """Parse an /eapi response as JSON, classifying anti-bot walls explicitly.
+
+    A healthy EAPI endpoint returns HTTP 200 with JSON. DiamWall-fronted
+    domains return a 307 self-redirect, 403/513/517 "Access Denied", or an
+    HTML block page — this raises DiamWallError for those so callers see
+    "anti-bot wall" instead of a bare JSONDecodeError or status error.
+    """
+    if resp.status_code == 200:
+        try:
+            return resp.json()
+        except ValueError:
+            pass  # fall through to wall classification
+    body = resp.text
+    if "diamwall" in body.lower():
+        raise _diamwall_error(domain, f"HTTP {resp.status_code} DiamWall block page")
+    if resp.status_code in WALLED_STATUS_CODES:
+        raise _diamwall_error(domain, f"HTTP {resp.status_code}")
+    resp.raise_for_status()
+    raise RuntimeError(
+        f"Expected JSON from {domain}, got non-JSON HTTP {resp.status_code} "
+        f"response (possible block page or upstream contract change)"
+    )
+
+
+async def probe_eapi_domain(
+    domain: str,
+    *,
+    timeout: float = 8.0,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+) -> bool:
+    """Cheaply check whether a domain serves real EAPI JSON.
+
+    Issues an unauthenticated GET /eapi/info/domains — never /eapi/user/login,
+    which is rate-limited (~10/hour/IP) and would lock out real credentials.
+    Healthy means HTTP 200 with a parseable JSON object containing a domains
+    payload. Redirects are NOT followed: DiamWall's 307 self-redirect is
+    itself the walled signal.
+
+    The `transport` parameter exists for tests (httpx.MockTransport); it is
+    None in production.
+    """
+    url = f"https://{domain.strip().rstrip('/')}/eapi/info/domains"
+    try:
+        async with httpx.AsyncClient(
+            headers=EAPI_HEADERS,
+            timeout=httpx.Timeout(timeout, connect=timeout),
+            follow_redirects=False,
+            transport=transport,
+        ) as client:
+            resp = await client.get(url)
+    except Exception as exc:  # noqa: BLE001 - any network failure means unusable
+        logger.debug(f"EAPI probe failed for {domain}: {type(exc).__name__}: {exc}")
+        return False
+    if resp.status_code != 200:
+        logger.debug(f"EAPI probe: {domain} returned HTTP {resp.status_code}")
+        return False
+    if "diamwall" in resp.text.lower():
+        logger.debug(f"EAPI probe: {domain} served a DiamWall block page")
+        return False
+    try:
+        payload = resp.json()
+    except ValueError:
+        logger.debug(f"EAPI probe: {domain} returned non-JSON")
+        return False
+    return isinstance(payload, dict) and "domains" in payload
+
+
+async def resolve_eapi_domain(
+    *,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+) -> str:
+    """Resolve the EAPI domain to use for login.
+
+    If ZLIBRARY_EAPI_DOMAIN is set, that domain is returned as-is with no
+    probing — an explicit override means no silent switching, ever.
+    Otherwise each candidate in DEFAULT_EAPI_DOMAINS is probed in order and
+    the first healthy one wins. If every candidate fails the probe, the
+    first candidate is returned so login can surface the real error.
+    """
+    override = os.environ.get("ZLIBRARY_EAPI_DOMAIN")
+    if override and override.strip():
+        domain = override.strip()
+        logger.info(f"EAPI domain pinned via ZLIBRARY_EAPI_DOMAIN: {domain}")
+        return domain
+    for candidate in DEFAULT_EAPI_DOMAINS:
+        if await probe_eapi_domain(candidate, transport=transport):
+            logger.info(f"EAPI domain selected by probe: {candidate}")
+            return candidate
+        logger.warning(
+            f"EAPI candidate domain {candidate} failed health probe "
+            f"(anti-bot wall or unreachable), trying next"
+        )
+    logger.warning(
+        f"All EAPI candidate domains failed the health probe; "
+        f"falling back to {DEFAULT_EAPI_DOMAINS[0]}"
+    )
+    return DEFAULT_EAPI_DOMAINS[0]
+
+
+async def select_advertised_domain(
+    advertised: Sequence[Union[str, dict]],
+    current: str,
+    *,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+) -> Optional[str]:
+    """Pick the first usable domain from a /eapi/info/domains listing.
+
+    /eapi/info/domains still advertises walled domains first (ISSUE-API-002),
+    so blindly adopting the primary entry would switch a working client onto
+    a dead domain. Each advertised entry is probed before being accepted;
+    walled/dead ones are skipped. Returns `current` if it appears in the list
+    before any healthy alternative (no switch needed), the first advertised
+    domain that passes the probe otherwise, or None when nothing advertised
+    is usable — the caller keeps whatever domain it already has.
+    """
+    for entry in advertised or []:
+        domain = entry if isinstance(entry, str) else (entry or {}).get("domain", "")
+        if not domain:
+            continue
+        if domain == current:
+            return current
+        if await probe_eapi_domain(domain, transport=transport):
+            return domain
+        logger.warning(
+            f"Skipping advertised EAPI domain {domain}: failed health probe "
+            f"(anti-bot wall or unreachable)"
+        )
+    return None
+
 
 # RFC 6266 / RFC 5987 permit three spellings of the filename parameter, and
 # Z-Library uses all of them depending on the title's character set. Tried in
@@ -125,15 +288,13 @@ class EAPIClient:
         client = await self._get_client()
         url = f"{self.base_url}{path}"
         resp = await client.post(url, data=data or {})
-        resp.raise_for_status()
-        return resp.json()
+        return decode_eapi_json(resp, self.domain)
 
     async def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> dict:
         client = await self._get_client()
         url = f"{self.base_url}{path}"
         resp = await client.get(url, params=params)
-        resp.raise_for_status()
-        return resp.json()
+        return decode_eapi_json(resp, self.domain)
 
     # --- Auth ---
 

--- a/zlibrary/src/zlibrary/libasync.py
+++ b/zlibrary/src/zlibrary/libasync.py
@@ -9,19 +9,20 @@ from urllib.parse import quote
 
 from .logger import logger
 from .exception import (
-    BookNotFound,
     EmptyQueryError,
     ProxyNotMatchError,
     NoProfileError,
     NoDomainError,
-    NoIdError,
     LoginFailed,
-    ParseError,
-    DownloadError
+    DownloadError,
 )
 from .util import GET_request, POST_request, GET_request_cookies
-from .abs import SearchPaginator, BookItem
-from .eapi import EAPIClient, normalize_eapi_book, normalize_eapi_search_response
+from .eapi import (
+    EAPIClient,
+    normalize_eapi_search_response,
+    resolve_eapi_domain,
+    select_advertised_domain,
+)
 from .profile import ZlibProfile
 from .const import Extension, Language, OrderOptions
 import json
@@ -102,19 +103,23 @@ class AsyncZlib:
                 response = await GET_request(
                     url, proxy_list=self.proxy_list, cookies=self.cookies
                 )
-                if hasattr(response, 'text'):
+                if hasattr(response, "text"):
                     logger.debug(f"Response text for {url}: {response.text[:1000]}")
                 else:
-                    logger.debug(f"Response for {url} is not an HTTPX object, it is a string: {str(response)[:1000]}")
+                    logger.debug(
+                        f"Response for {url} is not an HTTPX object, it is a string: {str(response)[:1000]}"
+                    )
                 return response
         else:
             response = await GET_request(
                 url, proxy_list=self.proxy_list, cookies=self.cookies
             )
-            if hasattr(response, 'text'):
+            if hasattr(response, "text"):
                 logger.debug(f"Response text for {url}: {response.text[:1000]}")
             else:
-                logger.debug(f"Response for {url} is not an HTTPX object, it is a string: {str(response)[:1000]}")
+                logger.debug(
+                    f"Response for {url} is not an HTTPX object, it is a string: {str(response)[:1000]}"
+                )
             return response
 
     async def login(self, email: str, password: str):
@@ -133,9 +138,9 @@ class AsyncZlib:
             self.login_domain, data, proxy_list=self.proxy_list
         )
         resp = json.loads(resp)
-        resp = resp['response']
+        resp = resp["response"]
         logger.debug(f"Login response: {resp}")
-        if resp.get('validationError'):
+        if resp.get("validationError"):
             raise LoginFailed(json.dumps(resp, indent=4))
         self._jar = jar
 
@@ -166,26 +171,37 @@ class AsyncZlib:
             if not self.mirror:
                 raise NoDomainError
 
-        # Initialize EAPI client with auth cookies
-        eapi_domain = "z-library.sk"  # Default domain for EAPI
+        # Initialize EAPI client with auth cookies. Respects
+        # ZLIBRARY_EAPI_DOMAIN, otherwise probes the fallback list
+        # (ISSUE-API-002: the old hardcoded z-library.sk is DiamWall-walled).
+        eapi_domain = await resolve_eapi_domain()
         self._eapi = EAPIClient(
             domain=eapi_domain,
             remix_userid=self.cookies.get("remix_userid"),
             remix_userkey=self.cookies.get("remix_userkey"),
         )
 
-        # Discover personal domain for downloads
+        # Discover personal domain for downloads — probe advertised domains
+        # before adopting one, since /eapi/info/domains advertises walled
+        # domains first (ISSUE-API-002).
         try:
             domains_resp = await self._eapi.get_domains()
             domains = domains_resp.get("domains", [])
-            if domains:
-                first = domains[0]
-                self._personal_domain = first if isinstance(first, str) else first.get("domain", "")
+            usable = await select_advertised_domain(domains, eapi_domain)
+            if usable:
+                self._personal_domain = usable
                 logger.info(f"EAPI personal domain: {self._personal_domain}")
+            elif domains:
+                logger.warning(
+                    "No advertised EAPI domain passed the health probe; "
+                    f"keeping {eapi_domain} for downloads."
+                )
         except Exception as e:
             logger.warning(f"Failed to discover EAPI domains: {e}. Using default.")
 
-        self.profile = ZlibProfile(self._r, self.cookies, self.mirror, ZLIB_DOMAIN, eapi_client=self._eapi)
+        self.profile = ZlibProfile(
+            self._r, self.cookies, self.mirror, ZLIB_DOMAIN, eapi_client=self._eapi
+        )
         return self.profile
 
     async def logout(self):
@@ -209,8 +225,12 @@ class AsyncZlib:
     ):
         if not self.profile:
             raise NoProfileError
-        if not q and not (order and (order == OrderOptions.NEWEST or order == "date_created")):
-             raise EmptyQueryError("Search query cannot be empty unless ordering by newest.")
+        if not q and not (
+            order and (order == OrderOptions.NEWEST or order == "date_created")
+        ):
+            raise EmptyQueryError(
+                "Search query cannot be empty unless ordering by newest."
+            )
 
         if not self._eapi:
             raise NoProfileError("EAPI client not initialized. Call login() first.")
@@ -245,7 +265,9 @@ class AsyncZlib:
                 else:
                     logger.warning(f"Invalid order value '{order}'. Ignoring.")
 
-        logger.info(f"EAPI search: q={q}, exact={exact}, count={count}, order={order_str}")
+        logger.info(
+            f"EAPI search: q={q}, exact={exact}, count={count}, order={order_str}"
+        )
 
         try:
             eapi_resp = await self._eapi.search(
@@ -266,11 +288,19 @@ class AsyncZlib:
         books = normalize_eapi_search_response(eapi_resp)
 
         # Build a lightweight paginator-like wrapper for backward compat
-        paginator = _EAPISearchResult(books, eapi_resp, self._eapi, q,
-                                       count=count, exact=exact,
-                                       from_year=from_year, to_year=to_year,
-                                       languages=languages, extensions=ext_list,
-                                       order=order_str)
+        paginator = _EAPISearchResult(
+            books,
+            eapi_resp,
+            self._eapi,
+            q,
+            count=count,
+            exact=exact,
+            from_year=from_year,
+            to_year=to_year,
+            languages=languages,
+            extensions=ext_list,
+            order=order_str,
+        )
         payload = f"{self.mirror}/eapi/book/search?message={quote(q)}"
 
         logger.info(f"EAPI search returned {len(books)} results")
@@ -345,10 +375,18 @@ class AsyncZlib:
             raise
 
         books = normalize_eapi_search_response(eapi_resp)
-        paginator = _EAPISearchResult(books, eapi_resp, self._eapi, q,
-                                       count=count, exact=exact,
-                                       from_year=from_year, to_year=to_year,
-                                       languages=languages, extensions=ext_list)
+        paginator = _EAPISearchResult(
+            books,
+            eapi_resp,
+            self._eapi,
+            q,
+            count=count,
+            exact=exact,
+            from_year=from_year,
+            to_year=to_year,
+            languages=languages,
+            extensions=ext_list,
+        )
         payload = f"{self.mirror}/eapi/book/search?message={quote(q)}"
 
         logger.info(f"EAPI full_text_search returned {len(books)} results")
@@ -362,19 +400,23 @@ class AsyncZlib:
         if not self._eapi:
             raise NoProfileError("EAPI client not initialized. Call login() first.")
 
-        book_id = book_details.get('id', 'Unknown')
-        book_hash = book_details.get('hash') or book_details.get('book_hash', '')
+        book_id = book_details.get("id", "Unknown")
+        book_hash = book_details.get("hash") or book_details.get("book_hash", "")
 
         if not book_hash:
-            logger.warning(f"No hash found in book_details for book ID {book_id}. "
-                          f"Attempting download without hash may fail.")
+            logger.warning(
+                f"No hash found in book_details for book ID {book_id}. "
+                f"Attempting download without hash may fail."
+            )
 
         logger.info(f"EAPI download_book: id={book_id}, hash={book_hash}")
 
         try:
             # Get download link from EAPI
             dl_resp = await self._eapi.get_download_link(int(book_id), book_hash)
-            download_url = dl_resp.get("file", {}).get("downloadLink") or dl_resp.get("downloadLink", "")
+            download_url = dl_resp.get("file", {}).get("downloadLink") or dl_resp.get(
+                "downloadLink", ""
+            )
 
             if not download_url:
                 # Try alternative response structures
@@ -383,26 +425,39 @@ class AsyncZlib:
                     download_url = dl_resp.get("url", "") or dl_resp.get("link", "")
 
             if not download_url:
-                raise DownloadError(f"EAPI returned no download link for book ID {book_id}. Response: {dl_resp}")
+                raise DownloadError(
+                    f"EAPI returned no download link for book ID {book_id}. Response: {dl_resp}"
+                )
 
             # Make URL absolute if needed
             if download_url.startswith("/"):
-                base = f"https://{self._personal_domain}" if self._personal_domain else self.mirror
+                base = (
+                    f"https://{self._personal_domain}"
+                    if self._personal_domain
+                    else self.mirror
+                )
                 download_url = f"{base.rstrip('/')}{download_url}"
 
             logger.info(f"EAPI download URL: {download_url}")
 
         except httpx.HTTPStatusError as e:
             logger.error(f"EAPI download link request failed: {e}", exc_info=True)
-            raise DownloadError(f"Failed to get download link for book ID {book_id} (HTTP {e.response.status_code})") from e
+            raise DownloadError(
+                f"Failed to get download link for book ID {book_id} (HTTP {e.response.status_code})"
+            ) from e
         except DownloadError:
             raise
         except Exception as e:
-            logger.error(f"Error getting EAPI download link for book ID {book_id}: {e}", exc_info=True)
-            raise DownloadError(f"Failed to get download link for book ID {book_id}") from e
+            logger.error(
+                f"Error getting EAPI download link for book ID {book_id}: {e}",
+                exc_info=True,
+            )
+            raise DownloadError(
+                f"Failed to get download link for book ID {book_id}"
+            ) from e
 
         # Construct output path
-        extension = book_details.get('extension', 'epub')
+        extension = book_details.get("extension", "epub")
         filename = f"{book_id}.{extension}"
         output_directory = Path(output_dir_str)
         actual_output_path = output_directory / filename
@@ -413,7 +468,9 @@ class AsyncZlib:
         try:
             os.makedirs(output_directory, exist_ok=True)
         except OSError as e:
-            raise DownloadError(f"Failed to create output directory {output_directory}: {e}") from e
+            raise DownloadError(
+                f"Failed to create output directory {output_directory}: {e}"
+            ) from e
 
         # Stream download
         try:
@@ -425,31 +482,39 @@ class AsyncZlib:
             ) as client:
                 async with client.stream("GET", download_url) as response:
                     response.raise_for_status()
-                    total_size = int(response.headers.get('content-length', 0))
+                    total_size = int(response.headers.get("content-length", 0))
                     logger.info(f"Starting download ({total_size} bytes)...")
 
-                    async with aiofiles.open(actual_output_path, 'wb') as f:
+                    async with aiofiles.open(actual_output_path, "wb") as f:
                         async for chunk in response.aiter_bytes():
                             await f.write(chunk)
 
-            logger.info(f"Successfully downloaded book ID {book_id} to {actual_output_path}")
+            logger.info(
+                f"Successfully downloaded book ID {book_id} to {actual_output_path}"
+            )
             return str(actual_output_path)
 
         except httpx.HTTPStatusError as e:
             if os.path.exists(actual_output_path):
                 os.remove(actual_output_path)
-            raise DownloadError(f"Download failed for book ID {book_id} (HTTP {e.response.status_code})") from e
+            raise DownloadError(
+                f"Download failed for book ID {book_id} (HTTP {e.response.status_code})"
+            ) from e
         except httpx.RequestError as e:
             if os.path.exists(actual_output_path):
                 os.remove(actual_output_path)
-            raise DownloadError(f"Download failed for book ID {book_id} (Network Error)") from e
+            raise DownloadError(
+                f"Download failed for book ID {book_id} (Network Error)"
+            ) from e
         except Exception as e:
             try:
                 if os.path.exists(actual_output_path):
                     os.remove(actual_output_path)
             except OSError:
                 pass
-            raise DownloadError(f"An unexpected error occurred during download for book ID {book_id}") from e
+            raise DownloadError(
+                f"An unexpected error occurred during download for book ID {book_id}"
+            ) from e
 
 
 class _EAPISearchResult:
@@ -459,9 +524,20 @@ class _EAPISearchResult:
     (result, total, next/prev page navigation).
     """
 
-    def __init__(self, books, eapi_response, eapi_client, query,
-                 count=10, exact=False, from_year=None, to_year=None,
-                 languages=None, extensions=None, order=None):
+    def __init__(
+        self,
+        books,
+        eapi_response,
+        eapi_client,
+        query,
+        count=10,
+        exact=False,
+        from_year=None,
+        to_year=None,
+        languages=None,
+        extensions=None,
+        order=None,
+    ):
         self.result = books
         self.storage = {1: books}
         self.page = 1
@@ -487,7 +563,9 @@ class _EAPISearchResult:
                 self.result = []
                 return self.result
 
-        self.result = self.storage.get(self.page, [])[self.__pos:self.__pos + self.count]
+        self.result = self.storage.get(self.page, [])[
+            self.__pos : self.__pos + self.count
+        ]
         self.__pos += self.count
         return self.result
 
@@ -500,7 +578,7 @@ class _EAPISearchResult:
                 return self.result
 
         start = max(0, self.__pos)
-        self.result = self.storage.get(self.page, [])[start:start + self.count]
+        self.result = self.storage.get(self.page, [])[start : start + self.count]
         return self.result
 
     async def next_page(self):

--- a/zlibrary/src/zlibrary/util.py
+++ b/zlibrary/src/zlibrary/util.py
@@ -35,9 +35,13 @@ async def GET_request(url, cookies=None, proxy_list=None) -> str:
                 logger.debug(f"Response status for {url}: {resp.status}")
                 logger.debug(f"Response headers for {url}: {resp.headers}")
                 if response_text:
-                    logger.debug(f"Response body for {url} (first 1000 chars): {response_text[:1000]}")
+                    logger.debug(
+                        f"Response body for {url} (first 1000 chars): {response_text[:1000]}"
+                    )
                     if len(response_text) > 1000:
-                        logger.debug(f"Response body for {url} is longer than 1000 chars, full length: {len(response_text)}")
+                        logger.debug(
+                            f"Response body for {url} is longer than 1000 chars, full length: {len(response_text)}"
+                        )
                     else:
                         logger.debug(f"Full response body for {url}: {response_text}")
                 else:
@@ -98,6 +102,7 @@ async def HEAD_request(url, proxy_list=None):
 
 # --- EAPI helpers ---
 
+
 async def eapi_login(domain: str, email: str, password: str):
     """Convenience: login via EAPI, return (remix_userid, remix_userkey, client).
 
@@ -114,9 +119,16 @@ async def eapi_login(domain: str, email: str, password: str):
 
 
 async def discover_eapi_domain(eapi_client):
-    """Call get_domains() and return the primary EAPI domain."""
+    """Call get_domains() and return the first *usable* advertised EAPI domain.
+
+    Advertised domains are probed before being returned (ISSUE-API-002:
+    /eapi/info/domains advertises DiamWall-walled domains first, so returning
+    the raw primary entry would steer a working client onto a dead domain).
+    Returns None when nothing advertised passes the probe — callers should
+    keep the domain they already have.
+    """
+    from .eapi import select_advertised_domain
+
     result = await eapi_client.get_domains()
     domains = result.get("domains", [])
-    if domains:
-        return domains[0] if isinstance(domains[0], str) else domains[0].get("domain", "")
-    return None
+    return await select_advertised_domain(domains, eapi_client.domain)


### PR DESCRIPTION
## Problem (ISSUE-API-002)

The default EAPI domain `z-library.sk` is fronted by the DiamWall anti-bot wall: every `/eapi/*` request gets an HTTP 307 self-redirect setting a `__diamwall` cookie, then 513/517 "Access Denied" on retry (DiamWall-branded page, cdn.diamwall.com assets). `1lib.sk` is walled the same way; `z-library.ec` serves normal EAPI JSON (verified 2026-07-24). Worse, `/eapi/info/domains` still advertises `z-library.sk` FIRST, so hydra-mode discovery would actively switch a working client back onto the walled domain. With default settings, `initialize_eapi_client()` died at login and every tool was dead.

## Design

1. **Probed fallback list instead of a single default** — `DEFAULT_EAPI_DOMAINS = ["z-library.ec", "z-library.sk", "1lib.sk"]` in `zlibrary/src/zlibrary/eapi.py`. Each candidate is validated with a cheap unauthenticated `GET /eapi/info/domains` before login; the first healthy one wins. The probe never touches `/eapi/user/login`, which is rate-limited (~10/hour/IP) and would lock out real credentials.
2. **Probe semantics** — healthy = HTTP 200 with parseable JSON containing a domains payload. Walled/dead = non-JSON, a body containing "diamwall" (case-insensitive), status 307/403/513/517, or a network error. Redirects are not followed: the 307 self-redirect is itself the walled signal.
3. **Explicit override means no silent switching, ever** — if `ZLIBRARY_EAPI_DOMAIN` is set, that domain is used verbatim: no probing, no fallback, and hydra discovery is skipped entirely.
4. **Probe-guarded hydra discovery** — `select_advertised_domain()` probes each advertised domain and skips walled ones; if nothing advertised is usable, the client keeps its current working domain. Wired into `initialize_eapi_client()` (lib/python_bridge.py), `discover_eapi_domain()` (zlibrary/src/zlibrary/util.py), and the personal-domain discovery in `libasync.py`. The standalone-client paths in `lib/{term,author,booklist}_tools.py` and `lib/enhanced_metadata.py` resolve through the same fallback instead of hardcoding `z-library.sk`.
5. **Clear diagnosis** — the EAPI client raises `DiamWallError` when a walled response appears where JSON was expected; `_classify_health_error()` reports `error_code: diamwall_blocked`; `npm run doctor` names the wall explicitly. All messages carry the remedy: `export ZLIBRARY_EAPI_DOMAIN=<working-domain>`. The doctor's default probe target now imports `DEFAULT_EAPI_DOMAINS` so it cannot drift from the runtime.

## Testing

- New `__tests__/python/test_eapi_domain_resilience.py` — 30 tests, all HTTP mocked via `httpx.MockTransport` (no real requests, never a login): probe discrimination (healthy JSON / 307 redirect / 517 DiamWall page / HTML-where-JSON / network error / JSON without domains payload), fallback ordering (first healthy wins; walled first candidate falls through; all-walled falls back to first), env override bypassing probing and discovery, probe-guarded discovery (skips walled advertised primary, keeps current when all advertised are walled), `initialize_eapi_client` wiring, and DiamWall classification with remedy in the message.
- Full fast suite: `uv run pytest -m "not slow and not integration"` — **1060 passed, 3 skipped, 7 xfailed, 0 failed**; coverage 67.54% against the 60% floor (unchanged).
- Live sanity check (2 unauthenticated probes, no login): the probe reports `z-library.ec` HEALTHY and `z-library.sk` walled (HTTP 307) — exactly the discrimination the design requires.

Docs updated: ISSUES.md (ISSUE-API-002 moved to Resolved, evidence preserved), CHANGELOG.md `[Unreleased]`, docs/TROUBLESHOOTING.md (DiamWall section), CLAUDE.md priorities.

Closes ISSUE-API-002.
