### PR TITLE
fix: upstream check must not report datacenter IP blocks as drift

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -33,6 +33,10 @@ jobs:
     outputs:
       report: ${{ steps.probe.outputs.report }}
       failed: ${{ steps.probe.outputs.failed }}
+      # Z-Library refuses this network's IP (anti-bot wall / datacenter
+      # blocking). Distinct from drift: the contract may be intact for
+      # clients the wall admits, so this must not fail jobs or file issues.
+      zlib_blocked: ${{ steps.probe.outputs.zlib_blocked }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -46,7 +50,10 @@ jobs:
     name: Live integration suite
     runs-on: ubuntu-latest
     # Credentials live in repository secrets. Forks and credential-less setups
-    # skip cleanly rather than reporting a false failure.
+    # skip cleanly rather than reporting a false failure. Depends on the
+    # reachability probe so a network-level block skips the suite instead of
+    # burning login attempts (~10/hour/IP) against a wall.
+    needs: reachability
     if: github.event_name == 'schedule' || inputs.run_live_tests
     steps:
       - uses: actions/checkout@v7
@@ -58,7 +65,13 @@ jobs:
         env:
           ZLIBRARY_EMAIL: ${{ secrets.ZLIBRARY_EMAIL }}
           ZLIBRARY_PASSWORD: ${{ secrets.ZLIBRARY_PASSWORD }}
+          ZLIB_BLOCKED: ${{ needs.reachability.outputs.zlib_blocked }}
         run: |
+          if [ "$ZLIB_BLOCKED" = "true" ]; then
+            echo "::warning::Z-Library refuses this network's IP (anti-bot/datacenter block) — live suite skipped. This is not upstream drift; run npm run doctor from a residential network to discriminate."
+            echo "status=blocked" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ -z "$ZLIBRARY_EMAIL" ] || [ -z "$ZLIBRARY_PASSWORD" ]; then
             echo "::warning::ZLIBRARY_EMAIL/ZLIBRARY_PASSWORD secrets are not set — live suite skipped."
             echo "status=skipped" >> "$GITHUB_OUTPUT"
@@ -74,7 +87,7 @@ jobs:
             echo "status=failed" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/upload-artifact@v4
-        if: always() && steps.live.outputs.status != 'skipped'
+        if: always() && (steps.live.outputs.status == 'passed' || steps.live.outputs.status == 'failed')
         with:
           name: live-integration-log
           path: live.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upstream contract check now distinguishes network-level blocks from drift: a
+  DiamWall wall or bare 403 (what GitHub-hosted runners get from every Z-Library
+  domain) reports as `BLOCK` instead of `FAIL`, does not file the rolling drift
+  issue, and skips the credentialed live suite rather than burning login
+  attempts (~10/hour/IP) against a wall. Only a probe from an unblocked network
+  can distinguish IP blocking from a global outage — `npm run doctor` says so
+  explicitly.
+
 ### Fixed
 
 - **Resilient EAPI domain fallback and probing** (ISSUE-API-002): the single default

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -130,6 +130,12 @@ advertised is usable; (3) DiamWall HTML-where-JSON-expected now raises
 `DiamWallError`, classified as `diamwall_blocked` by the health check and reported
 explicitly by `npm run doctor`, with the `export ZLIBRARY_EAPI_DOMAIN=<working-domain>`
 remedy in the message. Covered by `__tests__/python/test_eapi_domain_resilience.py`.
+**CI caveat** (2026-07-25, post-fix dispatch of upstream-check): GitHub-hosted
+runners get a bare HTTP 403 from **every** Z-Library domain including
+`z-library.ec` — datacenter-IP blocking, unrelated to which domain is default.
+The upstream check therefore classifies walls/403s as `BLOCK` (environmental,
+no drift issue filed, live suite skipped) rather than `FAIL`; only a probe from
+a residential network can distinguish IP blocking from a global outage.
 
 ### ISSUE-002: Venv Manager Test Failures [CLOSED]
 **Severity**: Was High

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -10,6 +10,7 @@ import os
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 
 MODULE_PATH = Path(__file__).parent.parent.parent / "scripts" / "check_upstream.py"
@@ -108,6 +109,75 @@ def test_probe_targets_match_runtime_defaults(check_upstream):
     # https://libgen.{suffix}/ — the probe must target that same host (it
     # previously hardcoded libgen.is while the runtime used libgen.li).
     assert check_upstream.LIBGEN_BASE_URL == f"https://libgen.{runtime.libgen_mirror}"
+
+
+def test_blocked_probe_reports_block_not_fail(check_upstream):
+    """An IP-level refusal is not drift; it must render as BLOCK, not FAIL."""
+    result = check_upstream.ProbeResult(
+        name="zlibrary:eapi/book/search",
+        ok=False,
+        detail="network-level block",
+        required=True,
+        blocked=True,
+    )
+    assert result.symbol == "BLOCK"
+
+
+def test_blocked_probe_is_not_actionable(check_upstream):
+    """Blocked probes must not set the failed flag that files the drift issue —
+    otherwise CI's datacenter address keeps the rolling issue open forever."""
+    results = [
+        check_upstream.ProbeResult("a", True, "fine"),
+        check_upstream.ProbeResult("b", False, "walled", required=True, blocked=True),
+    ]
+    assert check_upstream.actionable_failures(results) == []
+    results.append(check_upstream.ProbeResult("c", False, "drift", required=True))
+    assert [r.name for r in check_upstream.actionable_failures(results)] == ["c"]
+
+
+def test_render_counts_blocked_separately(check_upstream):
+    results = [
+        check_upstream.ProbeResult("a", True, "fine"),
+        check_upstream.ProbeResult("b", False, "walled", required=True, blocked=True),
+    ]
+    report = check_upstream.render(results)
+    assert "BLOCK" in report
+    assert "1 passing, 0 required failing, 0 optional failing" in report
+    assert "1 blocked (network-level, not drift)" in report
+
+
+def test_block_detail_classifies_bare_403(check_upstream):
+    """GitHub-hosted runners get a bare 403 with no DiamWall markers from every
+    Z-Library domain; that must classify as a block, with the caveat that only
+    a residential probe can distinguish IP blocking from a global wall."""
+    detail = check_upstream._block_detail(httpx.Response(403, text="Forbidden"))
+    assert detail is not None
+    assert "network-level block" in detail
+    assert "HTTP 403" in detail
+    assert "not upstream drift" in detail
+
+
+def test_block_detail_names_diamwall_when_present(check_upstream):
+    body = '<html><script src="https://cdn.diamwall.com/x.js"></script></html>'
+    detail = check_upstream._block_detail(httpx.Response(517, text=body))
+    assert detail is not None and "DiamWall" in detail
+
+
+def test_block_detail_passes_healthy_response(check_upstream):
+    assert check_upstream._block_detail(httpx.Response(200, text='{"ok":1}')) is None
+
+
+def test_github_output_carries_zlib_blocked_flag(check_upstream, tmp_path, monkeypatch):
+    """The live-suite job gates on zlib_blocked to avoid logging in through a
+    wall (spurious failure + burns the ~10/hour login rate limit)."""
+    out = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+
+    check_upstream.emit_github_output("report", failed=False, zlib_blocked=True)
+
+    written = out.read_text(encoding="utf-8")
+    assert "failed=false\n" in written
+    assert "zlib_blocked=true\n" in written
 
 
 def test_annas_parking_page_is_reported_as_parked(check_upstream):

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -34,7 +34,7 @@ import httpx
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "zlibrary" / "src"))
 from lib.sources.config import get_source_config  # noqa: E402
-from zlibrary.eapi import DEFAULT_EAPI_DOMAINS  # noqa: E402
+from zlibrary.eapi import DEFAULT_EAPI_DOMAINS, WALLED_STATUS_CODES  # noqa: E402
 
 TIMEOUT = httpx.Timeout(20.0, connect=10.0)
 
@@ -72,30 +72,44 @@ class ProbeResult:
     ok: bool
     detail: str
     required: bool = True
+    # A network-level refusal (anti-bot wall, datacenter-IP block). Not drift:
+    # the upstream contract may be perfectly intact for clients the wall lets
+    # through, so a blocked probe must not trigger the drift issue.
+    blocked: bool = False
     extra: dict[str, Any] = field(default_factory=dict)
 
     @property
     def symbol(self) -> str:
         if self.ok:
             return "OK"
+        if self.blocked:
+            return "BLOCK"
         return "FAIL" if self.required else "WARN"
 
 
-def _diamwall_detail(resp: httpx.Response) -> Optional[str]:
-    """Detect the DiamWall anti-bot wall in a response, returning a report line.
+def _block_detail(resp: httpx.Response) -> Optional[str]:
+    """Detect a network-level block in a response, returning a report line.
 
-    Walled domains 307-redirect /eapi/* to themselves setting a `__diamwall`
-    cookie, then serve 513/517 "Access Denied" pages built from
-    cdn.diamwall.com assets (ISSUE-API-002).
+    Covers the DiamWall anti-bot wall (307 self-redirect setting a `__diamwall`
+    cookie, then 513/517 "Access Denied" pages built from cdn.diamwall.com
+    assets — ISSUE-API-002) and plain IP-reputation blocking (bare 403, which
+    is what GitHub-hosted runners get from every Z-Library domain).
+
+    A probe from a blocked network cannot distinguish "this IP is refused"
+    from "the wall is up for everyone" — only a probe from a residential
+    network (a user running `npm run doctor`) can. So the detail says both.
     """
-    if "diamwall" in resp.text.lower():
-        return (
-            f"DiamWall anti-bot wall (HTTP {resp.status_code}) — {ZLIB_DOMAIN} "
-            "blocks programmatic /eapi access; "
-            "export ZLIBRARY_EAPI_DOMAIN=<working-domain> "
-            "(e.g. z-library.ec) or unset it to use the fallback list"
-        )
-    return None
+    body_is_diamwall = "diamwall" in resp.text.lower()
+    if not body_is_diamwall and resp.status_code not in WALLED_STATUS_CODES:
+        return None
+    wall = "DiamWall anti-bot wall" if body_is_diamwall else "network-level block"
+    return (
+        f"{wall} (HTTP {resp.status_code}) — {ZLIB_DOMAIN} refuses this "
+        "network's clients. From a datacenter/CI address this is expected IP "
+        "blocking, not upstream drift. From a residential network, "
+        "export ZLIBRARY_EAPI_DOMAIN=<working-domain> (e.g. z-library.ec) "
+        "or unset it to use the fallback list"
+    )
 
 
 async def probe_zlibrary_eapi(client: httpx.AsyncClient) -> list[ProbeResult]:
@@ -105,10 +119,15 @@ async def probe_zlibrary_eapi(client: httpx.AsyncClient) -> list[ProbeResult]:
 
     try:
         resp = await client.get(f"{base}/eapi/info/domains")
-        walled = _diamwall_detail(resp)
+        walled = _block_detail(resp)
         if walled:
             results.append(
-                ProbeResult(name="zlibrary:eapi/info/domains", ok=False, detail=walled)
+                ProbeResult(
+                    name="zlibrary:eapi/info/domains",
+                    ok=False,
+                    detail=walled,
+                    blocked=True,
+                )
             )
         else:
             resp.raise_for_status()
@@ -143,10 +162,15 @@ async def probe_zlibrary_eapi(client: httpx.AsyncClient) -> list[ProbeResult]:
             f"{base}/eapi/book/search",
             data={"message": "philosophy", "limit": "1", "page": "1"},
         )
-        walled = _diamwall_detail(resp)
+        walled = _block_detail(resp)
         if walled:
             results.append(
-                ProbeResult(name="zlibrary:eapi/book/search", ok=False, detail=walled)
+                ProbeResult(
+                    name="zlibrary:eapi/book/search",
+                    ok=False,
+                    detail=walled,
+                    blocked=True,
+                )
             )
             return results
         resp.raise_for_status()
@@ -252,26 +276,45 @@ async def run_probes() -> list[ProbeResult]:
     return [*zlib_results, annas, libgen]
 
 
+def actionable_failures(results: list[ProbeResult]) -> list[ProbeResult]:
+    """Failures that indicate drift a maintainer can act on.
+
+    Blocked probes are excluded: an IP-level refusal says nothing about the
+    upstream contract, and counting it would keep the drift issue permanently
+    open from CI's datacenter address.
+    """
+    return [r for r in results if r.required and not r.ok and not r.blocked]
+
+
 def render(results: list[ProbeResult]) -> str:
     width = max(len(r.name) for r in results)
     lines = [f"{r.symbol:<5} {r.name:<{width}}  {r.detail}" for r in results]
-    required_failures = [r for r in results if r.required and not r.ok]
-    optional_failures = [r for r in results if not r.required and not r.ok]
+    required_failures = actionable_failures(results)
+    optional_failures = [
+        r for r in results if not r.required and not r.ok and not r.blocked
+    ]
+    blocked = [r for r in results if r.blocked]
     lines.append("")
-    lines.append(
-        f"{len(results) - len(required_failures) - len(optional_failures)} passing, "
+    summary = (
+        f"{sum(1 for r in results if r.ok)} passing, "
         f"{len(required_failures)} required failing, "
         f"{len(optional_failures)} optional failing"
     )
+    if blocked:
+        summary += f", {len(blocked)} blocked (network-level, not drift)"
+    lines.append(summary)
     return "\n".join(lines)
 
 
-def emit_github_output(report: str, failed: bool) -> None:
+def emit_github_output(report: str, failed: bool, zlib_blocked: bool = False) -> None:
     path: Optional[str] = os.environ.get("GITHUB_OUTPUT")
     if not path:
         return
     with open(path, "a", encoding="utf-8") as handle:
         handle.write(f"failed={'true' if failed else 'false'}\n")
+        # The live-suite job gates on this: logging in through a wall would
+        # both fail spuriously and burn the ~10/hour login rate limit.
+        handle.write(f"zlib_blocked={'true' if zlib_blocked else 'false'}\n")
         # Heredoc form so multi-line reports survive intact.
         handle.write("report<<PROBE_EOF\n")
         handle.write(report + "\n")
@@ -291,18 +334,21 @@ def main() -> int:
     args = parser.parse_args()
 
     results = asyncio.run(run_probes())
-    required_failed = any(r.required and not r.ok for r in results)
+    required_failed = bool(actionable_failures(results))
+    zlib_blocked = any(r.blocked for r in results)
 
     if args.json:
         print(
             json.dumps(
                 {
                     "failed": required_failed,
+                    "zlib_blocked": zlib_blocked,
                     "results": [
                         {
                             "name": r.name,
                             "ok": r.ok,
                             "required": r.required,
+                            "blocked": r.blocked,
                             "detail": r.detail,
                             **r.extra,
                         }
@@ -316,7 +362,7 @@ def main() -> int:
         print(render(results))
 
     if args.github_output:
-        emit_github_output(render(results), required_failed)
+        emit_github_output(render(results), required_failed, zlib_blocked)
 
     # Required-source failure is an actionable signal; optional-source failure is not.
     return 1 if required_failed else 0


### PR DESCRIPTION
## Problem
The first dispatch of upstream-check after #36 showed GitHub-hosted runners receive a bare **HTTP 403 from every Z-Library domain**, including the working default `z-library.ec`. That's datacenter-IP blocking — environmental, not upstream drift. Left alone, the daily schedule fails forever, comments on the rolling `upstream-drift` issue every morning, and buries real Anna's/LibGen drift in noise. It also attempts credentialed logins through the wall, spending the ~10/hour/IP login rate limit for nothing.

## Change
- `scripts/check_upstream.py`: DiamWall markers or a walled status (307/403/513/517) now classify as **BLOCK** — rendered distinctly, excluded from the `failed` flag that files the drift issue, counted separately in the summary. Genuine drift (shape changes, unexpected errors, unreachable hosts) still FAILs.
- `upstream-check.yml`: reachability exports `zlib_blocked`; the live suite job now depends on it and skips with a warning when blocked instead of failing.
- The report text is explicit about the epistemics: a blocked network cannot distinguish IP refusal from a global outage — only `npm run doctor` from a residential network can.

## Testing
- 8 new tests in `__tests__/python/test_check_upstream.py` (classification, actionability, render, $GITHUB_OUTPUT contract): file passes 15/15.
- Full fast suite: **1067 passed, 3 skipped, 7 xfailed**, coverage 67.54% (floor 60%, untouched).
- Live doctor from a residential network: all four probes OK against `z-library.ec` (which still advertises the walled `.sk` first — the probe-guarded discovery from #36 stays load-bearing).