### PR TITLE
release: v1.4.0 — LibGen becomes a usable source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-10
+
+Z-Library is no longer the only source that can deliver a file. LibGen search
+results are now downloadable, so hitting the Z-Library daily limit has a
+fallback — a step toward VISION.md invariant 4 ("sources are adapters; no
+source is privileged").
+
+### Added
+
+- **LibGen downloads.** `download_book_to_file` accepts a `search_multi_source`
+  result and fetches it. Downloads resolve through `ads.php`, which is
+  addressable directly from the md5, and walk mirrors `li → vg → la`.
+  Failover is driven by *bytes actually served*, not by key resolution: a
+  mirror can hand out a valid key while the CDN node behind it is dead, so
+  each candidate is verified with a ranged request that rejects an expired-key
+  bounce to `/ads.php`, an HTML error page served as HTTP 200, and a truncated
+  body. **LibGen downloads require no Z-Library credentials.**
+- `libgen:download` probe in `npm run doctor` and the scheduled upstream check,
+  exercising resolve-and-fetch rather than reachability. The previous probe
+  stayed green while downloads were broken.
+
+### Fixed
+
+- **Security: `annas-archive.is` removed from `ANNAS_TRUSTED_HOSTS`.** That
+  list authorizes attaching `ANNAS_SECRET_KEY`, which the fast-download API
+  passes as a URL query parameter. The host is not Anna's Archive:
+  `/dyn/api/fast_download.json` returns 404 there versus 401 on the genuine
+  `.gl`, and it serves a secret-key "recovery" form. Anyone who set
+  `ANNAS_BASE_URL` to it would have disclosed their key.
+- `LibgenAdapter.get_download_url` no longer raises for every input. It looked
+  books up via `search_title(md5)`, but LibGen's title index holds no md5
+  strings, so it had never worked against the live service — the unit suite
+  mocked `LibgenSearch` and stayed green.
+- `SourceRouter` honours an explicit `source="annas"` without an API key.
+  Anna's search carries no credentials; only downloads need the key. Adapter
+  construction was gated on the key, so an explicit request silently returned
+  LibGen results.
+- Audit gate: `cryptography` floor raised to 50.0.0 and `nltk` to 3.10.0,
+  clearing four advisories that were failing CI on every PR.
+
 ### Changed
 
+- CI runs without Git LFS. The repository exceeded its LFS budget, which failed
+  `actions/checkout` outright and blocked every merge, plus releases. Existing
+  unhydrated-pointer guards skip the affected tests with an actionable reason,
+  surfaced via `pytest -rs`. **Five real-PDF tests no longer run in CI** — a
+  known coverage gap tracked in #85. Local runs are unaffected.
+- LibGen search results no longer carry a `.onion` `download_url`. The only URL
+  search can offer needs Tor, and a clearnet key expires in under 2.5 hours, so
+  callers resolve on demand.
 - README Docker instructions now lead with the published GHCR image (verified
   end-to-end: SSE handshake and `initialize` against the released container);
   building from source via compose is the secondary path.
 - Removed GSD-era `.claude/commands/` (referencing the deleted `ROADMAP.md`
   workflow) and the empty `.claude/settings.json`.
+
+### Known limitations
+
+- Keyless Anna's Archive downloads are **not supported and will not be**. The
+  `/slow_download/` route is gated by a DDoS-Guard browser challenge that the
+  project states is there to stop bots and scrapers. Anna's keyless *search*
+  works normally; keyed `fast_download` remains the supported download path.
 
 ## [1.3.2] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ source is privileged").
   each candidate is verified with a ranged request that rejects an expired-key
   bounce to `/ads.php`, an HTML error page served as HTTP 200, and a truncated
   body. **LibGen downloads require no Z-Library credentials.**
+- The server now starts without `ZLIBRARY_EMAIL`/`ZLIBRARY_PASSWORD`. Missing
+  credentials are a stderr warning rather than a fatal exit, so a LibGen-only
+  install works out of the box; Z-Library tools still error clearly when
+  called. Previously the process exited 1 at startup, which would have made
+  the new unlimited source unreachable on a bare install.
 - `libgen:download` probe in `npm run doctor` and the scheduled upstream check,
   exercising resolve-and-fetch rather than reachability. The previous probe
   stayed green while downloads were broken.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zlibrary-mcp",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zlibrary-mcp",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zlibrary-mcp",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Z-Library MCP server for AI assistants (UV-based)",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -573,8 +573,13 @@ function wrapResult(result: any, toolName: string) {
 // ============================================================================
 
 /**
- * Validate required environment variables before server startup.
- * Exits with a clear, actionable error if credentials are missing.
+ * Check Z-Library credentials before server startup.
+ *
+ * Missing credentials are a warning, not a fatal error: since v1.4.0 the
+ * LibGen source needs none, so `search_multi_source` and downloads of its
+ * results work on a bare install. Exiting here would make a working,
+ * unlimited source unreachable because an unrelated one was unconfigured.
+ * Z-Library tools still fail with their own clear error when invoked.
  */
 function validateCredentials(): void {
   const email = process.env.ZLIBRARY_EMAIL;
@@ -585,19 +590,15 @@ function validateCredentials(): void {
     if (!email) missing.push('ZLIBRARY_EMAIL');
     if (!password) missing.push('ZLIBRARY_PASSWORD');
 
-    console.error(
-      `\nError: Missing required environment variable(s): ${missing.join(', ')}\n\n` +
-        `Z-Library credentials are required for the MCP server to function.\n\n` +
-        `To fix this, set the following in your MCP client configuration:\n` +
-        `  "env": {\n` +
-        `    "ZLIBRARY_EMAIL": "your-email@example.com",\n` +
-        `    "ZLIBRARY_PASSWORD": "your-password"\n` +
-        `  }\n\n` +
-        `For Claude Desktop, add this to your claude_desktop_config.json.\n` +
-        `For other MCP clients, consult your client's documentation.\n` +
-        `See README.md for detailed setup instructions.\n`,
+    logger.warn(
+      `Missing environment variable(s): ${missing.join(', ')} — ` +
+        `Z-Library tools (search_books, full_text_search, get_download_limits, ` +
+        `download history) will fail when called. LibGen is unaffected: use ` +
+        `search_multi_source with source="libgen" and pass results to ` +
+        `download_book_to_file. To enable Z-Library, set "env": ` +
+        `{"ZLIBRARY_EMAIL": "...", "ZLIBRARY_PASSWORD": "..."} in your MCP ` +
+        `client configuration. See README.md.`,
     );
-    process.exit(1);
   }
 }
 


### PR DESCRIPTION
Cuts 1.4.0. npm currently serves 1.3.2, which predates every fix from today.

## Headline

Z-Library is no longer the only source that can deliver a file. LibGen search results are downloadable, so the Z-Library daily limit finally has a fallback — VISION.md invariant 4, realised for acquisition rather than just search.

## Included since 1.3.2

- **LibGen downloads** (#87) — `ads.php` resolution with `li -> vg -> la` failover driven by bytes actually served, not key resolution
- **Security fix** (#82) — `annas-archive.is` removed from the secret-key host allowlist; it is an impostor
- **CI unblock** (#86) — audit floors raised; CI runs without Git LFS after the budget was exhausted
- **Tracker config** (#83)
- **`libgen:download` doctor probe** — exercises resolve-and-fetch, not reachability

## The bug the release gate caught

`validateCredentials()` called `process.exit(1)` when `ZLIBRARY_EMAIL`/`ZLIBRARY_PASSWORD` were unset. Since LibGen needs no Z-Library account, that made the new unlimited source **unreachable on a bare install** — the server would not boot at all.

Found by running an MCP `initialize` handshake against the packed 1.4.0 tarball in a clean prefix, which exited 1 with no stdout. Missing credentials are now a stderr warning naming the affected tools; Z-Library tools still error clearly when invoked.

This is exactly the repo-works/package-breaks split the 1.3.2 notes warn about, and it would have shipped without the packed-artifact gate.

## Verification

**Packed artifact, clean prefix:**
```
bridge resolved -> <prefix>/lib/node_modules/zlibrary-mcp/lib/python_bridge.py   exists: true
libgen.py present: true    has ads.php resolver: true
initialize -> zlibrary-mcp 1.4.0
tools: 13 | search_multi_source: true | download_book_to_file: true
stdout: JSON-RPC only
```
(with `ZLIBRARY_EMAIL` and `ZLIBRARY_PASSWORD` both unset)

**Live end-to-end on merged master:** two real downloads via `libgen.li -> cdn3.booksdl.lc`, most recently a 20-page, 1.55 MB PDF, named by the existing unified-filename logic.

**Doctor:** 5 passing, 0 failing, including `libgen:download`.

**Suites:** 1052 Python passed / 3 skipped / 7 xfailed; Jest 178 passed. `npm ci` verified in sync after the lockfile bump.

## After merge

Tag `v1.4.0` to trigger `publish.yml` (npm via OIDC trusted publishing, plus GHCR). Note this is the first release since the LFS breakage — `publish.yml` carried `lfs: true` and would have failed at checkout; that is fixed here.

## Known gaps, stated plainly

- Five real-PDF tests do not run in CI while the LFS budget is exhausted (#85)
- Keyless Anna's downloads are not supported and will not be — DDoS-Guard browser challenge, deliberate anti-bot policy