### PR TITLE
fix: replace deprecated zod .passthrough() with .loose()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ const GetRecentBooksParamsSchema = z.object({
 const DownloadBookToFileParamsSchema = z.object({
   bookDetails: z
     .object({})
-    .passthrough()
+    .loose()
     .describe('The full book details object obtained from search_books'),
   outputDir: z
     .string()


### PR DESCRIPTION
zod v4 (adopted in #29) deprecates `ZodObject#passthrough()` in favor of `.loose()` / `z.looseObject()`, per the type declarations in `node_modules/zod/v4/classic/schemas.d.ts`. Both produce the identical `core.$loose` internal config, so this is a behavior-preserving rename: the `bookDetails` schema on `download_book_to_file` still accepts unknown keys, which is required since it re-validates the full book object returned verbatim by `search_books`. `.loose()` was chosen over `z.looseObject({...})` to keep the diff to a single call-site rename instead of restructuring the schema construction.

A repo-wide grep for `.passthrough()` outside `node_modules` found only this one call site in application code; the other hits are unrelated (docs/archive snapshots and Python identifiers like `markerless_passthrough` in the footnote corruption model).

**Verification**
- `npm ci` — clean install (had to point at `https://registry.npmjs.org/` explicitly; the environment's configured mirror, `registry.npmmirror.com`, 404'd on an unrelated dev dependency version)
- `npm run build` — passes, build validation reports 15/15 files present
- `node --experimental-vm-modules node_modules/jest/bin/jest.js` — 171 passed, 6 failed, 177 total. All 6 failures are in `__tests__/venv-manager.test.js` and are pre-existing/environmental: they assert against a UV-managed `.venv` that only exists after running `uv sync`, which this change doesn't touch. `__tests__/index.test.js`, which asserts on the tool input schemas including `bookDetails`, passes.

Closes #42

CI needs a workflow approval since I'm still a first-time contributor here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Replaces deprecated Zod v4 `.passthrough()` with `.loose()` for `download_book_to_file.bookDetails`.

- Preserves acceptance and retention of unknown book fields, maintaining compatibility with objects returned by `search_books`.
- Updates the only application-code use of `.passthrough()`; no exported APIs or other contracts change.
- `npm run build` and the relevant schema tests, including `__tests__/index.test.js`, pass.
- Six unrelated `venv-manager.test.js` failures remain because the UV-managed `.venv` is missing.
- The change is limited to schema configuration; human review should confirm that existing schema coverage adequately protects loose-object behavior. The PR does not add new runtime or type-level tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->