### PR TITLE
fix: remove annas-archive.is from the secret-key host allowlist

### DIFF
--- a/__tests__/python/test_annas_adapter.py
+++ b/__tests__/python/test_annas_adapter.py
@@ -428,6 +428,20 @@ class TestSecretKeyHostAllowlist:
 
         assert "annas-archive.li" not in ANNAS_TRUSTED_HOSTS
 
+    def test_impostor_host_is_not_allowlisted(self):
+        """annas-archive.is impersonates the project — never trust it.
+
+        Removed 2026-08-10. The discriminator is the endpoint this allowlist
+        exists to authorize: /dyn/api/fast_download.json returns 401 on the
+        genuine .gl (present, key rejected) and 404 on .is (absent). It also
+        serves /books/{id} rather than /md5/ URLs, runs a Google Analytics
+        property, and hosts a secret-key "recovery" form. Do not re-add it
+        without reproducing the 401 on that endpoint.
+        """
+        from lib.sources.config import ANNAS_TRUSTED_HOSTS
+
+        assert "annas-archive.is" not in ANNAS_TRUSTED_HOSTS
+
     @pytest.mark.asyncio
     async def test_key_not_sent_to_unknown_host(self):
         """get_download_url must refuse before any request leaves the process."""

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -13,19 +13,30 @@ from dataclasses import dataclass
 
 # Hosts operated by the Anna's Archive project, per the mirror list the live
 # site itself advertises (verified 2026-07-24: .gl/.pk/.gd serve real search
-# results; .is is the domain the project's Telegram channel names as official).
+# results). These three are also the domains Wikipedia's infobox lists as
+# active (checked 2026-08-10).
+#
+# annas-archive.is was REMOVED 2026-08-10: it is not Anna's Archive. The
+# discriminator is the endpoint this allowlist exists to authorize —
+# /dyn/api/fast_download.json returns 401 on the genuine .gl (endpoint present,
+# key rejected) and 404 on .is (endpoint absent). It also serves /books/{id}
+# URLs instead of /md5/, runs a Google Analytics property, and hosts a
+# secret-key "recovery" form. Its former justification here ("the domain the
+# project's Telegram channel names as official") was unverifiable. Do not
+# re-add it without reproducing the 401 on that endpoint.
 #
 # The former default annas-archive.li lapsed in March 2026 and is now PARKED
 # by a domain squatter (Trellian/Above.com traffic-monetization page), and
-# annas-archive.org/.se are NXDOMAIN. Parked or unknown hosts must NEVER
-# receive ANNAS_SECRET_KEY — the adapter refuses to attach the key to any
-# host not listed here (see AnnasArchiveAdapter.get_download_url).
+# annas-archive.org/.se are NXDOMAIN. Parked, impersonating, or unknown hosts
+# must NEVER receive ANNAS_SECRET_KEY — the fast-download API passes the key as
+# a URL query parameter, so listing a host here discloses the key to whoever
+# controls it. The adapter refuses to attach the key to any host not listed
+# here (see AnnasArchiveAdapter.get_download_url).
 ANNAS_TRUSTED_HOSTS = frozenset(
     {
         "annas-archive.gl",
         "annas-archive.pk",
         "annas-archive.gd",
-        "annas-archive.is",
     }
 )
 


### PR DESCRIPTION
## What

`ANNAS_TRUSTED_HOSTS` is the allowlist authorizing the adapter to attach `ANNAS_SECRET_KEY` to a request. The fast-download API passes that key as a **URL query parameter**, so listing a host here discloses the key to whoever controls it.

`annas-archive.is` was on that list and is not Anna's Archive.

## Evidence

The discriminator is the endpoint the allowlist exists to authorize:

| host | `/dyn/api/fast_download.json` |
|---|---|
| `annas-archive.gl` (genuine) | **401** — endpoint present, key rejected |
| `annas-archive.is` | **404** — endpoint absent |

Reproduce:

```bash
curl -s -o /dev/null -w '%{http_code}\n' 'https://annas-archive.gl/dyn/api/fast_download.json?md5=3912b2bed8950d6de2d051ae102010ea&key=INVALID&domain_index=1'
curl -s -o /dev/null -w '%{http_code}\n' 'https://annas-archive.is/dyn/api/fast_download.json?md5=3912b2bed8950d6de2d051ae102010ea&key=INVALID&domain_index=1'
```

Supporting signals: `/books/{id}-{slug}` URLs instead of `/md5/`; a Google Analytics property (genuine mirrors run none); a secret-key "recovery" form at `POST /account/recover-secret-key`. Listed by neither Wikipedia nor Wikidata, not even as deprecated.

The host's justification in `config.py` — "the domain the project's Telegram channel names as official" (`f118821`) — was unverifiable and is contradicted by every signal above.

## Impact

No key is configured in this environment, so nothing has leaked here. But anyone who set `ANNAS_BASE_URL` to this host would have handed their key to its operator.

## Changes

- Remove `annas-archive.is` from `ANNAS_TRUSTED_HOSTS`
- Rewrite the comment block to record the discriminator and the disclosure mechanism
- Add `test_impostor_host_is_not_allowlisted`, pinning the exclusion and documenting the 401 check any future re-add must pass

Fast suite green: 1036 passed, 3 skipped, 7 xfailed.

Refs #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Purpose

Prevent `ANNAS_SECRET_KEY` from being sent to the untrusted `annas-archive.is` host.

## Changes

- Removed `annas-archive.is` from `ANNAS_TRUSTED_HOSTS`.
- Kept `annas-archive.gl`, `annas-archive.pk`, and `annas-archive.gd` as trusted hosts.
- Updated the configuration comments to require endpoint verification and exclude parked, impersonating, or unknown hosts.
- Added `test_impostor_host_is_not_allowlisted`.
- The test records that genuine mirrors return `401` for an invalid key, while `annas-archive.is` returns `404` for the tested endpoint.

## Verification

The fast suite passed with 1036 tests, 3 skipped, and 7 expected failures. No secret key was configured in the reported environment.

## Review considerations

The allowlist controls whether the secret key is placed in a URL query parameter. Review future host additions against the documented endpoint behavior before adding them. This change does not validate host ownership or change secret-key handling outside the allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->