### PR TITLE
release: v1.3.2 — uv sync broken in the npm-installed layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,23 @@ jobs:
             exit 1
           fi
           echo "OK: No excluded patterns found in tarball"
+      # The packed layout differs from the repo (no src/, no test dirs), and
+      # setuptools package discovery behaves differently in it: v1.3.1 shipped
+      # with `uv sync` broken for every npm-installed user because the repo's
+      # src/ dir had been masking a flat-layout discovery failure. Run the
+      # Python environment setup inside the extracted tarball, exactly as the
+      # README quickstart does.
+      - name: Verify uv sync works in the packed layout
+        shell: bash
+        run: |
+          TARBALL=$(ls zlibrary-mcp-*.tgz | head -1)
+          EXTRACT=$(mktemp -d)
+          tar xzf "$TARBALL" -C "$EXTRACT"
           rm -f "$TARBALL"
+          cd "$EXTRACT/package"
+          uv sync
+          .venv/bin/python -c "import zlibrary, fitz, ebooklib" \
+            && echo "OK: packed layout installs and bridge imports resolve"
 
   docs-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-07-24
+
+### Fixed
+
+- **`uv sync` failed inside the npm-installed package**, breaking the README
+  quickstart's Python setup step for every npm user of v1.3.0/v1.3.1. The root
+  pyproject had always relied on an accident: the repo's `src/` directory flips
+  setuptools to src-layout package discovery (which finds no Python packages and
+  builds an empty dist), but the published package ships no `src/`, so flat-layout
+  discovery found `['lib', 'zlibrary', 'node_modules']` and refused to build.
+  The root project is dependency-management-only and is now declared
+  `[tool.uv] package = false`, which is layout-independent. CI's pack-check job
+  now extracts the actual npm tarball and runs `uv sync` plus bridge-import
+  checks inside it, so a repo-works/package-breaks split cannot ship again.
+  Verified end-to-end against the fixed layout: global install → bin symlink →
+  MCP `initialize` → live authenticated `search_books` returns results.
+
 ## [1.3.1] - 2026-07-24
 
 ### Changed
@@ -230,7 +247,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BUG-X/FIX comments cleaned from production code
 - Debug print statements converted to proper logging
 
-[Unreleased]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.2...HEAD
+[1.3.2]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.2.0...v1.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zlibrary-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zlibrary-mcp",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zlibrary-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Z-Library MCP server for AI assistants (UV-based)",
   "main": "dist/index.js",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,16 @@ build-backend = "setuptools.build_meta"
 
 # UV-specific configuration
 [tool.uv]
+# This pyproject exists for dependency management only — nothing imports the
+# root project as a Python package (the bridge runs lib/*.py by path, and the
+# importable `zlibrary` package is the vendored fork installed editable from
+# ./zlibrary). package = false stops uv from building/installing the root.
+# Without it the build only ever succeeded by accident: the repo's src/ dir
+# flips setuptools to src-layout discovery (which finds nothing), while the
+# published npm package ships no src/, so flat-layout discovery found
+# ['lib', 'zlibrary', 'node_modules'] and refused to build — breaking
+# `uv sync` for every npm-installed user.
+package = false
 # Development dependencies (alternative syntax)
 dev-dependencies = [
     "pytest>=9.0.3",  # PYSEC-2026-1845

--- a/uv.lock
+++ b/uv.lock
@@ -2884,7 +2884,7 @@ requires-dist = [
 [[package]]
 name = "zlibrary-mcp"
 version = "2.0.0"
-source = { editable = "." }
+source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "beautifulsoup4" },


### PR DESCRIPTION
End-to-end verification of the v1.3.1 npm quickstart caught a packaging bug: **`uv sync` fails inside the installed package** with `Multiple top-level packages discovered in a flat-layout: ['lib', 'zlibrary', 'node_modules']`.

## Why it never failed in the repo
The repo's `src/` directory flips setuptools to src-layout discovery, which finds no Python packages and builds an empty dist — success by accident. The npm package ships no `src/` (files whitelist), so flat-layout discovery runs and refuses. Same pyproject, opposite outcomes.

## Fix
The root project is dependency-management-only (nothing imports it; the bridge runs `lib/*.py` by path and the importable `zlibrary` package is the vendored fork installed editable). It is now declared `[tool.uv] package = false` — layout-independent, and uv stops building/installing the root entirely.

## Regression guard
`pack-check` now extracts the real `npm pack` tarball and runs `uv sync` + bridge-import checks inside it. The packed layout is CI-tested, not assumed.

## Verification (against the fixed layout)
- Repo: `uv sync` clean, fast suite **1067 passed**, coverage 67.55%
- Clean-prefix install of the published tarball + this pyproject: `uv sync` clean, `zlibrary`/`fitz`/`ebooklib` import
- Through the bin symlink: `initialize` answers (v1.3.1), `tools/list` = 13 tools, live authenticated `search_books` returns real results

After merge: tag `v1.3.2` → publish → fresh registry install re-verified.