### PR TITLE
fix: pin page objects in textpage cache to stop id-reuse footnote flakes

### DIFF
--- a/lib/rag/utils/cache.py
+++ b/lib/rag/utils/cache.py
@@ -16,7 +16,15 @@ __all__ = [
 ]
 
 # Cache for PyMuPDF textpage objects (performance optimization)
-# Key: (page_obj_id, extraction_type) -> cached result
+# Key: (page_obj_id, extraction_type) -> (page, cached result)
+#
+# The entry pins a strong reference to the page object. Without the pin,
+# CPython recycles the id() of a garbage-collected Page for the next Page
+# allocated (measured ~90% of the time for back-to-back load_page calls),
+# and the cache then serves page N's blocks for page M — non-deterministic
+# footnote detection that depends on heap state (i.e. on which tests ran
+# earlier in the suite). Storing the page keeps its id unique for the
+# lifetime of the entry; the identity check on read is belt-and-braces.
 _TEXTPAGE_CACHE = {}
 
 def _get_cached_text_blocks(page: Any, extraction_type: str = "dict") -> List[Dict[str, Any]]:
@@ -35,15 +43,19 @@ def _get_cached_text_blocks(page: Any, extraction_type: str = "dict") -> List[Di
     """
     cache_key = (id(page), extraction_type)
 
-    if cache_key not in _TEXTPAGE_CACHE:
-        if extraction_type == "dict":
-            _TEXTPAGE_CACHE[cache_key] = page.get_text("dict")["blocks"]
-        elif extraction_type == "text":
-            _TEXTPAGE_CACHE[cache_key] = page.get_text("text")
-        else:
-            raise ValueError(f"Invalid extraction_type: {extraction_type}")
+    entry = _TEXTPAGE_CACHE.get(cache_key)
+    if entry is not None and entry[0] is page:
+        return entry[1]
 
-    return _TEXTPAGE_CACHE[cache_key]
+    if extraction_type == "dict":
+        result = page.get_text("dict")["blocks"]
+    elif extraction_type == "text":
+        result = page.get_text("text")
+    else:
+        raise ValueError(f"Invalid extraction_type: {extraction_type}")
+
+    _TEXTPAGE_CACHE[cache_key] = (page, result)
+    return result
 
 
 def _clear_textpage_cache():


### PR DESCRIPTION
## Summary

Fixes the test-ordering flake that intermittently reddens `test-full` on:

- `test_inline_footnotes.py::TestMarkerlessContinuation::test_markerless_continuation_detected` ("Markerless continuation not detected on page 2")
- `test_real_footnotes.py::TestFootnoteRealWorld::test_footnote_detection_with_real_pdf` ("False positive footnotes detected. assert 4 == 2")

## Mechanism

`lib/rag/utils/cache.py` keys the textpage cache by `(id(page), extraction_type)` but stored only the extraction result — no reference to the page. PyMuPDF `Page` objects are transient (`doc[0]`, `doc[1]` each allocate a fresh object), and CPython recycles a freed object's `id()` for the next same-shaped allocation: measured **91/100** back-to-back `load_page` calls reuse the freed page's address. When that happens, `_get_cached_text_blocks(page_M)` hits page N's stale entry and detection runs on the wrong page's blocks:

- markerless-continuation: page 2 analyzed with page 1's blocks → continuation never found
- real-PDF Derrida run: stale blocks duplicate footnote definitions → 4 markers instead of 2

Whether the collision occurs depends on allocator/heap state left by earlier tests — hence full-suite-ordering-dependent, never reproducible in isolation, and uncorrelated with diffs. The v1.2.0 conftest autouse fixture clears the cache *between* tests; these collisions happen *within* one test (or one `process_pdf` pass), so it could not close the hole.

## Fix

Cache entries now store `(page, result)`: pinning the page makes id reuse impossible while the entry is alive, and reads verify `entry[0] is page`. The cache is still cleared per document (`orchestrator_pdf.py`) and per test (conftest), so memory behavior is unchanged. **No detection logic, thresholds, or assertions changed.**

## Repro / proof

Forcing the collision pre-fix (load page 0, run `_detect_footnotes_in_page`, free it, load page 1 at the recycled id) reproduces the exact assertion failure: the cache stays at 1 key (stale entry served) and the continuation is not found. Post-fix, 50 attempts produce zero collisions — the pin structurally prevents them.

Probabilistic repro pre-fix: `uv run pytest` (full suite) — failed with exactly these 2 tests on the first run of this investigation, passed on the second.

## Verification

- Both target modules in isolation: 49 passed
- Full suite (`uv run pytest`, integration excluded — those require live credentials): **3 consecutive green runs** pre-rebase (1155 passed each) + **1 green run after rebasing onto master** (1192 passed, 5 skipped, 7 xfailed)
- Coverage gate (`--cov-fail-under=60`) passing; no thresholds touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Purpose

Fix intermittent footnote-detection test failures caused by stale textpage-cache results being reused when Python recycles a page object's ID.

## Changes

- Textpage cache entries now retain the page object alongside the extracted result: `(page, result)`.
- Cache reads verify object identity (`entry[0] is page`) before returning cached blocks or text.
- Cache population computes results for the selected `dict` or `text` extraction type, while invalid types still raise `ValueError`.
- Existing per-document and per-test cache clearing behavior is unchanged.

## Verification

The fix was validated with isolated target tests, multiple full-suite runs, a post-rebase full-suite run, and a passing coverage gate.

## Scope and risks

- No footnote-detection logic, thresholds, assertions, public declarations, or cache-clearing contracts were changed.
- The main risk area is the new identity-sensitive cache path; reviewers should confirm that both extraction modes and ID-reuse scenarios are covered by tests and type checking. No new public API is introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->