### PR TITLE
docs: add VISION.md — project invariants, non-goals, amendment process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This applies equally to "cleanup" tasks. A file that looks stale may be a test f
 ## 🚀 Quick Start for Claude Code
 
 **Essential Reading Order**:
+0. `VISION.md` - Invariants and non-goals (what the project is, at project root)
 1. `.claude/PROJECT_CONTEXT.md` - Complete project understanding (mission, domain)
 2. `.claude/ARCHITECTURE.md` - **System structure** (components, design decisions, status)
 3. `ISSUES.md` - Known problems and priorities (at project root)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A Model Context Protocol (MCP) server that gives AI assistants -- Claude Code, Claude Desktop, RooCode, Cline -- the ability to search Z-Library, download books, and extract document content for Retrieval-Augmented Generation (RAG) workflows. Built with a Node.js/TypeScript MCP frontend and a Python bridge backend for document processing.
 
+For what this project is — and deliberately isn't — see [VISION.md](VISION.md).
+
 ## Quick Start
 
 **Prerequisites:** Node.js 22+, Python 3.10+, and [UV](https://docs.astral.sh/uv/)

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,65 @@
+# Vision
+
+zlibrary-mcp is the **acquisition layer** for research corpora: it finds books,
+retrieves them, and turns them into files a pipeline can use. It serves a
+researcher assembling a corpus — and any downstream tool that needs books —
+through the Model Context Protocol.
+
+This document states the commitments that make the project what it is.
+Implementations, sources, and even the project's name are revisable; the
+invariants below change only deliberately (see [Amending this
+document](#amending-this-document)). Everything else — the current roadmap, the
+current adapters, the current endpoints — is contingent and expected to change.
+
+## Invariants
+
+1. **Files, not payloads.** Output is paths to durable artifacts on disk, never
+   raw document text pushed through the context window.
+2. **stdout is the protocol.** Under the stdio transport, stdout carries
+   JSON-RPC and nothing else; all diagnostics go to stderr. (Enforced by
+   `__tests__/stdio-purity.test.js`.)
+3. **Per-user credentials and quotas.** Accounts, limits, and downloaded
+   content belong to the user running the server.
+4. **Sources are adapters; no source is privileged.** Z-Library is one adapter
+   among several, not the essence of the project. The adapter contract must
+   never be secretly shaped like any single source.
+5. **Acquisition is idempotent.** The server knows what it has already acquired
+   and processed, and does not re-fetch it. A corpus accretes; asking twice
+   costs nothing. *(Partially realized today — the downloads directory exists,
+   a queryable manifest does not yet.)*
+6. **Drift is detected, not assumed.** Every upstream surface that can break
+   silently gets a probe that notices (scheduled upstream checks, `npm run
+   doctor`). Green unit tests are not evidence that the world hasn't moved.
+7. **Heavy dependencies stay optional.** OCR models and similar machinery must
+   never be the price of basic search-and-download.
+
+## Non-goals
+
+Identity is sharpest at its boundary. This project deliberately does **not** do:
+
+- **Library management.** Organizing, curating, browsing, and reading a
+  collection belong downstream, in a dedicated library manager. This server
+  maintains a *manifest* of what it acquired — enough for idempotence and
+  offline reuse — but a manifest is not a library.
+- **A hosted or shared instance.** Credentials and quotas are per-user
+  (invariant 3); pooling them is the wrong shape for this tool.
+- **Bundled OCR models.** OCR remains an optional integration (invariant 7).
+- **Direct ID lookup against unstable upstream IDs.** Deprecated by
+  [ADR-003](docs/adr/ADR-003-Handling-ID-Lookup-Failures.md) for reasons that
+  have not changed.
+
+## How releases relate to this document
+
+Each release has a theme, and the theme is a concrete expression of one or more
+invariants. The milestone description opens by naming which. For example, v1.4
+("source layer as a first-class citizen") realizes invariant 4; a future
+manifest/resources release would realize invariant 5.
+
+A proposed feature that serves no invariant — or that serves a non-goal — needs
+either a rejection or an amendment, not a quiet merge.
+
+## Amending this document
+
+By pull request only. The PR description must name which invariant or non-goal
+is being revised and explain why the reason it was adopted no longer holds.
+Drift by silence is not amendment.


### PR DESCRIPTION
Adds a one-page constitutional document at the repo root: the telos (acquisition
layer for research corpora), seven invariants (files-not-payloads, stdout
purity, per-user credentials, source-neutral adapters, idempotent acquisition,
drift detection, optional heavy deps), explicit non-goals (library management,
hosted instances, bundled OCR, upstream-ID lookup), and an amendment process.

Release milestones will trace their themes to these invariants — v1.4 realizes
invariant 4 (sources are adapters; no source is privileged).

Also links the doc from the README intro and the CLAUDE.md reading order.

Notably, the invariants deliberately never mention Z-Library: the project's
identity is the acquisition role, not any single source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `VISION.md` as the project’s constitutional guide for its research-corpus acquisition layer. It defines seven invariants, explicit non-goals, release-theme traceability, and an amendment process.

README.md and `CLAUDE.md` now link to the document and place it first in the recommended reading order.

## Reviewer attention

- This changes project-level contracts and boundaries rather than runtime behavior.
- No production code, configuration, commands, or exported APIs were changed.
- No tests, type checks, or runtime verification were added or required; review should focus on whether the stated invariants, non-goals, amendment process, and documentation links accurately reflect project intent.
- The document explicitly excludes library management, hosted/shared instances, bundled OCR, and direct upstream-ID lookup. It also keeps Z-Library-specific details out of the invariants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->