### PR TITLE
docs: document LibGen as a download source and correct stale claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,11 +290,30 @@ The live plan is
 — the current health assessment and forward roadmap covering open PR/issue
 disposition, CI and release state, coverage gaps, and multi-source expansion.
 
-v1.3.0 was released 2026-07-24: the GitHub release, GHCR image, and npm package are
-all live. npm publishing authenticates via OIDC trusted publishing (no `NPM_TOKEN`
-secret; the trusted publisher is bound to `publish.yml`). v1.3 (RAG Pipeline Refinement) has
-Phase 19 complete; Phases 20-21 are pending, with acceptance criteria preserved in
+**v1.4.0 was released 2026-08-10** — npm, GHCR, and the git tag are all live. LibGen
+is now a real download source: `download_book_to_file` accepts a `search_multi_source`
+result, resolves a link through `ads.php`, and fails over across the mirrors
+`li → vg → la`. Failover is driven by bytes actually served, not by key resolution,
+because a mirror can return a valid key while its CDN node is dead. **LibGen needs no
+Z-Library account and has no daily limit**, so the ~10/day Z-Library ceiling finally
+has a fallback.
+
+Keyless Anna's Archive downloads are ruled out, not deferred: the free route sits
+behind a DDoS-Guard browser challenge the project operates deliberately. Anna's
+keyless *search* still works. See the v1.4 map (issue #75) for the full disposition.
+
+npm publishing authenticates via OIDC trusted publishing (no `NPM_TOKEN` secret; the
+trusted publisher is bound to `publish.yml`). Note the account rename
+`loganrooks` → `rookslog`: provenance validation cross-checks `package.json`
+`repository.url` against the OIDC claim, so both the trusted publisher binding and
+that URL must name the current owner.
+
+v1.3 (RAG Pipeline Refinement) has Phase 19 complete; Phases 20-21 are pending, with
+acceptance criteria preserved in
 [claudedocs/architecture/phase-20-21-review-2026-07-24.md](claudedocs/architecture/phase-20-21-review-2026-07-24.md).
+
+**Known gap:** CI runs with `lfs: false` because the repository exceeded its Git LFS
+budget, so five real-PDF tests do not run in CI (issue #85). Local runs are unaffected.
 
 Branching Strategy: See `.claude/VERSION_CONTROL.md` for feature branch conventions and workflow.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Z-Library MCP Server
 
-[![CI](https://github.com/loganrooks/zlibrary-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/loganrooks/zlibrary-mcp/actions/workflows/ci.yml)
+[![CI](https://github.com/rookslog/zlibrary-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/rookslog/zlibrary-mcp/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/zlibrary-mcp)](https://www.npmjs.com/package/zlibrary-mcp)
-[![License: MIT](https://img.shields.io/github/license/loganrooks/zlibrary-mcp)](https://github.com/loganrooks/zlibrary-mcp/blob/master/LICENSE)
+[![License: MIT](https://img.shields.io/github/license/rookslog/zlibrary-mcp)](https://github.com/rookslog/zlibrary-mcp/blob/master/LICENSE)
 
-A Model Context Protocol (MCP) server that gives AI assistants -- Claude Code, Claude Desktop, RooCode, Cline -- the ability to search Z-Library, download books, and extract document content for Retrieval-Augmented Generation (RAG) workflows. Built with a Node.js/TypeScript MCP frontend and a Python bridge backend for document processing.
+A Model Context Protocol (MCP) server that gives AI assistants -- Claude Code, Claude Desktop, RooCode, Cline -- the ability to search for books, download them, and extract document content for Retrieval-Augmented Generation (RAG) workflows. The server reads from Z-Library and Library Genesis. It uses a Node.js/TypeScript MCP frontend and a Python bridge backend for document processing.
 
 For what this project is — and deliberately isn't — see [VISION.md](VISION.md).
 
@@ -18,7 +18,22 @@ npm install -g zlibrary-mcp
 cd "$(npm root -g)/zlibrary-mcp" && bash setup-uv.sh   # one-time Python environment setup
 ```
 
-Then add to your MCP client config (Claude Code `.mcp.json`, Claude Desktop `claude_desktop_config.json`):
+Then add the server to your MCP client config (Claude Code `.mcp.json`, Claude Desktop `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "zlibrary": {
+      "command": "zlibrary-mcp"
+    }
+  }
+}
+```
+
+This configuration gives you Library Genesis search and downloads. Library Genesis needs
+no account and applies no daily limit.
+
+To also use the Z-Library tools, add your credentials:
 
 ```json
 {
@@ -33,6 +48,9 @@ Then add to your MCP client config (Claude Code `.mcp.json`, Claude Desktop `cla
   }
 }
 ```
+
+The server starts without credentials. It writes a warning to stderr and names the tools
+that will fail. See [Sources](#sources) for what each source provides.
 
 Developing or contributing? Install [from source](#option-b-from-source-for-development) instead.
 
@@ -53,18 +71,24 @@ flowchart LR
         C[python_bridge.py]
         D[lib/rag/ modules]
     end
-    subgraph "External"
+    subgraph "Sources"
         E[Z-Library EAPI]
+        F[Library Genesis]
+        G[Anna's Archive]
     end
     A -->|stdio| B
     A -->|SSE/HTTP| SG -->|stdio| B
     B -->|PythonShell| C
     C --> D
     C -->|httpx| E
+    C -->|SourceRouter| F
+    C -->|SourceRouter| G
 ```
 
 - **Node.js/TypeScript MCP Server**: 13 tools registered via McpServer `server.tool()` API (MCP SDK 1.25+)
 - **Python Bridge**: Z-Library EAPI client (httpx) + document processing (lib/rag/ modules)
+- **Source Router**: routes Library Genesis and Anna's Archive requests, with mirror
+  failover on downloads (`lib/sources/`). Z-Library keeps its own path until #40 lands.
 - **EAPI Transport**: JSON API endpoints at `/eapi/` bypass Cloudflare browser challenges
 - **UV-Based Python Environment**: Project-local `.venv/` with `uv.lock` for reproducible builds
 - **Vendored Z-Library Fork**: Custom EAPI client for search and file downloads
@@ -81,7 +105,7 @@ flowchart LR
 | `search_by_term` | Conceptual navigation via terms |
 | `search_by_author` | Advanced author search |
 | `search_advanced` | Fuzzy match detection with separate exact/fuzzy results |
-| `search_multi_source` | Parallel search across multiple sources |
+| `search_multi_source` | Search Library Genesis or Anna's Archive (see [Sources](#sources)) |
 | `get_recent_books` | Recently added books |
 
 ### Metadata Tools (1)
@@ -112,6 +136,81 @@ flowchart LR
 
 For complete parameter documentation, types, and examples, see [API Reference](docs/api.md).
 
+## Sources
+
+The server reads from three sources. Each source has different requirements and different
+capabilities.
+
+| Source | Account | Daily limit | Search | Download |
+|--------|---------|-------------|--------|----------|
+| Library Genesis | No | None | Yes | Yes |
+| Z-Library | Yes | Approximately 10 books | Yes | Yes |
+| Anna's Archive | API key for downloads | Set by membership | Yes | Only with an API key |
+
+### Library Genesis
+
+Library Genesis needs no account and applies no daily limit. Use it when you reach the
+Z-Library limit, or when you do not want an account.
+
+To find a book, call `search_multi_source` with `source: "libgen"`. To download it, pass a
+result to `download_book_to_file`.
+
+```jsonc
+// 1. Search
+{ "query": "Phenomenology of Spirit", "source": "libgen", "count": 5 }
+
+// 2. Download a result. Pass the book object from step 1 as bookDetails.
+{ "bookDetails": { "md5": "...", "source": "libgen", "title": "...", "extension": "pdf" },
+  "process_for_rag": true }
+```
+
+The server resolves a download link at the moment you request the file. It tries the
+mirrors `libgen.li`, `libgen.vg`, and `libgen.la` in order. Each mirror sends the file
+from a different content delivery network (CDN) node, and these nodes fail independently.
+Therefore the server does not accept a mirror until that mirror sends file data. This
+behavior routes around a failed CDN node.
+
+Library Genesis download links expire in less than 2.5 hours. The server does not cache
+them. An expired link returns the intermediate web page instead of an error, so the server
+treats that response as a failure.
+
+### Z-Library
+
+Z-Library needs an account. Set `ZLIBRARY_EMAIL` and `ZLIBRARY_PASSWORD` in your MCP client
+config. Without these variables, the Z-Library tools fail when you call them. The other
+tools continue to work.
+
+Z-Library applies a daily download limit of approximately 10 books. Call
+`get_download_limits` to check your remaining quota.
+
+### Anna's Archive
+
+Anna's Archive search needs no account. Call `search_multi_source` with
+`source: "annas"`.
+
+**Note:** keyless search returns the MD5 hash and the record URL only. It does not return
+the title, the author, or the file format.
+
+Anna's Archive downloads need a membership API key in `ANNAS_SECRET_KEY`. Without a key,
+the server cannot download from Anna's Archive. Anna's Archive protects its free download
+route with a browser verification challenge, and this server does not defeat that
+protection. Open the record URL in a web browser to download a file without a key.
+
+**Warning:** the fast-download API sends `ANNAS_SECRET_KEY` as a URL parameter. Therefore
+the server sends the key only to hosts in `ANNAS_TRUSTED_HOSTS` in `lib/sources/config.py`.
+Anna's Archive domains lapse, and other operators re-register them. Do not add a host to
+that list until you confirm the host is genuine.
+
+### Check source health
+
+```bash
+npm run doctor
+```
+
+This command tests each source and reports the result. The Library Genesis test resolves a
+download link and reads the first 2 KB of a file. Therefore it detects a broken download
+path, not only a reachable web page.
+
 ## Installation
 
 ### Option A: npm (recommended)
@@ -135,7 +234,7 @@ fork, `pyproject.toml`, `uv.lock`), so no clone is needed. Since v1.3.0 the
 release workflow verifies the tag against `package.json` and publishes with
 provenance, so the registry version tracks GitHub releases; if
 `npm view zlibrary-mcp version` ever trails the
-[latest release](https://github.com/loganrooks/zlibrary-mcp/releases), that is a
+[latest release](https://github.com/rookslog/zlibrary-mcp/releases), that is a
 release-pipeline bug worth filing.
 
 ### Option B: From Source (for development)
@@ -147,7 +246,7 @@ release-pipeline bug worth filing.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # 2. Clone and build
-git clone https://github.com/loganrooks/zlibrary-mcp.git
+git clone https://github.com/rookslog/zlibrary-mcp.git
 cd zlibrary-mcp
 git lfs pull         # Hydrates LFS-tracked test PDFs (don't run `git lfs install`;
                      # it conflicts with the repo's Husky-managed hooks)
@@ -198,15 +297,15 @@ RooCode / Cline (`mcp_settings.json`):
 
 **Prerequisites:** Docker
 
-Versioned images are published to GHCR on every release (`latest`, `1.3`,
-`1.3.2`, …) — no clone or build needed:
+Versioned images are published to GHCR on every release (`latest`, `1.4`,
+`1.4.0`, …) — no clone or build needed:
 
 ```bash
 docker run -d --name zlibrary-mcp -p 8000:8000 \
   -e ZLIBRARY_EMAIL="your-email@example.com" \
   -e ZLIBRARY_PASSWORD="your-password" \
   -v "$PWD/downloads:/app/downloads" \
-  ghcr.io/loganrooks/zlibrary-mcp:latest
+  ghcr.io/rookslog/zlibrary-mcp:latest
 ```
 
 The image wraps the stdio server in
@@ -225,7 +324,7 @@ curl -s -N --max-time 3 http://localhost:8000/sse | head -2
 **Building from source instead** (adds a `/health` endpoint via compose):
 
 ```bash
-git clone https://github.com/loganrooks/zlibrary-mcp.git && cd zlibrary-mcp
+git clone https://github.com/rookslog/zlibrary-mcp.git && cd zlibrary-mcp
 cp docker/env.example docker/.env   # then edit in your credentials
 docker compose -f docker/docker-compose.yaml up -d
 curl http://localhost:8000/health

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,13 @@
 # API Reference
 
-This is the API reference for the **zlibrary-mcp** MCP (Model Context Protocol) server. Tools are invoked via MCP protocol -- not HTTP REST. All tools require valid Z-Library credentials (`ZLIBRARY_EMAIL` and `ZLIBRARY_PASSWORD`) configured in the MCP client's environment.
+This is the API reference for the **zlibrary-mcp** MCP (Model Context Protocol) server. Tools are invoked via MCP protocol -- not HTTP REST.
+
+**Credentials.** Most tools read from Z-Library and need `ZLIBRARY_EMAIL` and `ZLIBRARY_PASSWORD` in the MCP client environment. Two tools do not:
+
+- `search_multi_source` reads from Library Genesis and Anna's Archive.
+- `download_book_to_file` needs no credentials when you pass it a Library Genesis result.
+
+The server starts without credentials. The Z-Library tools then fail when you call them, and the other tools continue to work.
 
 All tools return MCP content arrays in the format:
 
@@ -239,7 +246,11 @@ Each entry contains standard book metadata fields.
 
 ### search_multi_source
 
-**Description:** Search for books across Anna's Archive and LibGen. An alternative to Z-Library's EAPI. Use `source=auto` to prefer Anna's Archive with LibGen fallback, or force a specific source.
+**Description:** Search for books in Library Genesis or Anna's Archive. This tool is an alternative to the Z-Library search tools. It needs no Z-Library account.
+
+Results from this tool can be downloaded. Pass a result to `download_book_to_file` as `bookDetails`.
+
+**Note:** Anna's Archive results contain the MD5 hash and the record URL only, unless you set `ANNAS_SECRET_KEY`. Library Genesis results contain full metadata and can be downloaded without a key.
 
 **Parameters:**
 
@@ -249,7 +260,9 @@ Each entry contains standard book metadata fields.
 | source | enum | No | `"auto"` | Source selection: `"auto"` (Anna's Archive if key available, else LibGen), `"annas"` (force Anna's Archive), or `"libgen"` (force LibGen) |
 | count | integer | No | `10` | Maximum number of results to return |
 
-**Returns:** JSON array of book objects with source-specific fields: `md5`, `title`, `author`, `year`, `extension`, `size`, `source`, `download_url`.
+**Returns:** JSON array of book objects with the fields `md5`, `title`, `author`, `year`, `extension`, `size`, and `source`.
+
+**Note:** `download_url` is empty for Library Genesis results. The server resolves a download link only when you request the file, because a Library Genesis link expires in less than 2.5 hours.
 
 **Example Usage:**
 
@@ -266,9 +279,10 @@ Each entry contains standard book metadata fields.
 
 **Error Cases:**
 - Invalid or missing `query` parameter
-- Anna's Archive API key not configured (when `source="annas"`)
 - Both sources unavailable (network errors, rate limiting)
 - Invalid `source` value (must be `"auto"`, `"annas"`, or `"libgen"`)
+
+**Note:** `source="annas"` works without an API key. Anna's Archive needs a key for downloads only.
 
 ---
 
@@ -383,13 +397,15 @@ Each entry contains standard book metadata fields.
 
 ### download_book_to_file
 
-**Description:** Download a book to a local file. Pass the full `bookDetails` object from `search_books` results. Optionally process the document for RAG after download. When processing is enabled, the response stays additive: `processed_file_path` remains the body-text anchor and sibling bundle paths are returned when available.
+**Description:** Download a book to a local file. Pass the full `bookDetails` object from a search result.
+
+This tool accepts results from `search_books` (Z-Library) and from `search_multi_source` (Library Genesis or Anna's Archive). The server reads the `source` field to select the download path. A Library Genesis download needs no Z-Library account. Optionally process the document for RAG after download. When processing is enabled, the response stays additive: `processed_file_path` remains the body-text anchor and sibling bundle paths are returned when available.
 
 **Parameters:**
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| bookDetails | object | Yes | -- | The full book details object obtained from `search_books` |
+| bookDetails | object | Yes | -- | The full book object from `search_books` or `search_multi_source` |
 | outputDir | string | No | `"./downloads"` | Directory to save the file to |
 | process_for_rag | boolean | No | -- | Whether to process the document content for RAG after download |
 | processed_output_format | string | No | -- | Desired output format for RAG processing (e.g., `"text"`, `"markdown"`) |


### PR DESCRIPTION
v1.4.0 made LibGen downloadable, but the docs still described a Z-Library-only server. Several statements were untrue as written.

## Claims corrected

| Where | Said | Reality |
|---|---|---|
| README Quick Start | Credentials shown as required | Server starts without them; LibGen needs none |
| `docs/api.md` line 1 | "All tools require valid Z-Library credentials" | Two tools do not |
| Tool table | `search_multi_source` — "Parallel search across multiple sources" | Routes to one source with fallback. It does not search in parallel |
| API returns | Promises `download_url` | Empty for LibGen: links resolve on demand and expire in under 2.5h |
| `download_book_to_file` | Takes `search_books` results | Also takes `search_multi_source` results, routing on `source` |
| Architecture diagram | Z-Library as the only external source | Three sources via `SourceRouter` |
| Badges, links, GHCR path | `loganrooks` | `rookslog` after the rename |
| Docker tags | `1.3` / `1.3.2` | `1.4` / `1.4.0` |

## Added: a Sources section

One table covering account requirement, daily limit, search, and download per source, then a subsection each.

It documents what a user actually needs to know and could not previously find:

- LibGen needs no account and has no daily limit — the answer to "I hit the Z-Library limit"
- Mirror failover, and **why failover is driven by bytes served rather than key resolution** (a mirror can return a valid key while its CDN node is dead)
- Link expiry under 2.5 hours, and that an expired link returns a web page rather than an error
- Anna's keyless search returns md5 and URL only
- Anna's keyless downloads are not supported, with the reason stated plainly, and the browser hand-off as the alternative
- A warning that `ANNAS_SECRET_KEY` travels as a URL parameter, so hosts must be verified before being added to the allowlist

## Writing standard

New prose follows ASD-STE100 (Simplified Technical English): active voice with a named actor, one idea per sentence, a 25-word limit, no semicolons, no contractions, and one term per item. Verified mechanically over the new section — 0 sentences above 25 words, 0 semicolons, 0 contractions.

Existing prose is left as it was, so the diff stays reviewable.

## Also

`CLAUDE.md` "Current Development" moved to v1.4.0, recording the account rename's effect on npm provenance validation and the Git LFS coverage gap (#85).

`validate-readme-tools.sh` passes; 1052 Python tests pass; build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the documentation for v1.4.0 support for Library Genesis downloads. It corrects stale information about credentials, search behavior, download URLs, supported inputs, repository ownership, architecture, and Docker tags.

### Main changes

- Documents credential-free startup and Library Genesis downloads.
- Documents source behavior for Library Genesis, Z-Library, and Anna’s Archive.
- Adds details about account requirements, daily limits, mirror failover, expiring links, source health checks, and `ANNAS_SECRET_KEY`.
- Updates `search_multi_source` and `download_book_to_file` contracts:
  - `search_multi_source` can return Library Genesis and Anna’s Archive results without a Z-Library account.
  - Results do not guarantee a populated `download_url`.
  - Library Genesis download URLs resolve during download.
  - `download_book_to_file.bookDetails` accepts complete results from `search_books` and `search_multi_source`.
- Updates repository links, clone commands, Docker instructions, GHCR namespace, and version range.
- Updates `CLAUDE.md` with v1.4.0 details, npm provenance effects, and the Git LFS limitation for real-PDF tests.

### Verification and review focus

Validation passed with 1,052 Python tests, the README tool validator, and a clean build.

This PR changes documentation and declared tool contracts only. It adds no implementation code or corresponding runtime tests. Reviewers should verify that the documented source behavior, download resolution rules, Docker tags, repository ownership, and configuration requirements match the current implementation and release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->