### PR TITLE
release: v1.3.1 — fix silent no-start under global npm install; npm-first README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-24
+
 ### Changed
 
 - Upstream contract check now distinguishes network-level blocks from drift: a
@@ -19,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`zlibrary-mcp` bin never started under a global npm install**: npm installs the
+  bin as a symlink into `<prefix>/bin`, so `argv[1]` is the link path while
+  `import.meta.url` is the real file — the ESM entry guard's lexical path
+  comparison never matched and the server exited silently, making
+  `"command": "zlibrary-mcp"` in an MCP client config a no-op. The guard now
+  canonicalises both sides with `realpathSync` (falling back to lexical
+  resolution for paths that do not exist). Verified end-to-end: a symlinked
+  invocation now answers `initialize` over stdio.
+- **Footnote detection was non-deterministic across a full test run**: the PyMuPDF
+  textpage cache keyed entries by `id(page)` without holding a reference; CPython
+  recycles a freed page's address (~90% of back-to-back loads), so page N's cached
+  text blocks could be served for page M. Entries now pin the page object and
+  verify identity on read. This was the cause of the long-standing
+  full-suite-ordering test flakes.
+- Tests no longer leak `MagicMock/` and `dummy_output*/` directories into the
+  repository root (mocked argparse args now route `output_dir` through pytest
+  `tmp_path`); removed the orphaned `test_data/` fixtures (referenced by nothing)
+  and untracked per-developer `.serena/` tool state.
 - **Resilient EAPI domain fallback and probing** (ISSUE-API-002): the single default
   EAPI domain `z-library.sk` is fronted by the DiamWall anti-bot wall (HTTP 307
   self-redirect setting a `__diamwall` cookie, then 513/517 Access Denied), which
@@ -210,7 +230,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BUG-X/FIX comments cleaned from production code
 - Debug print statements converted to proper logging
 
-[Unreleased]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.1...v1.2.0
 [1.1.0]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.0...v1.1

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ A Model Context Protocol (MCP) server that gives AI assistants -- Claude Code, C
 
 ## Quick Start
 
+**Prerequisites:** Node.js 22+, Python 3.10+, and [UV](https://docs.astral.sh/uv/)
+(`curl -LsSf https://astral.sh/uv/install.sh | sh`)
+
 ```bash
-git clone https://github.com/loganrooks/zlibrary-mcp.git
-cd zlibrary-mcp
-git lfs pull        # hydrates the LFS-tracked test PDFs; don't run `git lfs install` (conflicts with the repo's Husky hooks)
-bash setup-uv.sh && npm install && npm run build
+npm install -g zlibrary-mcp
+cd "$(npm root -g)/zlibrary-mcp" && bash setup-uv.sh   # one-time Python environment setup
 ```
 
 Then add to your MCP client config (Claude Code `.mcp.json`, Claude Desktop `claude_desktop_config.json`):
@@ -21,8 +22,7 @@ Then add to your MCP client config (Claude Code `.mcp.json`, Claude Desktop `cla
 {
   "mcpServers": {
     "zlibrary": {
-      "command": "node",
-      "args": ["/absolute/path/to/zlibrary-mcp/dist/index.js"],
+      "command": "zlibrary-mcp",
       "env": {
         "ZLIBRARY_EMAIL": "your-email@example.com",
         "ZLIBRARY_PASSWORD": "your-password"
@@ -31,6 +31,8 @@ Then add to your MCP client config (Claude Code `.mcp.json`, Claude Desktop `cla
   }
 }
 ```
+
+Developing or contributing? Install [from source](#option-b-from-source-for-development) instead.
 
 ## Architecture Overview
 
@@ -110,30 +112,31 @@ For complete parameter documentation, types, and examples, see [API Reference](d
 
 ## Installation
 
-### Option A: npm
+### Option A: npm (recommended)
 
 **Prerequisites:** Node.js 22+, Python 3.10+, [UV](https://docs.astral.sh/uv/)
-
-> **Check the published version before using this path.** The npm release
-> pipeline was broken from v1.2 through v1.2.1, so the registry may still serve an
-> older build than this repository. Compare
-> [the npm version badge](https://www.npmjs.com/package/zlibrary-mcp) against
-> [the latest release](https://github.com/loganrooks/zlibrary-mcp/releases); if
-> they differ, install from source (Option B).
 
 ```bash
 npm install -g zlibrary-mcp
 ```
 
-Then set up the Python environment:
+Then set up the Python environment inside the installed package (one-time):
 
 ```bash
-cd $(npm root -g)/zlibrary-mcp
+cd "$(npm root -g)/zlibrary-mcp"
 curl -LsSf https://astral.sh/uv/install.sh | sh  # Install UV if needed
 bash setup-uv.sh
 ```
 
-### Option B: From Source (stdio transport, recommended)
+The package ships the complete Python bridge (`lib/`, the vendored `zlibrary/`
+fork, `pyproject.toml`, `uv.lock`), so no clone is needed. Since v1.3.0 the
+release workflow verifies the tag against `package.json` and publishes with
+provenance, so the registry version tracks GitHub releases; if
+`npm view zlibrary-mcp version` ever trails the
+[latest release](https://github.com/loganrooks/zlibrary-mcp/releases), that is a
+release-pipeline bug worth filing.
+
+### Option B: From Source (for development)
 
 **Prerequisites:** Node.js 22+, Python 3.10+, [UV](https://docs.astral.sh/uv/)
 

--- a/__tests__/platform-compat.test.js
+++ b/__tests__/platform-compat.test.js
@@ -10,6 +10,8 @@
  */
 
 import { describe, test, expect } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import {
@@ -74,6 +76,23 @@ describe('ESM entry-point detection across platforms', () => {
     const windowsArgv = 'C:\\app\\dist\\index.js';
     const windowsUrl = 'file:///C:/app/dist/index.js';
     expect(windowsUrl === `file://${windowsArgv}`).toBe(false);
+  });
+
+  test('detects the entry point through an npm-style bin symlink', () => {
+    // npm installs bins as symlinks into <prefix>/bin: argv[1] is the link,
+    // import.meta.url the real file. This is the global-install/`zlibrary-mcp`
+    // startup path, and a lexical path comparison silently fails it.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'entry-guard-'));
+    try {
+      const real = path.join(dir, 'index.js');
+      fs.writeFileSync(real, '');
+      const link = path.join(dir, 'zlibrary-mcp');
+      fs.symlinkSync(real, link);
+      const url = pathToFileURL(real).href;
+      expect(isProcessEntryPoint(url, link)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('returns false when the module is imported rather than executed', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zlibrary-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zlibrary-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zlibrary-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Z-Library MCP server for AI assistants (UV-based)",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -796,8 +796,21 @@ async function start(
  */
 export function isProcessEntryPoint(moduleUrl: string, argv1: string | undefined): boolean {
   if (!argv1) return false;
+  // npm installs the `zlibrary-mcp` bin as a symlink into <prefix>/bin, so
+  // argv[1] is the link path while import.meta.url is the real file under the
+  // package directory — a plain path.resolve comparison never matches and the
+  // server silently refused to auto-start for global-install users. Resolve
+  // symlinks when the path exists; fall back to lexical resolution so the
+  // comparison still works for paths that do not exist on this filesystem.
+  const canonical = (p: string): string => {
+    try {
+      return fs.realpathSync(p);
+    } catch {
+      return path.resolve(p);
+    }
+  };
   try {
-    return path.resolve(fileURLToPath(moduleUrl)) === path.resolve(argv1);
+    return canonical(fileURLToPath(moduleUrl)) === canonical(argv1);
   } catch {
     // A non-file:// URL (e.g. a bundler's virtual module) is never the entry point.
     return false;


### PR DESCRIPTION
## The bug that forced a patch release
Making the README quickstart npm-first surfaced a shipping defect: **the `zlibrary-mcp` bin has never worked**. npm installs bins as symlinks into `<prefix>/bin`; the ESM entry guard compared `import.meta.url` to `argv[1]` lexically (`path.resolve`), the symlink never matched the real file, and the server exited silently — `"command": "zlibrary-mcp"` in an MCP config was a no-op. Proven with a JSON-RPC `initialize` probe: direct invocation responds, symlinked invocation returns nothing.

**Fix**: canonicalise both sides with `realpathSync`, falling back to lexical resolution for nonexistent paths (keeps bundler-virtual-module and unit-test semantics). Verified end-to-end post-fix: the symlinked bin answers `initialize`. New unit test covers the npm-symlink shape. Jest: **178/178**.

## Also in this release (already on master)
- Resilient EAPI domain fallback + probing (#36, ISSUE-API-002)
- Upstream-check BLOCK classification for datacenter IP blocks (#37)
- Textpage-cache id-reuse fix — the full-suite footnote flake (#38)
- Test-artifact hygiene (#43)

## README
Quickstart is now npm-first (`npm install -g` + one-time `setup-uv.sh` in the package dir, config uses the bin); the stale "registry may serve an older build" warning is removed (the pipeline now verifies tag↔version and publishes with provenance); from-source is repositioned as the development path.

After merge: tag `v1.3.1` → publish workflow (npm OIDC + GHCR).