### PR TITLE
chore: sweep remaining loganrooks references after the account rename

### DIFF
--- a/.claude/VERSION_CONTROL.md
+++ b/.claude/VERSION_CONTROL.md
@@ -604,7 +604,7 @@ gh workflow run ci.yml
 gh workflow view
 
 # Repository operations
-gh repo clone loganrooks/zlibrary-mcp
+gh repo clone rookslog/zlibrary-mcp
 gh repo view --web  # Open in browser
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,11 +315,12 @@ source is privileged").
 - BUG-X/FIX comments cleaned from production code
 - Debug print statements converted to proper logging
 
-[Unreleased]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.2...HEAD
-[1.3.2]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.1...v1.3.2
-[1.3.1]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.2.1...v1.3.0
-[1.2.1]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.2.0...v1.2.1
-[1.2.0]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.1...v1.2.0
-[1.1.0]: https://github.com/loganrooks/zlibrary-mcp/compare/v1.0...v1.1
-[1.0.0]: https://github.com/loganrooks/zlibrary-mcp/releases/tag/v1.0
+[Unreleased]: https://github.com/rookslog/zlibrary-mcp/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/rookslog/zlibrary-mcp/compare/v1.3.2...v1.4.0
+[1.3.2]: https://github.com/rookslog/zlibrary-mcp/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/rookslog/zlibrary-mcp/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/rookslog/zlibrary-mcp/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/rookslog/zlibrary-mcp/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/rookslog/zlibrary-mcp/compare/v1.1...v1.2.0
+[1.1.0]: https://github.com/rookslog/zlibrary-mcp/compare/v1.0...v1.1
+[1.0.0]: https://github.com/rookslog/zlibrary-mcp/releases/tag/v1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,7 @@ keyless *search* still works. See the v1.4 map (issue #75) for the full disposit
 
 npm publishing authenticates via OIDC trusted publishing (no `NPM_TOKEN` secret; the
 trusted publisher is bound to `publish.yml`). Note the account rename
-`loganrooks` → `rookslog`: provenance validation cross-checks `package.json`
+`rookslog` → `rookslog`: provenance validation cross-checks `package.json`
 `repository.url` against the OIDC claim, so both the trusted publisher binding and
 that URL must name the current owner.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 ### Clone and Setup
 
 ```bash
-git clone https://github.com/loganrooks/zlibrary-mcp.git
+git clone https://github.com/rookslog/zlibrary-mcp.git
 cd zlibrary-mcp
 
 # Hydrate LFS-tracked test fixtures (no `git lfs install` needed -- see Prerequisites)
@@ -251,7 +251,7 @@ For detailed patterns, see the project's internal documentation in `.claude/PATT
 
 ## Reporting Issues
 
-Use [GitHub Issues](https://github.com/loganrooks/zlibrary-mcp/issues) to report bugs or request features.
+Use [GitHub Issues](https://github.com/rookslog/zlibrary-mcp/issues) to report bugs or request features.
 
 Include:
 - Node.js version (`node --version`)

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -4,7 +4,7 @@
 
 > **Contributing?** This file is the maintainer's internal issue ledger (history,
 > evidence, resolutions). For anything you want to report or pick up, use
-> [GitHub Issues](https://github.com/loganrooks/zlibrary-mcp/issues) — issues
+> [GitHub Issues](https://github.com/rookslog/zlibrary-mcp/issues) — issues
 > labeled `good first issue` and `help wanted` are curated entry points.
 
 ## Executive Summary

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Only the latest release line receives fixes. Check [releases](https://github.com/loganrooks/zlibrary-mcp/releases)
+Only the latest release line receives fixes. Check [releases](https://github.com/rookslog/zlibrary-mcp/releases)
 for the current version.
 
 ## Reporting a vulnerability
 
 Report privately through
-[GitHub Security Advisories](https://github.com/loganrooks/zlibrary-mcp/security/advisories/new)
+[GitHub Security Advisories](https://github.com/rookslog/zlibrary-mcp/security/advisories/new)
 rather than opening a public issue. Include reproduction steps and the version
 you tested. Expect an initial response within a week.
 

--- a/claudedocs/README.md
+++ b/claudedocs/README.md
@@ -11,7 +11,7 @@ is a point-in-time record (see the documentation-guidelines table in
   — the live health assessment and forward roadmap (the "current plan" document)
 - [architecture/phase-20-21-review-2026-07-24.md](architecture/phase-20-21-review-2026-07-24.md)
   — acceptance criteria for the pending RAG quality-scoring work
-  (referenced by issue [#39](https://github.com/loganrooks/zlibrary-mcp/issues/39))
+  (referenced by issue [#39](https://github.com/rookslog/zlibrary-mcp/issues/39))
 - [milestone-history.md](milestone-history.md) — condensed record of all
   development milestones from v1.0 through v1.3
 - [session-notes/2025-10-28-footnote-continuation-state-machine.md](session-notes/2025-10-28-footnote-continuation-state-machine.md)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -59,7 +59,7 @@ npm link zlibrary-mcp
 
 #### 3. **Clone and Build**
 ```bash
-git clone https://github.com/loganrooks/zlibrary-mcp.git
+git clone https://github.com/rookslog/zlibrary-mcp.git
 cd zlibrary-mcp
 npm install
 npm run build

--- a/docs/MIGRATION_V2.md
+++ b/docs/MIGRATION_V2.md
@@ -295,7 +295,7 @@ If you encounter issues:
 git checkout v1.9.9  # Last v1.x version
 
 # Option 2: Report issue
-# GitHub: https://github.com/loganrooks/zlibrary-mcp/issues
+# GitHub: https://github.com/rookslog/zlibrary-mcp/issues
 ```
 
 ---
@@ -338,7 +338,7 @@ rm -rf ~/.cache/zlibrary-mcp/
 - [UV Migration Plan](UV_MIGRATION_PLAN.md)
 - [Architecture Analysis](ARCHITECTURE_ANALYSIS.md)
 
-**Issues**: https://github.com/loganrooks/zlibrary-mcp/issues
+**Issues**: https://github.com/rookslog/zlibrary-mcp/issues
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -214,7 +214,7 @@ uv run pytest -m "not slow and not integration and not performance"  # fast Pyth
 ## Getting Help
 
 1. Run `npm run doctor` and `npm run validate` and capture the output.
-2. Check existing issues: https://github.com/loganrooks/zlibrary-mcp/issues
+2. Check existing issues: https://github.com/rookslog/zlibrary-mcp/issues
 3. Open a bug report — the issue template asks for the doctor output and your
    OS/client; scrub any credentials from pasted stderr logs first.
 

--- a/docs/UV_MIGRATION_PLAN.md
+++ b/docs/UV_MIGRATION_PLAN.md
@@ -136,7 +136,7 @@ description = "Z-Library MCP server for AI assistants"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [
-    { name = "loganrooks", email = "loganrooks@users.noreply.github.com" }
+    { name = "rookslog", email = "rookslog@users.noreply.github.com" }
 ]
 keywords = ["mcp", "zlibrary", "ai", "roocode", "cline"]
 license = { text = "MIT" }
@@ -364,7 +364,7 @@ fi
 
 2. **Clone and setup**:
    ```bash
-   git clone https://github.com/loganrooks/zlibrary-mcp.git
+   git clone https://github.com/rookslog/zlibrary-mcp.git
    cd zlibrary-mcp
    ```
 

--- a/docs/adr/ADR-004-Python-Bridge-Path-Resolution.md
+++ b/docs/adr/ADR-004-Python-Bridge-Path-Resolution.md
@@ -242,7 +242,7 @@ Tested on:
 
 ---
 
-**Author**: Claude Code (with loganrooks)
+**Author**: Claude Code (with rookslog)
 **Date**: 2025-10-12
 **Supersedes**: None
 **Superseded by**: None (current)

--- a/docs/deployment/DEPLOYMENT_CHECKLIST.md
+++ b/docs/deployment/DEPLOYMENT_CHECKLIST.md
@@ -89,7 +89,7 @@
 ### 1. Clone Repository
 
 ```bash
-git clone https://github.com/loganrooks/zlibrary-mcp.git
+git clone https://github.com/rookslog/zlibrary-mcp.git
 cd zlibrary-mcp
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Z-Library MCP server for AI assistants"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
-    { name = "loganrooks" }
+    { name = "rookslog" }
 ]
 keywords = ["mcp", "zlibrary", "ai", "books", "library"]
 license = { text = "MIT" }
@@ -60,9 +60,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/loganrooks/zlibrary-mcp"
-Repository = "https://github.com/loganrooks/zlibrary-mcp.git"
-Issues = "https://github.com/loganrooks/zlibrary-mcp/issues"
+Homepage = "https://github.com/rookslog/zlibrary-mcp"
+Repository = "https://github.com/rookslog/zlibrary-mcp.git"
+Issues = "https://github.com/rookslog/zlibrary-mcp/issues"
 
 [build-system]
 requires = ["setuptools>=83.0.0", "wheel"]


### PR DESCRIPTION
Finishes what #89 started.

## Why this is not cosmetic

Two publishes failed today because of this staleness:

| Attempt | Error | Cause |
|---|---|---|
| 1st | `E404` | npm trusted publisher bound to the old owner |
| 2nd | `E422` | `package.json` `repository.url` did not match the OIDC provenance claim |

GitHub redirects renamed URLs, so nothing looked broken — and that redirect is exactly why the publish-blocking copies survived unnoticed until a release forced the issue.

## Functional

`pyproject.toml` — `authors` and all three `project.urls`. The only remaining reference that software reads rather than a human.

## Navigational

`CONTRIBUTING.md`, `SECURITY.md`, `ISSUES.md`, `.claude/VERSION_CONTROL.md`, `claudedocs/README.md`, `docs/DEPLOYMENT.md`, `docs/TROUBLESHOOTING.md`, `docs/MIGRATION_V2.md`, `docs/UV_MIGRATION_PLAN.md`, `docs/adr/ADR-004`, `docs/deployment/DEPLOYMENT_CHECKLIST.md`, and the CHANGELOG version-compare block.

Note `SECURITY.md` pointed reporters at a security-advisory URL under the old owner — worth having correct.

## Also fixed

The CHANGELOG link block had no `[1.4.0]` entry and `[Unreleased]` still compared from `v1.3.2`. My oversight when adding the 1.4.0 section in #88.

## Deliberately untouched

`LICENSE` still reads `Copyright (c) 2025 loganrooks`. That is a legal attribution which was accurate when written, and changing a copyright holder name is a maintainer decision rather than part of a mechanical sweep. Say the word if you want it updated.

`uv sync` resolves; `validate-readme-tools.sh` passes.