### PR TITLE
fix: point repository URLs at rookslog after the account rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,17 +1,17 @@
 blank_issues_enabled: true
 contact_links:
   - name: Server disconnects immediately on startup
-    url: https://github.com/loganrooks/zlibrary-mcp/blob/master/docs/TROUBLESHOOTING.md
+    url: https://github.com/rookslog/zlibrary-mcp/blob/master/docs/TROUBLESHOOTING.md
     about: >
       Usually a setup problem rather than a bug — missing credentials, a
       Python environment that was never created with `uv sync`, or a stale build.
       The troubleshooting guide walks through each in order.
   - name: Upstream source is down
-    url: https://github.com/loganrooks/zlibrary-mcp/issues?q=is%3Aissue+label%3Aupstream-drift
+    url: https://github.com/rookslog/zlibrary-mcp/issues?q=is%3Aissue+label%3Aupstream-drift
     about: >
       Z-Library, Anna's Archive, and LibGen rotate domains without notice. A
       scheduled job tracks their availability and files here. Run
       `npm run doctor` to confirm before opening a new issue.
   - name: Security vulnerability
-    url: https://github.com/loganrooks/zlibrary-mcp/security/advisories/new
+    url: https://github.com/rookslog/zlibrary-mcp/security/advisories/new
     about: Report privately rather than in a public issue.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "roocode",
     "cline"
   ],
-  "author": "loganrooks",
+  "author": "rookslog",
   "license": "MIT",
   "files": [
     "dist/",
@@ -64,12 +64,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/loganrooks/zlibrary-mcp.git"
+    "url": "git+https://github.com/rookslog/zlibrary-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/loganrooks/zlibrary-mcp/issues"
+    "url": "https://github.com/rookslog/zlibrary-mcp/issues"
   },
-  "homepage": "https://github.com/loganrooks/zlibrary-mcp#readme",
+  "homepage": "https://github.com/rookslog/zlibrary-mcp#readme",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Unblocks the v1.4.0 npm publish.

## The failure

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is
"git+https://github.com/loganrooks/zlibrary-mcp.git", expected to match
"https://github.com/rookslog/zlibrary-mcp" from provenance
```

The GitHub account was renamed `loganrooks` -> `rookslog`. GitHub redirects the old URLs, so nothing visibly broke — but a sigstore provenance bundle carries the OIDC `repository` claim, and npm cross-checks it against `package.json`, where the old owner was still recorded.

This only surfaced *after* the trusted publisher was re-bound to the new owner. The earlier failure was `E404` (binding mismatch), which never reached provenance validation.

## Changes

`package.json`: `repository.url`, `bugs.url`, `homepage`, `author`. Plus `.github/ISSUE_TEMPLATE/config.yml` links, which pointed at the old owner for troubleshooting docs, the drift-issue query, and the security-advisory form.

Docs and CHANGELOG history are deliberately left alone — prose about past events, and GitHub redirects them.

`npm ci` verified in sync after the lockfile refresh; build passes.

## After merge

Move the `v1.4.0` tag to the new commit and re-run Publish. GHCR already has `1.4.0`/`1.4`/`latest` from the first run; npm still serves 1.3.2.