### PR TITLE
chore(deps): remove unused ts-jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,18 +1,10 @@
-// Simplified jest.config.js for ESM troubleshooting
-import { createDefaultEsmPreset } from 'ts-jest';
-
-const preset = createDefaultEsmPreset();
-
 export default {
-  // Apply the ts-jest ESM preset
-  ...preset,
-
   // Basic Node environment
   testEnvironment: 'node',
 
   // Match test files in __tests__
   testMatch: [
-    '**/__tests__/**/*.test.js' // Assuming tests remain JS files
+    '**/__tests__/**/*.test.js', // Assuming tests remain JS files
   ],
 
   // Ignore node_modules and dist (except for moduleNameMapper resolution)
@@ -20,13 +12,11 @@ export default {
     '/node_modules/',
     '/dist/', // Ignore compiled output for test discovery
     '/__tests__/e2e/', // E2E tests require running Docker container
-    '/__tests__/integration/' // Integration tests require live services
+    '/__tests__/integration/', // Integration tests require live services
   ],
 
   // Crucial: Map imports from __tests__ to compiled dist/ files
   moduleNameMapper: {
-    // Add preset's moduleNameMapper first
-    ...preset.moduleNameMapper,
     // Map relative paths from __tests__ to the compiled files in dist/
     // Match imports like '../lib/module.js' from '__tests__/...'
     '^../lib/(.*)\\.js$': '<rootDir>/dist/lib/$1.js',
@@ -46,11 +36,7 @@ export default {
   collectCoverage: true,
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'json-summary'],
-  collectCoverageFrom: [
-    'dist/**/*.js',
-    '!dist/**/*.test.js',
-    '!dist/**/*.d.ts',
-  ],
+  collectCoverageFrom: ['dist/**/*.js', '!dist/**/*.test.js', '!dist/**/*.d.ts'],
   // Ratcheted to just under the actual measurement (85.08 / 79.59 / 77.89 / 87.37
   // at 165 tests) so the gate catches a real regression. The previous floors were
   // set against a 93-test suite and had drifted ~20 points below reality, which

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "prettier": "^3.9.6",
         "sinon": "^22.1.0",
         "supertest": "^7.2.2",
-        "ts-jest": "^29.4.12",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.65.0"
       },
@@ -2614,18 +2613,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -4070,28 +4057,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5293,12 +5258,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5337,12 +5296,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -5466,16 +5419,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -5530,13 +5473,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nock": {
       "version": "14.0.17",
@@ -6735,85 +6671,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-jest": {
-      "version": "29.4.12",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
-      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs-logger": "^0.2.6",
-        "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.9",
-        "json5": "^2.2.3",
-        "lodash.memoize": "^4.1.2",
-        "make-error": "^1.3.6",
-        "semver": "^7.8.5",
-        "type-fest": "^4.41.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0 || ^30.0.0",
-        "@jest/types": "^29.0.0 || ^30.0.0",
-        "babel-jest": "^29.0.0 || ^30.0.0",
-        "jest": "^29.0.0 || ^30.0.0",
-        "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <7"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/transform": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jest-util": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ts-jest/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6923,20 +6780,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -7089,13 +6932,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "prettier": "^3.9.6",
     "sinon": "^22.1.0",
     "supertest": "^7.2.2",
-    "ts-jest": "^29.4.12",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.65.0"
   }


### PR DESCRIPTION
## What this changes

Removes the unused `ts-jest` preset from `jest.config.js` and drops `ts-jest` from the development dependency graph. Jest continues to run the compiled JavaScript in `dist/` with transformations explicitly disabled.

## Why

The preset's transform was already overridden by `transform: {}`, its ESM extension list does not apply to the JavaScript-only test suite, and it provides no module-name mappings. Keeping it added 11 packages and an unnecessary TypeScript peer-version constraint.

Closes #93.

## How it was verified

- [x] Clean `npm ci` (512 packages, down from 523)
- [x] `npm run build`
- [x] `npm test -- --runInBand` — 178/178 tests passed
- [x] `uv run pytest -m "not slow and not integration and not performance"` — 1047 passed, 8 skipped, 7 xfailed
- [x] `npm pack --dry-run`
- [x] `npm ls ts-jest --all` — empty
- [ ] Tests added or updated for the change — existing full-suite coverage directly exercises the Jest configuration

## Notes for reviewers

No production source or runtime behavior changes. The lockfile removes `ts-jest` and its now-unreferenced transitive dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Purpose

Remove the unused `ts-jest` preset and dependency. This reduces the development dependency graph and removes its TypeScript peer-version constraint.

## Changes

- Removed the `ts-jest` ESM preset from `jest.config.js`.
- Kept Jest configured to run compiled JavaScript from `dist/`.
- Kept transformations disabled with `transform: {}`.
- Removed `ts-jest` from `package.json`.
- No production source or runtime behavior changed.
- No public or exported entities changed.

## Verification

- Build succeeded.
- All 178 Jest tests passed.
- Python tests passed.
- Package dry-run succeeded.
- Clean installation succeeded.
- Confirmed that `ts-jest` is no longer installed.

## Review considerations

The main risk is Jest configuration compatibility after removing the preset. The existing build and test verification covers the JavaScript-only test workflow. No new production code was added, so no new production type checks or runtime tests are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->