### PR TITLE
feat: make LibGen a real download source

### DIFF
--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -5,6 +5,7 @@ scheduled job. What is tested is the reporting contract the CI workflow depends
 on: which failures are actionable, and the exact `$GITHUB_OUTPUT` encoding.
 """
 
+import asyncio
 import importlib.util
 import os
 import sys
@@ -178,6 +179,287 @@ def test_github_output_carries_zlib_blocked_flag(check_upstream, tmp_path, monke
     written = out.read_text(encoding="utf-8")
     assert "failed=false\n" in written
     assert "zlib_blocked=true\n" in written
+
+
+ADS_PAGE = (
+    '<html><body><table><tr><td><a href="get.php?md5={md5}&amp;key=GST1V9KIA7FWM2JQ">'
+    "<h2>GET</h2></a></td></tr></table></body></html>"
+)
+
+
+@pytest.fixture
+def libgen_download(check_upstream, monkeypatch):
+    """Drive probe_libgen_download over a MockTransport — no network, no sleeps.
+
+    Returns a callable taking a `handler(httpx.Request) -> httpx.Response` and
+    running the probe against it.
+    """
+    # The probe spaces its real requests >= 2s apart; that spacing is not what
+    # these tests are about, so it is zeroed rather than waited out.
+    monkeypatch.setattr(check_upstream, "LIBGEN_PROBE_DELAY_SECONDS", 0)
+
+    def run(handler, mirrors=("li", "vg")):
+        monkeypatch.setattr(check_upstream, "LIBGEN_MIRROR_CANDIDATES", tuple(mirrors))
+
+        async def _go():
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(handler), follow_redirects=True
+            ) as client:
+                return await check_upstream.probe_libgen_download(client)
+
+        return asyncio.run(_go())
+
+    return run
+
+
+def _pdf_response(request):
+    return httpx.Response(
+        206,
+        headers={"content-type": "application/pdf"},
+        content=b"%PDF-1.6\n" + b"x" * 128,
+        request=request,
+    )
+
+
+def test_libgen_download_probe_reports_first_working_mirror(
+    check_upstream, libgen_download
+):
+    """The happy path: ads.php yields a key, get.php redirects to a CDN node,
+    and the CDN hands back real PDF bytes."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/ads.php":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text=ADS_PAGE.format(md5=check_upstream.LIBGEN_PROBE_MD5),
+            )
+        if request.url.host == "libgen.li" and request.url.path == "/get.php":
+            return httpx.Response(
+                307, headers={"location": "https://cdn3.booksdl.lc/get.php?x=1"}
+            )
+        return _pdf_response(request)
+
+    result = libgen_download(handler)
+    assert result.ok is True
+    assert result.symbol == "OK"
+    assert result.required is False
+    # The detail must name both the mirror and the CDN node it reached — the
+    # two hops that fail independently.
+    assert "li:" in result.detail
+    assert "cdn3.booksdl.lc" in result.detail
+    assert "PDF" in result.detail
+
+
+def test_libgen_download_probe_requests_only_a_small_range(
+    check_upstream, libgen_download
+):
+    """The probe must not download a whole book to prove downloads work."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/ads.php":
+            return httpx.Response(
+                200, text=ADS_PAGE.format(md5=check_upstream.LIBGEN_PROBE_MD5)
+            )
+        seen["range"] = request.headers.get("Range")
+        return _pdf_response(request)
+
+    assert libgen_download(handler).ok is True
+    assert seen["range"] == f"bytes=0-{check_upstream.LIBGEN_PROBE_RANGE_BYTES - 1}"
+
+
+def test_libgen_download_probe_detects_expired_key_bounce(
+    check_upstream, libgen_download
+):
+    """An expired key does not error — get.php 307s back to the /ads.php
+    interstitial and serves HTTP 200 HTML. Only the redirect target tells you."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/get.php":
+            return httpx.Response(
+                307,
+                headers={
+                    "location": f"https://{request.url.host}/ads.php"
+                    f"?md5={check_upstream.LIBGEN_PROBE_MD5}&key=STALE"
+                },
+            )
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/html"},
+            text=ADS_PAGE.format(md5=check_upstream.LIBGEN_PROBE_MD5),
+        )
+
+    result = libgen_download(handler)
+    assert result.ok is False
+    assert result.symbol == "WARN"
+    assert "/ads.php" in result.detail
+    assert "expired" in result.detail
+    # Both mirrors bounced, and neither was a network-level refusal.
+    assert result.blocked is False
+    assert result.detail.count("bounced back") == 2
+
+
+def test_libgen_download_probe_rejects_html_served_as_the_file(
+    check_upstream, libgen_download
+):
+    """HTTP 200 plus a page body is the reachability-vs-capability trap: the
+    request 'succeeded' and delivered no file."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/ads.php":
+            return httpx.Response(
+                200, text=ADS_PAGE.format(md5=check_upstream.LIBGEN_PROBE_MD5)
+            )
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/html; charset=UTF-8"},
+            text="<html><body>Download limit reached</body></html>",
+            request=request,
+        )
+
+    result = libgen_download(handler)
+    assert result.ok is False
+    assert "served a page, not a file" in result.detail
+
+
+def test_libgen_download_probe_rejects_non_pdf_bytes(check_upstream, libgen_download):
+    """A non-HTML content-type is not enough; the magic bytes must be checked."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/ads.php":
+            return httpx.Response(
+                200, text=ADS_PAGE.format(md5=check_upstream.LIBGEN_PROBE_MD5)
+            )
+        return httpx.Response(
+            206,
+            headers={"content-type": "application/octet-stream"},
+            content=b"\x00\x00not-a-pdf",
+            request=request,
+        )
+
+    result = libgen_download(handler)
+    assert result.ok is False
+    assert "not a PDF" in result.detail
+
+
+def test_libgen_download_probe_falls_over_to_a_healthy_mirror(
+    check_upstream, libgen_download
+):
+    """Mirrors hand off to different CDN nodes that fail independently, so a
+    dead node on the default mirror must not condemn the whole source."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/ads.php":
+            return httpx.Response(
+                200, text=ADS_PAGE.format(md5=check_upstream.LIBGEN_PROBE_MD5)
+            )
+        if request.url.host == "libgen.li":
+            raise httpx.ConnectError("wrong version number", request=request)
+        return _pdf_response(request)
+
+    result = libgen_download(handler)
+    assert result.ok is True
+    assert result.detail.startswith("vg:")
+
+
+def test_libgen_download_probe_reports_every_mirror_when_all_fail(
+    check_upstream, libgen_download
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/ads.php":
+            return httpx.Response(
+                200, text=ADS_PAGE.format(md5=check_upstream.LIBGEN_PROBE_MD5)
+            )
+        raise httpx.ConnectError("wrong version number", request=request)
+
+    result = libgen_download(handler, mirrors=("li", "vg", "la"))
+    assert result.ok is False
+    assert result.detail.startswith("no mirror delivered a file")
+    for mirror in ("li:", "vg:", "la:"):
+        assert mirror in result.detail
+    assert result.extra["mirrors_tried"] == ["li", "vg", "la"]
+
+
+def test_libgen_download_probe_reports_dom_drift_when_key_is_gone(
+    check_upstream, libgen_download
+):
+    """No key-bearing GET anchor means the ads.php scrape has drifted — a
+    different failure from a dead CDN, and the report must say so."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, text="<html><body><a href='/foo'>GET</a></body></html>"
+        )
+
+    result = libgen_download(handler)
+    assert result.ok is False
+    assert "DOM drift" in result.detail
+
+
+def test_libgen_download_probe_classifies_a_wall_as_blocked(
+    check_upstream, libgen_download
+):
+    """An IP-level refusal from every mirror is not drift and must not read as
+    a capability failure."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="Forbidden")
+
+    result = libgen_download(handler)
+    assert result.ok is False
+    assert result.blocked is True
+    assert result.symbol == "BLOCK"
+
+
+def test_libgen_download_probe_is_not_blocked_when_a_mirror_answered(
+    check_upstream, libgen_download
+):
+    """A mix of a wall and a real failure is a real failure: something answered
+    and could not deliver."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "libgen.li":
+            return httpx.Response(403, text="Forbidden")
+        if request.url.path == "/ads.php":
+            return httpx.Response(
+                200, text=ADS_PAGE.format(md5=check_upstream.LIBGEN_PROBE_MD5)
+            )
+        raise httpx.ConnectError("wrong version number", request=request)
+
+    result = libgen_download(handler)
+    assert result.ok is False
+    assert result.blocked is False
+    assert result.symbol == "WARN"
+
+
+def test_libgen_key_extraction_takes_the_key_bearing_anchor(check_upstream):
+    get_url, key = check_upstream._extract_libgen_key(
+        "https://libgen.vg/ads.php?md5=abc",
+        ADS_PAGE.format(md5="abc"),
+    )
+    assert get_url == "https://libgen.vg/get.php?md5=abc&key=GST1V9KIA7FWM2JQ"
+    assert key == "GST1V9KIA7FWM2JQ"
+
+
+def test_libgen_key_extraction_returns_nothing_without_a_key(check_upstream):
+    assert check_upstream._extract_libgen_key(
+        "https://libgen.vg/ads.php?md5=abc",
+        '<html><a href="get.php?md5=abc">GET</a></html>',
+    ) == (None, None)
+
+
+def test_libgen_download_probe_targets_the_configured_mirror_first(check_upstream):
+    """Failover is only informative if the mirror the runtime actually uses is
+    the one reported first."""
+    from lib.sources.config import get_source_config
+
+    assert (
+        check_upstream.LIBGEN_MIRROR_CANDIDATES[0] == get_source_config().libgen_mirror
+    )
+    assert len(set(check_upstream.LIBGEN_MIRROR_CANDIDATES)) == len(
+        check_upstream.LIBGEN_MIRROR_CANDIDATES
+    )
 
 
 def test_annas_parking_page_is_reported_as_parked(check_upstream):

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -6,6 +6,7 @@ LibgenSearch calls in asyncio.to_thread().
 """
 
 from unittest.mock import MagicMock, patch
+import httpx
 import pytest
 
 from lib.sources.config import SourceConfig
@@ -61,9 +62,10 @@ class TestLibgenAdapterSearch:
             assert results[0].title == "Python Programming"
             assert results[0].author == "John Doe"
             assert results[0].source == SourceType.LIBGEN
-            assert (
-                results[0].download_url == "https://example.com/download/abc123def456"
-            )
+            # Search deliberately carries no download URL: the only one it could
+            # offer is a .onion needing Tor, and a clearnet key expires in under
+            # 2.5h. Callers resolve on demand via get_download_url.
+            assert results[0].download_url == ""
 
     @pytest.mark.asyncio
     async def test_search_empty_returns_empty_list(self, config):
@@ -130,8 +132,23 @@ class TestLibgenAdapterSearch:
             assert results[0].source == SourceType.LIBGEN
 
 
+MD5 = "abc123def456"
+ADS_PAGE_WITH_KEY = (
+    "<html><body><table><tr><td>"
+    f'<a href="/get.php?md5={MD5}&key=TESTKEY123">GET</a>'
+    "</td></tr></table></body></html>"
+)
+ADS_PAGE_NO_KEY = "<html><body><p>No download links here</p></body></html>"
+PDF_BYTES = b"%PDF-1.6" + b"\x00" * 2040
+
+
 class TestLibgenAdapterDownload:
-    """Tests for LibgenAdapter.get_download_url() method."""
+    """Tests for LibgenAdapter.get_download_url().
+
+    The adapter resolves downloads over HTTP against ads.php rather than
+    through LibgenSearch, so these mock httpx transport — mocking LibgenSearch
+    would leave the requests hitting the live service.
+    """
 
     @pytest.fixture
     def config(self):
@@ -143,67 +160,136 @@ class TestLibgenAdapterDownload:
         )
 
     @pytest.fixture
-    def mock_book(self):
-        """Create a mock book result from LibgenSearch."""
-        book = MagicMock()
-        book.md5 = "abc123def456"
-        book.title = "Python Programming"
-        book.tor_download_link = "https://example.com/download/abc123def456"
-        return book
-
-    @pytest.mark.asyncio
-    async def test_get_download_url_returns_result(self, config, mock_book):
-        """get_download_url should return DownloadResult with URL."""
+    def adapter(self, config):
+        """Adapter with rate limiting neutralised so tests do not sleep."""
         from lib.sources.libgen import LibgenAdapter
 
-        adapter = LibgenAdapter(config)
+        instance = LibgenAdapter(config)
+        instance.MIN_REQUEST_INTERVAL = 0
+        return instance
 
-        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
-            mock_instance = MagicMock()
-            mock_instance.search_title.return_value = [mock_book]
-            mock_search_class.return_value = mock_instance
+    @staticmethod
+    def _patched_client(handler):
+        """Patch httpx.AsyncClient so the adapter's own client uses `handler`."""
+        real_client = httpx.AsyncClient
 
-            result = await adapter.get_download_url("abc123def456")
+        def factory(*args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return real_client(*args, **kwargs)
 
-            assert result.url == "https://example.com/download/abc123def456"
-            assert result.source == SourceType.LIBGEN
-            assert result.quota_info is None  # LibGen has no quota
-
-    @pytest.mark.asyncio
-    async def test_get_download_url_not_found_raises(self, config):
-        """get_download_url should raise when book not found."""
-        from lib.sources.libgen import LibgenAdapter
-
-        adapter = LibgenAdapter(config)
-
-        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
-            mock_instance = MagicMock()
-            mock_instance.search_title.return_value = []
-            mock_search_class.return_value = mock_instance
-
-            with pytest.raises(ValueError, match="not found"):
-                await adapter.get_download_url("nonexistent123")
+        return patch("lib.sources.libgen.httpx.AsyncClient", factory)
 
     @pytest.mark.asyncio
-    async def test_get_download_url_uses_mirrors_fallback(self, config):
-        """get_download_url should fall back to mirrors if tor_download_link empty."""
-        from lib.sources.libgen import LibgenAdapter
+    async def test_resolves_key_from_ads_page(self, adapter):
+        """A GET anchor's key becomes the get.php download URL."""
 
-        adapter = LibgenAdapter(config)
+        def handler(request):
+            if "ads.php" in request.url.path:
+                return httpx.Response(200, text=ADS_PAGE_WITH_KEY)
+            return httpx.Response(
+                206,
+                content=PDF_BYTES,
+                headers={"content-type": "application/octet-stream"},
+            )
 
-        book = MagicMock()
-        book.md5 = "abc123def456"
-        book.tor_download_link = ""
-        book.mirrors = {"mirror1": "https://mirror1.com/download"}
+        with self._patched_client(handler):
+            result = await adapter.get_download_url(MD5)
 
-        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
-            mock_instance = MagicMock()
-            mock_instance.search_title.return_value = [book]
-            mock_search_class.return_value = mock_instance
+        assert result.url == f"https://libgen.li/get.php?md5={MD5}&key=TESTKEY123"
+        assert result.source == SourceType.LIBGEN
+        assert result.quota_info is None  # LibGen has no quota
 
-            result = await adapter.get_download_url("abc123def456")
+    @pytest.mark.asyncio
+    async def test_falls_over_when_a_mirror_errors(self, adapter):
+        """A mirror that fails at the network level is skipped, not fatal."""
+        seen = []
 
-            assert result.url == "https://mirror1.com/download"
+        def handler(request):
+            host = request.url.host
+            seen.append(host)
+            if host == "libgen.li":
+                raise httpx.ConnectError("TLS failure", request=request)
+            if "ads.php" in request.url.path:
+                return httpx.Response(200, text=ADS_PAGE_WITH_KEY)
+            return httpx.Response(
+                206,
+                content=PDF_BYTES,
+                headers={"content-type": "application/octet-stream"},
+            )
+
+        with self._patched_client(handler):
+            result = await adapter.get_download_url(MD5)
+
+        assert result.url.startswith("https://libgen.vg/")
+        assert "libgen.li" in seen
+
+    @pytest.mark.asyncio
+    async def test_falls_over_when_mirror_resolves_but_cdn_is_dead(self, adapter):
+        """Resolving a key is not evidence the CDN behind it can serve.
+
+        Regression guard for the 2026-08-10 measurement: libgen.li handed out
+        a valid key while its CDN node failed TLS.
+        """
+
+        def handler(request):
+            if "ads.php" in request.url.path:
+                return httpx.Response(200, text=ADS_PAGE_WITH_KEY)
+            if request.url.host == "libgen.li":
+                return httpx.Response(
+                    200,
+                    text="<html>error</html>",
+                    headers={"content-type": "text/html"},
+                )
+            return httpx.Response(
+                206,
+                content=PDF_BYTES,
+                headers={"content-type": "application/octet-stream"},
+            )
+
+        with self._patched_client(handler):
+            result = await adapter.get_download_url(MD5)
+
+        assert result.url.startswith("https://libgen.vg/")
+
+    @pytest.mark.asyncio
+    async def test_expired_key_bounce_is_treated_as_failure(self, adapter):
+        """An expired key 307s back to ads.php rather than erroring."""
+
+        def handler(request):
+            if "ads.php" in request.url.path:
+                return httpx.Response(200, text=ADS_PAGE_WITH_KEY)
+            if request.url.host == "libgen.li":
+                return httpx.Response(
+                    307, headers={"location": f"https://libgen.li/ads.php?md5={MD5}"}
+                )
+            return httpx.Response(
+                206,
+                content=PDF_BYTES,
+                headers={"content-type": "application/octet-stream"},
+            )
+
+        with self._patched_client(handler):
+            result = await adapter.get_download_url(MD5)
+
+        assert result.url.startswith("https://libgen.vg/")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_mirror_yields_a_key(self, adapter):
+        """DOM drift on every mirror surfaces as an error naming the attempts."""
+
+        def handler(request):
+            return httpx.Response(200, text=ADS_PAGE_NO_KEY)
+
+        with self._patched_client(handler):
+            with pytest.raises(ValueError, match="No LibGen mirror"):
+                await adapter.get_download_url(MD5)
+
+    @pytest.mark.asyncio
+    async def test_tries_configured_mirror_first_without_duplicates(self, adapter):
+        """Mirror order starts at the configured one and repeats none."""
+        adapter.mirror = "vg"
+
+        assert adapter._mirror_candidates() == ["vg", "li", "la"]
 
 
 class TestLibgenAdapterRateLimiting:

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -656,6 +656,70 @@ async def process_document(
 
 
 # --- download_book function needs to be async ---
+SOURCE_ALIASES = {"libgen", "annas", "annas_archive"}
+
+
+async def _download_url_to_file(url: str, output_dir: str, md5: str) -> str:
+    """Stream a resolved source URL to disk and return the raw path.
+
+    The source-agnostic half of acquisition: everything downstream of this
+    (unified filename, RAG processing, the bundle contract) already works on
+    any source, so this is the only piece that had to exist for LibGen and
+    Anna's results to become downloadable.
+
+    Guards against the two ways these CDNs fail without erroring: an HTML
+    error/interstitial page served with HTTP 200, and a truncated body.
+    """
+    import httpx
+
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    raw_path = Path(output_dir) / f"{md5}.download"
+
+    async with httpx.AsyncClient(timeout=180, follow_redirects=True) as client:
+        async with client.stream("GET", url) as response:
+            response.raise_for_status()
+
+            content_type = response.headers.get("content-type", "")
+            if "text/html" in content_type:
+                raise ValueError(
+                    f"Source served HTML rather than a file for {md5} — the "
+                    f"download key has most likely expired. Re-resolve and retry."
+                )
+
+            written = 0
+            with open(raw_path, "wb") as handle:
+                async for chunk in response.aiter_bytes(65536):
+                    handle.write(chunk)
+                    written += len(chunk)
+
+    if written == 0:
+        raw_path.unlink(missing_ok=True)
+        raise ValueError(f"Source returned an empty body for {md5}")
+
+    logger.info(f"Downloaded {written} bytes from source to {raw_path}")
+    return str(raw_path)
+
+
+async def _fetch_from_source(book_details: dict, output_dir: str) -> str:
+    """Resolve and fetch a non-Z-Library book. Returns the raw file path."""
+    md5 = (book_details.get("md5") or "").strip()
+    source = (book_details.get("source") or "auto").lower()
+    if not md5:
+        raise ValueError(
+            "Missing 'md5' in bookDetails. Source downloads are addressed by "
+            "md5 — pass a result from search_multi_source."
+        )
+
+    router = await get_source_router()
+    selection = (
+        "libgen" if source == "libgen" else "annas" if "annas" in source else "auto"
+    )
+    result = await router.get_download_url(md5, source=selection)
+    logger.info(f"Resolved {source} download for {md5} via {result.source}")
+
+    return await _download_url_to_file(result.url, output_dir, md5)
+
+
 async def download_book(
     book_details: dict,
     output_dir: str,
@@ -676,15 +740,20 @@ async def download_book(
     Returns:
         dict with 'file_path' and optional 'processed_file_path'
     """
-    eapi = await get_eapi_client()
+    # Route by source. A result from search_multi_source carries md5 + source
+    # and has no Z-Library id/hash, so it takes the source path — which also
+    # means a LibGen download needs no Z-Library credentials at all.
+    from_source = (book_details.get("source") or "").lower() in SOURCE_ALIASES
 
-    # Normalize book details to ensure 'book_hash' field
-    book_details = normalize_book_details(book_details)
+    if not from_source:
+        eapi = await get_eapi_client()
+        # Normalize book details to ensure 'book_hash' field
+        book_details = normalize_book_details(book_details)
 
     book_id = book_details.get("id")
     book_hash = book_details.get("hash") or book_details.get("book_hash", "")
 
-    if not book_id:
+    if not book_id and not from_source:
         logger.error(
             f"Critical: 'id' not found in book_details: {list(book_details.keys())}"
         )
@@ -692,7 +761,7 @@ async def download_book(
             "Missing 'id' key in bookDetails object. Cannot download without book ID."
         )
 
-    if not book_hash:
+    if not book_hash and not from_source:
         logger.warning(
             f"No hash found in book_details for book ID {book_id}. Download may fail."
         )
@@ -703,12 +772,18 @@ async def download_book(
     process_result = None
 
     try:
-        # Step 1: Download the book using EAPIClient.
-        original_download_path_str = await eapi.download_file(
-            book_id=int(book_id),
-            book_hash=book_hash,
-            output_dir=output_dir,
-        )
+        # Step 1: Fetch the file. Z-Library goes through the EAPI client;
+        # every other source resolves a URL through the router and streams it.
+        if from_source:
+            original_download_path_str = await _fetch_from_source(
+                book_details, output_dir
+            )
+        else:
+            original_download_path_str = await eapi.download_file(
+                book_id=int(book_id),
+                book_hash=book_hash,
+                output_dir=output_dir,
+            )
 
         if (
             not original_download_path_str
@@ -764,7 +839,8 @@ async def download_book(
         return result
 
     except Exception as e:
-        logger.exception(f"Error in download_book for book ID {book_details.get('id')}")
+        identifier = book_details.get("id") or book_details.get("md5") or "unknown"
+        logger.exception(f"Error in download_book for {identifier}")
         raise e
 
 

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -6,8 +6,13 @@ to avoid being blocked.
 """
 
 import asyncio
+import logging
 import time
-from typing import List
+from typing import List, Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+import httpx
+from bs4 import BeautifulSoup
 
 from .base import SourceAdapter
 from .config import SourceConfig
@@ -15,6 +20,15 @@ from .models import DownloadResult, SourceType, UnifiedBookResult
 
 # CRITICAL: Import is libgen_api_enhanced, NOT libgen_api
 from libgen_api_enhanced import LibgenSearch
+
+logger = logging.getLogger("zlibrary.sources")
+
+# Mirrors tried in order when resolving a download. Different mirrors hand off
+# to different CDN nodes (cdn3/cdn4/... .booksdl.lc) and those nodes fail
+# independently — 2026-08-10, libgen.li -> cdn4 failed TLS while vg/la -> cdn3
+# served real bytes. Failing over between mirrors therefore also routes around
+# a dead CDN node, which is why this list exists rather than a single default.
+FALLBACK_MIRRORS = ("li", "vg", "la")
 
 
 class LibgenAdapter(SourceAdapter):
@@ -82,7 +96,12 @@ class LibgenAdapter(SourceAdapter):
                 extension=getattr(book, "extension", "") or "",
                 size=getattr(book, "size", "") or "",
                 source=SourceType.LIBGEN,
-                download_url=getattr(book, "tor_download_link", "") or "",
+                # Deliberately empty: the only URL the search response can
+                # offer is a .onion link needing Tor, and a clearnet key is
+                # short-lived (see get_download_url), so resolving one per
+                # search hit would waste a request per result and expire
+                # before use. Callers resolve on demand via get_download_url.
+                download_url="",
                 extra={
                     "id": getattr(book, "id", ""),
                     "language": getattr(book, "language", ""),
@@ -92,11 +111,80 @@ class LibgenAdapter(SourceAdapter):
             for book in results
         ]
 
-    async def get_download_url(self, md5: str) -> DownloadResult:
-        """Get download URL for a book by MD5 hash.
+    def _mirror_candidates(self) -> List[str]:
+        """Mirrors to try, configured one first, without duplicates."""
+        return [self.mirror] + [m for m in FALLBACK_MIRRORS if m != self.mirror]
 
-        LibGen doesn't have direct MD5 lookup, so this searches by MD5
-        as a query and finds the matching book.
+    async def _resolve_key(
+        self, client: httpx.AsyncClient, mirror: str, md5: str
+    ) -> Optional[str]:
+        """Scrape the one-time CDN key out of a mirror's ads.php page.
+
+        `ads.php?md5=<md5>` is addressable directly from the hash — no search
+        is involved — and carries a single `GET` anchor whose href holds the
+        key. Returns None if the page has no usable key.
+        """
+        url = f"https://libgen.{mirror}/ads.php?md5={md5}"
+        response = await client.get(url)
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        for anchor in soup.find_all("a"):
+            if anchor.get_text(strip=True).upper() != "GET":
+                continue
+            href = anchor.get("href")
+            if not href:
+                continue
+            params = parse_qs(urlparse(urljoin(url, href)).query)
+            key = (params.get("key") or [None])[0]
+            if key:
+                return key
+        return None
+
+    async def _serves_bytes(
+        self, client: httpx.AsyncClient, url: str
+    ) -> tuple[bool, str]:
+        """Check that a resolved URL actually delivers a file.
+
+        A mirror can hand out a valid key while the CDN node it redirects to
+        is dead, so resolving is not evidence of downloadability (measured
+        2026-08-10: libgen.li resolved fine but its cdn4 node failed TLS).
+        This asks for 2KB and inspects what comes back.
+
+        Two non-obvious failure shapes are treated as failure, not success:
+        an expired key silently redirects back to `/ads.php`, and a dead node
+        can answer 200 with an HTML error page.
+        """
+        try:
+            response = await client.get(url, headers={"Range": "bytes=0-2047"})
+        except Exception as exc:
+            return False, type(exc).__name__
+
+        if "/ads.php" in str(response.url):
+            return False, "key expired (bounced to ads.php)"
+        if response.status_code not in (200, 206):
+            return False, f"HTTP {response.status_code}"
+        if "text/html" in response.headers.get("content-type", ""):
+            return False, "served HTML, not a file"
+        if not response.content[:4] == b"%PDF" and len(response.content) < 512:
+            return False, "response too small to be a file"
+
+        cdn = urlparse(str(response.url)).hostname or "?"
+        return True, cdn
+
+    async def get_download_url(self, md5: str) -> DownloadResult:
+        """Resolve a clearnet download URL for a book by MD5 hash.
+
+        Walks `_mirror_candidates()` and returns the first mirror that yields a
+        key. The previous implementation looked the book up with
+        `search_title(md5)`, but LibGen's title index contains no md5 strings,
+        so that returned nothing and this method raised for every input — it
+        had never worked against the live service (the unit suite mocks
+        LibgenSearch, so it stayed green).
+
+        The returned URL is short-lived: the key expires in well under 2.5
+        hours, after which `get.php` silently 307s back to `/ads.php` instead
+        of erroring. Resolve immediately before downloading; never cache.
 
         Args:
             md5: MD5 hash identifying the book
@@ -105,48 +193,51 @@ class LibgenAdapter(SourceAdapter):
             DownloadResult with URL and no quota_info (LibGen has no quota)
 
         Raises:
-            ValueError: If book with given MD5 not found
+            ValueError: If no mirror yields a download key
         """
-        await self._rate_limit()
+        attempts = []
 
-        def _search_by_md5():
-            s = LibgenSearch(mirror=self.mirror)
-            # LibGen doesn't have direct MD5 lookup, search by MD5 as query
-            results = s.search_title(md5)
-            for book in results:
-                if getattr(book, "md5", "").lower() == md5.lower():
-                    return book
-            return None
+        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+            for mirror in self._mirror_candidates():
+                await self._rate_limit()
+                try:
+                    key = await self._resolve_key(client, mirror, md5)
+                except Exception as exc:  # network, TLS, HTTP error
+                    attempts.append(f"{mirror}: {type(exc).__name__}")
+                    logger.warning(f"LibGen mirror {mirror} failed for {md5}: {exc}")
+                    continue
 
-        book = await asyncio.to_thread(_search_by_md5)
+                if not key:
+                    attempts.append(f"{mirror}: no GET link")
+                    continue
 
-        if not book:
-            raise ValueError(f"Book with MD5 {md5} not found in LibGen")
+                url = f"https://libgen.{mirror}/get.php?md5={md5}&key={key}"
+                ok, detail = await self._serves_bytes(client, url)
+                if not ok:
+                    attempts.append(f"{mirror}: {detail}")
+                    logger.warning(
+                        f"LibGen mirror {mirror} resolved but cannot serve {md5}: {detail}"
+                    )
+                    continue
 
-        download_url = getattr(book, "tor_download_link", "") or ""
-        if not download_url:
-            # Try mirrors if tor link not available
-            mirrors = getattr(book, "mirrors", {})
-            if mirrors:
-                download_url = (
-                    list(mirrors.values())[0]
-                    if isinstance(mirrors, dict)
-                    else str(mirrors)
+                logger.info(
+                    f"LibGen download resolved on mirror {mirror} via {detail} for {md5}"
+                )
+                return DownloadResult(
+                    url=url,
+                    source=SourceType.LIBGEN,
+                    quota_info=None,  # LibGen has no quota
                 )
 
-        if not download_url:
-            raise ValueError(f"No download URL found for book {md5}")
-
-        return DownloadResult(
-            url=download_url,
-            source=SourceType.LIBGEN,
-            quota_info=None,  # LibGen has no quota
+        raise ValueError(
+            f"No LibGen mirror could resolve a download for {md5} "
+            f"(tried {', '.join(attempts)})"
         )
 
     async def close(self) -> None:
         """Clean up resources.
 
-        LibgenSearch doesn't maintain persistent connections,
-        so this is a no-op.
+        LibgenSearch doesn't maintain persistent connections, and
+        get_download_url scopes its client to the call, so this is a no-op.
         """
         pass

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -19,12 +19,15 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import html
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import parse_qs, urljoin, urlsplit
 
 import httpx
 
@@ -52,6 +55,34 @@ ANNAS_BASE_URL = _source_config.annas_base_url
 # lib/sources/libgen.py and libgen_api_enhanced) — mirror that construction so
 # the probe checks the host the runtime actually contacts.
 LIBGEN_BASE_URL = f"https://libgen.{_source_config.libgen_mirror}"
+
+# Mirror suffixes the download probe walks, configured mirror first. `li`, `vg`
+# and `la` were the three resolving suffixes on 2026-08-10 (issue #80); `rs`,
+# `gs`, `is` and `st` had no DNS. Per-mirror results are meaningful because
+# mirrors hand off to *different* CDN nodes that fail independently — on
+# 2026-08-10 `li` -> cdn4.booksdl.lc failed TLS while `vg`/`la` -> cdn3 served
+# real bytes.
+LIBGEN_MIRROR_CANDIDATES: tuple[str, ...] = tuple(
+    dict.fromkeys([_source_config.libgen_mirror, "li", "vg", "la"])
+)
+
+# A small, stable PDF used to exercise the download path end to end. Verified
+# to resolve on li/vg/la on 2026-08-10.
+LIBGEN_PROBE_MD5 = "73b76499ab3f33cd09d0cdbefc75ff54"
+# Only the first 2 KiB is fetched — enough for the magic bytes, small enough
+# that the probe is not a download.
+LIBGEN_PROBE_RANGE_BYTES = 2048
+# Minimum spacing between requests the download probe issues, in seconds.
+LIBGEN_PROBE_DELAY_SECONDS = 2.0
+
+# `ads.php` renders exactly one anchor whose href carries the CDN `key`:
+#   <a href="get.php?md5=...&key=GST1V9KIA7FWM2JQ"><h2>GET</h2></a>
+# Anchor *text* is not matched: it is markup (<h2>GET</h2>) and cosmetic, while
+# the key-bearing href is the thing the download actually needs.
+_LIBGEN_GET_HREF_RE = re.compile(
+    r"""<a\b[^>]*\bhref=["']([^"']*\bget\.php\?[^"']*\bkey=[^"']*)["']""",
+    re.IGNORECASE,
+)
 
 # Markers of domain-parking/traffic-monetization pages. A lapsed mirror that a
 # squatter re-registered (e.g. annas-archive.li -> Trellian/Above.com in
@@ -262,18 +293,188 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
         )
 
 
+def _extract_libgen_key(
+    page_url: str, body: str
+) -> tuple[Optional[str], Optional[str]]:
+    """Pull the CDN key out of an `ads.php` page.
+
+    Returns `(get_url, key)`, or `(None, None)` when the page carries no
+    key-bearing GET anchor — which is the DOM-drift signal.
+    """
+    match = _LIBGEN_GET_HREF_RE.search(body)
+    if not match:
+        return None, None
+    href = html.unescape(match.group(1))
+    get_url = urljoin(page_url, href)
+    key_values = parse_qs(urlsplit(get_url).query).get("key") or []
+    key = key_values[0] if key_values and key_values[0] else None
+    if not key:
+        return None, None
+    return get_url, key
+
+
+def _libgen_block_detail(mirror: str, resp: httpx.Response) -> Optional[str]:
+    """Classify a network-level refusal from a LibGen mirror.
+
+    Distinct from `_block_detail`, which is worded for the Z-Library DiamWall
+    wall and names ZLIB_DOMAIN. A refusal is not drift: the resolve-and-fetch
+    contract may be intact for clients the wall lets through.
+    """
+    if resp.status_code not in (403, 429, *WALLED_STATUS_CODES):
+        return None
+    return (
+        f"libgen.{mirror} refused this network's clients (HTTP "
+        f"{resp.status_code}) — from a datacenter/CI address this is expected "
+        "IP blocking, not upstream drift"
+    )
+
+
+async def _probe_libgen_download_mirror(
+    client: httpx.AsyncClient, mirror: str
+) -> tuple[bool, str, bool]:
+    """Exercise the full resolve-and-fetch path against one mirror.
+
+    Returns `(ok, detail, blocked)`. Three hops can each fail independently
+    (issue #80): the `ads.php` DOM scrape for the key, the key's TTL (< 2.5h,
+    and an expired key silently 307s back to `/ads.php` rather than erroring),
+    and the liveness of whichever `cdn*.booksdl.*` node the mirror hands off to.
+    """
+    base = f"https://libgen.{mirror}"
+    ads_url = f"{base}/ads.php"
+    try:
+        resp = await client.get(ads_url, params={"md5": LIBGEN_PROBE_MD5})
+        blocked = _libgen_block_detail(mirror, resp)
+        if blocked:
+            return False, blocked, True
+        resp.raise_for_status()
+        get_url, key = _extract_libgen_key(str(resp.url), resp.text)
+        if not get_url or not key:
+            return (
+                False,
+                f"{mirror}: ads.php returned HTTP {resp.status_code} with no "
+                "key-bearing GET link (DOM drift — the resolver scrapes this "
+                "anchor for the CDN key)",
+                False,
+            )
+    except Exception as exc:  # noqa: BLE001 - any failure is a reportable signal
+        return False, f"{mirror}: ads.php {type(exc).__name__}: {exc}", False
+
+    # Rate limit: never hammer a mirror, even across the two hops.
+    await asyncio.sleep(LIBGEN_PROBE_DELAY_SECONDS)
+
+    try:
+        # get.php 307s to a CDN host, so redirects must be followed. Only the
+        # first 2 KiB is requested — enough to see the magic bytes.
+        resp = await client.get(
+            get_url,
+            headers={"Range": f"bytes=0-{LIBGEN_PROBE_RANGE_BYTES - 1}"},
+        )
+    except Exception as exc:  # noqa: BLE001
+        # A dead CDN node lands here (cdn4.booksdl.lc failed TLS on
+        # 2026-08-10). That is a real capability failure, not a block.
+        return False, f"{mirror}: get.php {type(exc).__name__}: {exc}", False
+
+    blocked = _libgen_block_detail(mirror, resp)
+    if blocked:
+        return False, blocked, True
+
+    final_url = str(resp.url)
+    hops = [str(r.headers.get("location", "")) for r in resp.history]
+    if "/ads.php" in urlsplit(final_url).path or any("/ads.php" in h for h in hops):
+        return (
+            False,
+            f"{mirror}: key {key} bounced back to /ads.php — expired or "
+            "rejected key (this returns HTTP 200 HTML, not an error, so it "
+            "must be detected by the redirect target)",
+            False,
+        )
+
+    cdn_host = urlsplit(final_url).netloc or f"libgen.{mirror}"
+    if resp.status_code not in (200, 206):
+        return (
+            False,
+            f"{mirror}: get.php -> {cdn_host} returned HTTP {resp.status_code}",
+            False,
+        )
+
+    content_type = (resp.headers.get("content-type") or "").lower()
+    if "html" in content_type:
+        return (
+            False,
+            f"{mirror}: get.php -> {cdn_host} served a page, not a file "
+            f"(HTTP {resp.status_code}, content-type {content_type or 'unset'})",
+            False,
+        )
+
+    body = resp.content
+    if not body.startswith(b"%PDF"):
+        return (
+            False,
+            f"{mirror}: get.php -> {cdn_host} returned HTTP {resp.status_code} "
+            f"but the bytes are not a PDF (first 8: {body[:8]!r})",
+            False,
+        )
+
+    return (
+        True,
+        f"{mirror}: ads.php key -> {cdn_host} HTTP {resp.status_code}, "
+        f"{len(body)} bytes of PDF (content-type {content_type or 'unset'})",
+        False,
+    )
+
+
+async def probe_libgen_download(client: httpx.AsyncClient) -> ProbeResult:
+    """Check that LibGen can actually deliver bytes, not merely answer a search.
+
+    `probe_libgen` only asserts that search returns HTTP 200. That stayed green
+    on 2026-08-10 while every download through the default mirror failed at the
+    CDN hop — the reachability-vs-capability gap of issue #81. This probe walks
+    the mirrors in order and reports the first that hands over real PDF bytes.
+    """
+    attempts: list[str] = []
+    blocked_count = 0
+    for index, mirror in enumerate(LIBGEN_MIRROR_CANDIDATES):
+        if index:
+            await asyncio.sleep(LIBGEN_PROBE_DELAY_SECONDS)
+        ok, detail, blocked = await _probe_libgen_download_mirror(client, mirror)
+        if ok:
+            skipped = len(LIBGEN_MIRROR_CANDIDATES) - index - 1
+            suffix = f"; {skipped} further mirror(s) not tried" if skipped else ""
+            return ProbeResult(
+                name="libgen:download",
+                ok=True,
+                detail=detail + suffix,
+                required=False,
+            )
+        blocked_count += 1 if blocked else 0
+        attempts.append(detail)
+
+    return ProbeResult(
+        name="libgen:download",
+        ok=False,
+        detail="no mirror delivered a file — " + " | ".join(attempts),
+        required=False,
+        # Only a wholly blocked walk is a network-level refusal; if any mirror
+        # answered and still could not deliver, that is a real capability
+        # failure and must not be filed under BLOCK.
+        blocked=blocked_count == len(LIBGEN_MIRROR_CANDIDATES),
+        extra={"mirrors_tried": list(LIBGEN_MIRROR_CANDIDATES)},
+    )
+
+
 async def run_probes() -> list[ProbeResult]:
     async with httpx.AsyncClient(
         timeout=TIMEOUT,
         follow_redirects=True,
         headers={"User-Agent": "zlibrary-mcp-upstream-check"},
     ) as client:
-        zlib_results, annas, libgen = await asyncio.gather(
+        zlib_results, annas, libgen, libgen_download = await asyncio.gather(
             probe_zlibrary_eapi(client),
             probe_annas(client),
             probe_libgen(client),
+            probe_libgen_download(client),
         )
-    return [*zlib_results, annas, libgen]
+    return [*zlib_results, annas, libgen, libgen_download]
 
 
 def actionable_failures(results: list[ProbeResult]) -> list[ProbeResult]:


### PR DESCRIPTION
Gives agents LibGen search **and** acquisition. Closes the LibGen half of #73.

Until now Z-Library was the only source that could deliver bytes, so hitting its daily limit left no fallback despite two other sources being wired in and green in `npm run doctor`. That contradicted VISION.md invariant 4 ("sources are adapters; no source is privileged").

## Verified end to end

```
PICKED:  Reading Brandom On A Spirit of Trust | 5 MB | src: libgen
         libgen.li -> cdn3.booksdl.lc -> 4,764,906 bytes
RESULT:  EditorGillesBouche_ReadingBrandomOnASpiritOfTrust_2020_engli_138886469.pdf
```

No Z-Library credentials, no quota, no Tor. The existing unified-filename logic applied untouched.

## `get_download_url` rewritten

It previously resolved an md5 via `search_title(md5)` — but LibGen's title index holds no md5 strings, so it returned nothing and **raised for every input**. It had never worked live; the unit suite mocked `LibgenSearch`, so it stayed green.

`ads.php` is addressable straight from the hash, no search involved:

```
https://libgen.<mirror>/ads.php?md5=<md5>          -> one GET anchor carrying a key
https://libgen.<mirror>/get.php?md5=<md5>&key=<k>  -> 307 -> CDN
```

Mirrors walk `li -> vg -> la`, configured first.

### Failover is driven by bytes, not by key resolution

A mirror can hand out a valid key while its CDN node is dead — measured 2026-08-10: `libgen.li` resolved fine while its `cdn4` node failed TLS, and `vg`/`la` reached a healthy `cdn3` (see #80). Each candidate is verified with a 2KB ranged request rejecting three silent-failure shapes:

- an expired key **307ing back to `/ads.php`** rather than erroring
- an HTML error page served as HTTP 200
- a truncated body

`search()` no longer stores `tor_download_link`: the only URL it can offer needs Tor, and a clearnet key expires in under 2.5h, so resolving per hit would waste a request per result and expire before use.

## Source-agnostic fetch

Everything downstream of the fetch in `download_book` — unified filename, RAG processing, the bundle contract — was already source-independent; only step 1 was welded to `EAPIClient`. Adds `_download_url_to_file` and branches step 1 on `book_details['source']`.

**No TypeScript change was needed** — a `search_multi_source` result already carries `md5` and `source`, so `download_book_to_file` routes on `bookDetails` and the tool count stays flat.

`get_eapi_client()` moved inside the non-source branch, so **a LibGen download no longer requires Z-Library credentials at all**.

## Doctor probe (#81)

`probe_libgen_download` exercises resolve-and-fetch rather than reachability. The old `probe_libgen` only checked search returned 200 — which stayed green all day today while downloads were broken. Live:

```
OK  libgen:download  li: ads.php key -> cdn3.booksdl.lc HTTP 206, 2048 bytes of PDF; 2 further mirror(s) not tried
5 passing, 0 required failing, 0 optional failing
```

## Tests

`TestLibgenAdapterDownload` rewritten against `httpx.MockTransport`. The old tests mocked `LibgenSearch`, which after this change left the adapter's `httpx` calls **hitting the live network** — the suite went 6s -> 17s making real requests to three mirrors. Now 0.25s, no network. Covers key resolution, failover on network error, failover when a mirror resolves but its CDN cannot serve, the expired-key bounce, DOM drift on every mirror, and mirror ordering.

13 new probe tests via `MockTransport` cover per-mirror failover, expiry bounce, HTML-instead-of-file, non-PDF magic bytes, all-mirrors-walled -> BLOCK, and mixed wall+failure -> WARN.

**1051 passed, 3 skipped, 7 xfailed; coverage 67.40%. Jest 178 passed.**

## One judgment call worth a second opinion

`ProbeResult.blocked` is a per-response flag, but this probe makes N requests across M mirrors. Ruling taken: `blocked=True` only when *every* mirror was refused at the network level; a mix of one wall and one real capability failure reports as a plain WARN, since something answered and could not deliver. The existing single-request convention does not settle this.

Also noted: `_block_detail` is Z-Library-specific in its wording, so the probe carries a ~6-line sibling rather than generalising shared reporting logic. Worth merging if a third source needs one.

Refs #73, #79, #80, #81