### PR TITLE
chore: migrate dev dependencies to PEP 735 dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,20 @@ dev = [
     "pytest-benchmark>=5.2.3",
 ]
 
+# Development and test dependencies (PEP 735 dependency groups)
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",  # PYSEC-2026-1845
+    "pytest-asyncio>=1.2.0",
+    "pytest-mock>=3.15.0",
+    "pytest-benchmark>=5.2.3",
+    "ruff>=0.14.14",
+    "jsonschema>=4.26.0",
+    "pytest-cov>=7.0.0",
+    "pip-audit>=2.7.0",
+    "pip>=26.1.2",  # PYSEC-2026-196, PYSEC-2026-2875, PYSEC-2026-2876 (pulled in by pip-audit)
+]
+
 [project.urls]
 Homepage = "https://github.com/rookslog/zlibrary-mcp"
 Repository = "https://github.com/rookslog/zlibrary-mcp.git"
@@ -84,19 +98,6 @@ build-backend = "setuptools.build_meta"
 # ['lib', 'zlibrary', 'node_modules'] and refused to build — breaking
 # `uv sync` for every npm-installed user.
 package = false
-# Development dependencies (alternative syntax)
-dev-dependencies = [
-    "pytest>=9.0.3",  # PYSEC-2026-1845
-    "pytest-asyncio>=1.2.0",
-    "pytest-mock>=3.15.0",
-    "pytest-benchmark>=5.2.3",
-    "ruff>=0.14.14",
-    "jsonschema>=4.26.0",
-    "pytest-cov>=7.0.0",
-    "pip-audit>=2.7.0",
-    "pip>=26.1.2",  # PYSEC-2026-196, PYSEC-2026-2875, PYSEC-2026-2876 (pulled in by pip-audit)
-]
-
 # Constraints to fix security vulnerabilities in transitive deps.
 # Floors are raised to the lowest version pip-audit reports as fixed; keep them
 # as `>=` so Dependabot/`uv lock --upgrade` can move forward without edits here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,16 @@ build-backend = "setuptools.build_meta"
 # ['lib', 'zlibrary', 'node_modules'] and refused to build — breaking
 # `uv sync` for every npm-installed user.
 package = false
+# Dev dependencies are declared in [dependency-groups] (PEP 735), which uv
+# gained in 0.4.27. The legacy `tool.uv.dev-dependencies` field that older
+# clients understand is gone, so on a pre-0.4.27 uv the dev group is not
+# installed and `uv run ruff` / `uv run pytest` fail with a confusing
+# "not found" rather than a version complaint. Fail early and say why instead.
+#
+# This is a backstop, not the whole guard: a uv old enough to lack PEP 735 may
+# also predate `required-version` and ignore this key. setup-uv.sh checks the
+# version directly, which works regardless.
+required-version = ">=0.4.27"
 # Constraints to fix security vulnerabilities in transitive deps.
 # Floors are raised to the lowest version pip-audit reports as fixed; keep them
 # as `>=` so Dependabot/`uv lock --upgrade` can move forward without edits here.

--- a/setup-uv.sh
+++ b/setup-uv.sh
@@ -44,6 +44,20 @@ fi
 
 UV_VERSION=$(uv --version)
 echo "✅ UV found: $UV_VERSION"
+
+# Dev dependencies live in [dependency-groups] (PEP 735), which uv gained in
+# 0.4.27. An older uv does not read that table and installs no dev group, so
+# `uv run pytest` fails with "not found" — a symptom that points nowhere near
+# the cause. Check it here rather than letting it surface three steps later.
+# Same `sort -V` comparison used for the Python version above.
+UV_NUMBER=$(printf '%s' "$UV_VERSION" | awk '{print $2}')
+UV_REQUIRED="0.4.27"
+if [ -n "$UV_NUMBER" ] && \
+   [ "$(printf '%s\n' "$UV_REQUIRED" "$UV_NUMBER" | sort -V | head -n1)" != "$UV_REQUIRED" ]; then
+    echo "Error: UV $UV_REQUIRED+ required (dev dependencies use PEP 735 [dependency-groups]), found $UV_NUMBER"
+    echo "Upgrade with: uv self update    (or reinstall: curl -LsSf https://astral.sh/uv/install.sh | sh)"
+    exit 1
+fi
 echo ""
 
 # Initialize UV project (creates .venv and installs deps)


### PR DESCRIPTION
Every `uv` invocation currently prints `warning: The \`tool.uv.dev-dependencies\` field (used in \`pyproject.toml\`) is deprecated and will be removed in a future release; use \`dependency-groups.dev\` instead`. This moves the dev-dependencies list from `[tool.uv].dev-dependencies` (uv's legacy alternate syntax) to the standard `[dependency-groups].dev` table (PEP 735), verbatim. `[tool.uv]` keeps its unrelated `constraint-dependencies` table.

`uv.lock` is unaffected — uv folds both the legacy field and the PEP 735 group into the same internal "dev" dependency group, so `uv sync` after this change resolves to an identical lock (`git diff uv.lock` is empty, so no lock changes are included in this PR).

Grepped `.github/workflows/`, `setup-uv.sh`, `docker/Dockerfile`, and `Dockerfile.test` for anything tied to the old field name or uv dev-group flags. Nothing references `dev-dependencies` directly. The two `--no-dev` usages in `docker/Dockerfile` and `Dockerfile.test` disable "the development dependency group" per `uv sync --help`, regardless of which syntax declares that group, so they're unaffected.

**Verification**
- `uv sync` — clean install, deprecation warning gone; confirmed by running the identical command on `master` first (warning present) then on this branch (no warning)
- `uv run pytest -m "not slow and not integration"` — same result on both branches under identical environment conditions: 41 failed, 1019 passed, 3 skipped, 152 deselected, 7 xfailed, 7 errors. All failures/errors are pre-existing and unrelated to this change: this sandbox's network blocks NLTK's downloader (`urlopen` connection refused/timeout to nltk.org, flagged by the repo's own vendored SSRF guard), which corrupts/prevents fetching the `punkt` tokenizer data that a large chunk of the footnote-detection test suite imports at collection time. A handful of the remaining failures are `test_referenced_pdf_exists` cases whose PDF fixtures are LFS pointers I wasn't able to fully hydrate in this environment (`git lfs pull` itself hit the same network restriction). None of this is touched by the dependency-groups migration; identical failure signature confirmed on master.

Closes #41

CI needs a workflow approval since I'm still a first-time contributor here.