### PR TITLE
fix(annas): honour explicit source="annas" and extract full metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,13 @@ Z-Library applies a daily download limit of approximately 10 books. Call
 Anna's Archive search needs no account. Call `search_multi_source` with
 `source: "annas"`.
 
-**Note:** keyless search returns the MD5 hash and the record URL only. It does not return
-the title, the author, or the file format.
+Search without a key returns the title, the author, the year, the file format, and the
+file size. It also returns `also_available_on`, which lists the other sources that hold
+the same file.
+
+**Note:** `also_available_on` is a hint, not a guarantee. Anna's Archive reports it, and
+the file can leave the other source later. Use it to prefer a source that has no daily
+limit. Do not depend on it.
 
 Anna's Archive downloads need a membership API key in `ANNAS_SECRET_KEY`. Without a key,
 the server cannot download from Anna's Archive. Anna's Archive protects its free download

--- a/__tests__/python/test_annas_adapter.py
+++ b/__tests__/python/test_annas_adapter.py
@@ -7,6 +7,7 @@ Tests cover:
 4. Error handling for invalid inputs
 """
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -538,25 +539,55 @@ class TestAnnasMetadataExtraction:
 
     @pytest.fixture
     def results(self):
+        """Drive the real AnnasArchiveAdapter.search() against the fixture.
+
+        Deliberately NOT a reimplementation of search()'s filtering loop. An
+        earlier version of this fixture called _build_result directly, which
+        meant reverting the dedupe fix left these tests green — the headline
+        regression was not pinned at all. The whole point is that search() is
+        the thing under test.
+        """
         from lib.sources.annas import AnnasArchiveAdapter
         from lib.sources.config import SourceConfig
 
         adapter = AnnasArchiveAdapter(
             SourceConfig(annas_base_url="https://annas-archive.gl")
         )
-        soup = BeautifulSoup(self.FIXTURE.read_text(), "html.parser")
 
-        out, seen = [], set()
-        for link in soup.select("a[href^='/md5/']"):
-            title = link.get_text(strip=True)
-            if not title:
-                continue
-            md5 = link.get("href", "").split("/")[-1]
-            if not md5 or md5 in seen:
-                continue
-            seen.add(md5)
-            out.append(adapter._build_result(link, md5, title))
-        return out
+        mock_response = MagicMock()
+        mock_response.text = self.FIXTURE.read_text()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(adapter, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_get_client.return_value = mock_client
+            return (
+                asyncio.get_event_loop_policy()
+                .new_event_loop()
+                .run_until_complete(adapter.search("hegel"))
+            )
+
+    def test_fixture_reproduces_the_two_anchor_markup(self):
+        """Guard the guard.
+
+        These tests are only meaningful if the fixture contains the cover +
+        title anchor PAIR that caused the bug. A fixture holding just the title
+        anchor passes against the broken implementation too, so assert the
+        precondition rather than trusting it.
+        """
+        soup = BeautifulSoup(self.FIXTURE.read_text(), "html.parser")
+        groups = {}
+        for anchor in soup.select("a[href^='/md5/']"):
+            groups.setdefault(anchor.get("href", "").split("/")[-1], []).append(anchor)
+
+        assert len(groups) == 4
+        for md5, anchors in groups.items():
+            assert len(anchors) == 2, f"{md5} must render cover + title"
+            texts = sorted(len(a.get_text(strip=True)) for a in anchors)
+            assert texts[0] == 0, f"{md5} must have an empty-text cover anchor"
+            assert texts[1] > 0, f"{md5} must have a text-bearing title anchor"
 
     def test_titles_are_extracted_not_unknown(self, results):
         """The headline bug: every keyless result came back titled 'Unknown'."""
@@ -630,3 +661,39 @@ class TestAnnasMetadataExtraction:
         for r in results:
             for field in (r.author, r.year, r.extension, r.size, r.download_url):
                 assert isinstance(field, str)
+
+    def test_pre_1500_years_are_preserved(self):
+        """Incunabula and early-modern imprints carry dates before 1500.
+
+        A 15xx-and-later floor silently dropped a year that was present
+        upstream. This is a scholarly-text tool; those dates are real.
+        """
+        from lib.sources.annas import _parse_metadata_strip
+
+        parsed = _parse_metadata_strip("Latin [la] · PDF · 12.0MB · 1492 · 📘 Book")
+        assert parsed["year"] == "1492"
+        assert parsed["extension"] == "pdf"
+
+    def test_strip_without_size_is_still_parsed(self):
+        """Every segment is optional — including the one used to find the strip.
+
+        Recognising the strip by its size segment discarded the entire strip for
+        records that omit size, losing language, extension, year and content
+        type that were all present.
+        """
+        from bs4 import BeautifulSoup
+
+        from lib.sources.annas import _find_metadata_strip, _parse_metadata_strip
+
+        card = BeautifulSoup(
+            "<div><div>English [en] · PDF · 2008 · 📕 Book (fiction)</div></div>",
+            "html.parser",
+        )
+        strip = _find_metadata_strip(card)
+        assert strip is not None, "strip must be found without a size segment"
+
+        parsed = _parse_metadata_strip(strip)
+        assert parsed["language"] == "en"
+        assert parsed["extension"] == "pdf"
+        assert parsed["year"] == "2008"
+        assert "size" not in parsed

--- a/__tests__/python/test_annas_adapter.py
+++ b/__tests__/python/test_annas_adapter.py
@@ -7,8 +7,13 @@ Tests cover:
 4. Error handling for invalid inputs
 """
 
+from pathlib import Path
+
 import pytest
+from bs4 import BeautifulSoup
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from lib.sources.models import SourceType
 
 pytestmark = pytest.mark.unit
 
@@ -512,3 +517,116 @@ class TestSecretKeyHostAllowlist:
             results = await adapter.search("python")
 
         assert len(results) == 3
+
+
+class TestAnnasMetadataExtraction:
+    """Extraction of full metadata from real Anna's search HTML (#78).
+
+    These run against `test_files/annas/search_results.html`, trimmed from a
+    live capture rather than hand-written, because the bug being fixed was
+    caused by real markup that a hand-written mock did not reproduce: each
+    record renders two /md5/ anchors, and deduping by first kept the cover
+    image (empty text) over the title.
+    """
+
+    FIXTURE = (
+        Path(__file__).resolve().parents[2]
+        / "test_files"
+        / "annas"
+        / "search_results.html"
+    )
+
+    @pytest.fixture
+    def results(self):
+        from lib.sources.annas import AnnasArchiveAdapter
+        from lib.sources.config import SourceConfig
+
+        adapter = AnnasArchiveAdapter(
+            SourceConfig(annas_base_url="https://annas-archive.gl")
+        )
+        soup = BeautifulSoup(self.FIXTURE.read_text(), "html.parser")
+
+        out, seen = [], set()
+        for link in soup.select("a[href^='/md5/']"):
+            title = link.get_text(strip=True)
+            if not title:
+                continue
+            md5 = link.get("href", "").split("/")[-1]
+            if not md5 or md5 in seen:
+                continue
+            seen.add(md5)
+            out.append(adapter._build_result(link, md5, title))
+        return out
+
+    def test_titles_are_extracted_not_unknown(self, results):
+        """The headline bug: every keyless result came back titled 'Unknown'."""
+        assert len(results) == 4
+        assert all(r.title and r.title != "Unknown" for r in results)
+        assert results[0].title == "Phenomenology of spirit"
+
+    def test_full_metadata_is_extracted(self, results):
+        """Option E: author, year, extension and size, not titles alone."""
+        first = results[0]
+        assert first.author == "Georg Wilhelm Friedrich Hegel"
+        assert first.year == "1977"
+        assert first.extension == "azw3"
+        assert first.size == "0.6MB"
+
+    def test_missing_year_does_not_corrupt_extension(self, results):
+        """The regression this parser exists to prevent.
+
+        Year is absent from ~9% of records. Parsing the metadata strip by
+        position would shift the next segment into the year slot and the
+        extension into the size slot. Record 2 has no year; every other field
+        must still land correctly.
+        """
+        no_year = results[1]
+        assert no_year.year == ""
+        assert no_year.extension == "pdf"
+        assert no_year.size == "6.7MB"
+        assert no_year.title == "Phenomenology of Spirit"
+
+    def test_year_is_never_mistaken_for_an_extension(self):
+        """A bare [A-Z0-9]{2,5} extension pattern also matches a 4-digit year."""
+        from lib.sources.annas import _parse_metadata_strip
+
+        parsed = _parse_metadata_strip(
+            "English [en] · PDF · 5.6MB · 2008 · 📕 Book (fiction)"
+        )
+        assert parsed["year"] == "2008"
+        assert parsed["extension"] == "pdf"
+        assert parsed["size"] == "5.6MB"
+        assert parsed["language"] == "en"
+
+    def test_segments_are_order_independent(self):
+        """Order is not guaranteed, so parsing must not depend on it."""
+        from lib.sources.annas import _parse_metadata_strip
+
+        forward = _parse_metadata_strip("English [en] · EPUB · 1.2MB · 1999")
+        shuffled = _parse_metadata_strip("1999 · 1.2MB · EPUB · English [en]")
+        assert forward == shuffled
+
+    def test_upstream_provenance_is_surfaced(self, results):
+        """Anna's names which other sources hold the same file (#78).
+
+        Verified to mean 'retrievable', not merely 'ingested from': 3/3 records
+        marked /lgli resolved on LibGen, 0/2 unmarked did.
+        """
+        assert results[0].extra["also_available_on"] == ["lgli", "zlib"]
+        assert "lgli" in results[2].extra["also_available_on"]
+
+    def test_provenance_is_surfaced_but_not_acted_on(self, results):
+        """Adapters expose provenance; they must not rank or dedupe on it.
+
+        Reporting is #96 and cross-source dedup is #52. Source-comparison logic
+        inside one source's adapter is what invariant 4 forbids.
+        """
+        for r in results:
+            assert r.source == SourceType.ANNAS_ARCHIVE
+            assert r.download_url == ""
+
+    def test_absent_fields_are_empty_strings(self, results):
+        """Matches UnifiedBookResult defaults and LibGen's behaviour."""
+        for r in results:
+            for field in (r.author, r.year, r.extension, r.size, r.download_url):
+                assert isinstance(field, str)

--- a/__tests__/python/test_source_router.py
+++ b/__tests__/python/test_source_router.py
@@ -357,9 +357,79 @@ class TestRouterLifecycle:
         assert libgen is not None
         assert router._libgen is not None
 
-    def test_no_annas_adapter_without_key(self, config_without_annas):
-        """Should not create Anna's adapter without API key."""
+    def test_annas_adapter_is_built_without_key(self, config_without_annas):
+        """Anna's adapter is built with or without a key (#74).
+
+        This previously asserted the adapter was None without a key. That
+        encoded the bug: Anna's search is credential-free HTML scraping, so
+        gating construction on the key made an explicit source="annas" fall
+        through to LibGen silently. The key belongs on get_download_url, which
+        enforces it itself.
+        """
         router = SourceRouter(config_without_annas)
 
         annas = router._get_annas()
-        assert annas is None
+        assert annas is not None
+        assert router._annas is annas  # and is cached
+
+    @pytest.mark.asyncio
+    async def test_explicit_annas_is_not_silently_swapped_for_libgen(
+        self, config_without_annas
+    ):
+        """An explicit source="annas" must query Anna's, not LibGen (#74).
+
+        The user-visible bug: search_multi_source(source="annas") returned
+        LibGen results with nothing indicating the requested source was never
+        contacted.
+        """
+        router = SourceRouter(config_without_annas)
+
+        annas_hit = False
+
+        async def fake_annas_search(query, **kwargs):
+            nonlocal annas_hit
+            annas_hit = True
+            return [
+                UnifiedBookResult(
+                    md5="deadbeef", title="From Anna's", source=SourceType.ANNAS_ARCHIVE
+                )
+            ]
+
+        async def fail_libgen_search(query, **kwargs):
+            raise AssertionError("LibGen was queried for an explicit source='annas'")
+
+        router._get_annas().search = fake_annas_search
+        router._get_libgen().search = fail_libgen_search
+
+        results = await router.search("hegel", source="annas")
+
+        assert annas_hit
+        assert len(results) == 1
+        assert results[0].source == SourceType.ANNAS_ARCHIVE
+
+    @pytest.mark.asyncio
+    async def test_auto_still_prefers_libgen_without_key(self, config_without_annas):
+        """'auto' stays LibGen-first without a key — deliberately unchanged.
+
+        Fixing the explicit-source gate must not quietly reroute 'auto'. LibGen
+        returns a resolvable download link; an Anna's result without a key still
+        needs a route the caller may not have.
+        """
+        router = SourceRouter(config_without_annas)
+
+        async def fake_libgen_search(query, **kwargs):
+            return [
+                UnifiedBookResult(
+                    md5="cafe", title="From LibGen", source=SourceType.LIBGEN
+                )
+            ]
+
+        async def fail_annas_search(query, **kwargs):
+            raise AssertionError("Anna's was queried for source='auto' with no key")
+
+        router._get_libgen().search = fake_libgen_search
+        router._get_annas().search = fail_annas_search
+
+        results = await router.search("hegel", source="auto")
+
+        assert results[0].source == SourceType.LIBGEN

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -28,7 +28,13 @@ from .models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
 # therefore matched by pattern, never by index: positional parsing silently
 # shifts year into extension on the records that omit it.
 _SIZE_RE = re.compile(r"^\d+(?:\.\d+)?\s*[KMGT]B$", re.IGNORECASE)
-_YEAR_RE = re.compile(r"^(?:1[5-9]\d{2}|20\d{2})$")
+# Any plausible four-digit year, deliberately including pre-1500 ones. This is a
+# scholarly-text tool: incunabula and early-modern imprints carry dates like
+# 1492, and a 15xx-and-later floor silently dropped a year that was present
+# upstream. Widening is safe because size carries a unit suffix, content type
+# carries parentheses, and extension must start with a letter — so no other
+# segment can be mistaken for a bare four-digit number.
+_YEAR_RE = re.compile(r"^(?:1[0-9]\d{2}|20\d{2})$")
 # Extension must START with a letter. A bare "[A-Z0-9]{2,5}" also matches a
 # four-digit year, which is exactly the corruption this parser exists to avoid.
 _EXT_RE = re.compile(r"^[A-Z][A-Z0-9]{1,6}$")
@@ -70,12 +76,19 @@ def _find_metadata_strip(card: Tag) -> Optional[str]:
 
     Identified by content rather than by class name: Anna's uses generated
     Tailwind classes that change between deploys, whereas a "·"-separated run
-    containing a file size is a stable shape.
+    of recognisable segments is a stable shape.
+
+    Recognition must not hinge on any single segment. Requiring a size segment
+    discarded the whole strip for records that omit it — losing the language,
+    extension, year and content type that were present — which contradicted the
+    parser's own every-segment-is-optional contract.
     """
     for text in card.find_all(string=lambda t: t and "·" in t):
         candidate = text.strip()
-        if any(_SIZE_RE.match(part.strip()) for part in candidate.split("·")):
-            return candidate
+        for part in candidate.split("·"):
+            seg = part.replace("\U0001f680", "").strip()
+            if _SIZE_RE.match(seg) or _EXT_RE.match(seg) or _LANG_RE.search(seg):
+                return candidate
     return None
 
 

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -9,15 +9,74 @@ Key decisions:
 - ANNAS-SCRAPE-SEARCH: Search via HTML scraping (no search API exists)
 """
 
-from typing import List, Optional
+import re
+from typing import Dict, List, Optional
 from urllib.parse import quote, urlsplit
 
 import httpx
 from bs4 import BeautifulSoup
+from bs4.element import Tag
 
 from .base import SourceAdapter
 from .config import ANNAS_TRUSTED_HOSTS, SourceConfig
 from .models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
+
+# Each Anna's result renders a metadata strip of "·"-separated segments, e.g.
+#   English [en] · PDF · 5.6MB · 2008 · 📕 Book (fiction) · 🚀/lgli/nexusstc/zlib
+# Segments are OPTIONAL and ORDER IS NOT GUARANTEED — year is absent from about
+# 9% of results (measured over 100 results across two queries). The strip is
+# therefore matched by pattern, never by index: positional parsing silently
+# shifts year into extension on the records that omit it.
+_SIZE_RE = re.compile(r"^\d+(?:\.\d+)?\s*[KMGT]B$", re.IGNORECASE)
+_YEAR_RE = re.compile(r"^(?:1[5-9]\d{2}|20\d{2})$")
+# Extension must START with a letter. A bare "[A-Z0-9]{2,5}" also matches a
+# four-digit year, which is exactly the corruption this parser exists to avoid.
+_EXT_RE = re.compile(r"^[A-Z][A-Z0-9]{1,6}$")
+_LANG_RE = re.compile(r"\[([a-z]{2,3})\]")
+
+
+def _parse_metadata_strip(strip: str) -> Dict[str, str]:
+    """Pattern-match the '·'-separated metadata strip on an Anna's result.
+
+    Args:
+        strip: Raw strip text
+
+    Returns:
+        Dict with any of: language, extension, size, year, content_type,
+        provenance. Absent segments are simply omitted.
+    """
+    parsed: Dict[str, str] = {}
+    for raw in strip.split("·"):
+        seg = raw.replace("\U0001f680", "").strip()  # 🚀 prefixes provenance
+        if not seg:
+            continue
+        if "year" not in parsed and _YEAR_RE.match(seg):
+            parsed["year"] = seg
+        elif "size" not in parsed and _SIZE_RE.match(seg):
+            parsed["size"] = seg.replace(" ", "")
+        elif "language" not in parsed and _LANG_RE.search(seg):
+            parsed["language"] = _LANG_RE.search(seg).group(1)
+        elif "extension" not in parsed and _EXT_RE.match(seg):
+            parsed["extension"] = seg.lower()
+        elif "content_type" not in parsed and "(" in seg:
+            parsed["content_type"] = seg
+        elif "provenance" not in parsed and ("/" in seg or seg in ("zlib", "upload")):
+            parsed["provenance"] = seg.strip("/")
+    return parsed
+
+
+def _find_metadata_strip(card: Tag) -> Optional[str]:
+    """Locate the metadata strip within a result card.
+
+    Identified by content rather than by class name: Anna's uses generated
+    Tailwind classes that change between deploys, whereas a "·"-separated run
+    containing a file size is a stable shape.
+    """
+    for text in card.find_all(string=lambda t: t and "·" in t):
+        candidate = text.strip()
+        if any(_SIZE_RE.match(part.strip()) for part in candidate.split("·")):
+            return candidate
+    return None
 
 
 class QuotaExhaustedError(Exception):
@@ -88,27 +147,87 @@ class AnnasArchiveAdapter(SourceAdapter):
         results = []
         seen = set()
 
+        # Each record renders TWO /md5/ anchors: a cover image with empty text,
+        # then the title. Dedupe-by-first kept the cover, so every result came
+        # back titled "Unknown" (#78). Select only text-bearing anchors — measured
+        # over 100 records on two unrelated queries, every md5 group has exactly
+        # two anchors and exactly one of them bears text.
         for link in soup.select("a[href^='/md5/']"):
-            href = link.get("href", "")
-            md5 = href.split("/")[-1]
-
-            # Skip empty or duplicate MD5s
-            if not md5 or md5 in seen:
+            title = link.get_text(strip=True)
+            if not title:
                 continue
 
+            md5 = link.get("href", "").split("/")[-1]
+            if not md5 or md5 in seen:
+                continue
             seen.add(md5)
-            title = link.get_text(strip=True) or "Unknown"
 
-            results.append(
-                UnifiedBookResult(
-                    md5=md5,
-                    title=title,
-                    source=SourceType.ANNAS_ARCHIVE,
-                    extra={"url": f"{self.base_url}/md5/{md5}"},
-                )
-            )
+            results.append(self._build_result(link, md5, title))
 
         return results
+
+    def _build_result(self, link: Tag, md5: str, title: str) -> UnifiedBookResult:
+        """Assemble one search result from its title anchor.
+
+        Args:
+            link: The text-bearing /md5/ anchor
+            md5: MD5 extracted from its href
+            title: Its text
+
+        Returns:
+            UnifiedBookResult with whatever fields the card exposed
+        """
+        card = link.parent
+        extra: Dict[str, str] = {"url": f"{self.base_url}/md5/{md5}"}
+
+        # Author and publisher carry semantic icon markers, which survive the
+        # generated-class churn that would break a class-name selector.
+        author = ""
+        if card is not None:
+            author_icon = card.select_one('a span[class*="mdi--user-edit"]')
+            if author_icon is not None and author_icon.parent is not None:
+                author = author_icon.parent.get_text(strip=True)
+
+            publisher_icon = card.select_one('a span[class*="mdi--company"]')
+            if publisher_icon is not None and publisher_icon.parent is not None:
+                publisher = publisher_icon.parent.get_text(strip=True)
+                if publisher:
+                    extra["publisher"] = publisher
+
+        meta: Dict[str, str] = {}
+        strip_host = card.parent if card is not None else None
+        if strip_host is not None:
+            strip = _find_metadata_strip(strip_host)
+            if strip:
+                meta = _parse_metadata_strip(strip)
+
+        if "language" in meta:
+            extra["language"] = meta["language"]
+        if "content_type" in meta:
+            extra["content_type"] = meta["content_type"]
+
+        # Which OTHER sources hold this same file, as claimed by Anna's. Verified
+        # to mean "retrievable", not merely "ingested from": 3/3 records marked
+        # /lgli resolved on LibGen, 0/2 unmarked did (#78).
+        #
+        # Surfaced only. Choosing a source from it is deliberately NOT done here:
+        # how it is reported is #96, and cross-source dedup is #52. Comparison
+        # logic inside a single source's adapter is what invariant 4 forbids.
+        if "provenance" in meta:
+            extra["also_available_on"] = [
+                part for part in meta["provenance"].split("/") if part
+            ]
+
+        return UnifiedBookResult(
+            md5=md5,
+            title=title,
+            source=SourceType.ANNAS_ARCHIVE,
+            author=author,
+            year=meta.get("year", ""),
+            extension=meta.get("extension", ""),
+            size=meta.get("size", ""),
+            extra=extra,
+        )
 
     async def get_download_url(self, md5: str) -> DownloadResult:
         """Get fast download URL for a book.

--- a/lib/sources/router.py
+++ b/lib/sources/router.py
@@ -33,6 +33,11 @@ class SourceRouter:
     - If fallback_enabled=True (default), LibGen is used as fallback
     - 'auto' source selection picks Anna's if key exists, else LibGen
 
+    An explicit source="annas" is honoured with or without a key, because Anna's
+    search needs no credentials. 'auto' deliberately stays LibGen-first when no
+    key is set: LibGen returns a resolvable download link, whereas an Anna's
+    result without a key still needs a route the caller may not have.
+
     Usage:
         config = get_source_config()
         router = SourceRouter(config)
@@ -50,13 +55,19 @@ class SourceRouter:
         self._annas: Optional[AnnasArchiveAdapter] = None
         self._libgen: Optional[LibgenAdapter] = None
 
-    def _get_annas(self) -> Optional[AnnasArchiveAdapter]:
-        """Get or create Anna's Archive adapter if API key is configured.
+    def _get_annas(self) -> AnnasArchiveAdapter:
+        """Get or create the Anna's Archive adapter.
+
+        Constructed unconditionally. Anna's search is HTML scraping that carries
+        no credentials, so it works without ANNAS_SECRET_KEY; only
+        get_download_url needs the key, and it enforces that itself. Gating
+        construction on the key put the check in the wrong place and made an
+        explicit source="annas" silently return LibGen results instead (#74).
 
         Returns:
-            AnnasArchiveAdapter if key is set, None otherwise
+            AnnasArchiveAdapter instance (always available)
         """
-        if self._annas is None and self.config.has_annas_key:
+        if self._annas is None:
             self._annas = AnnasArchiveAdapter(self.config)
         return self._annas
 
@@ -102,21 +113,19 @@ class SourceRouter:
         actual_source = self._determine_source(source)
 
         if actual_source == "annas":
-            annas = self._get_annas()
-            if annas:
-                try:
-                    results = await annas.search(query, **kwargs)
-                    if results:
-                        return results
-                    logger.info("Anna's Archive returned no results")
-                except Exception as e:
-                    logger.warning(f"Anna's Archive search failed: {e}")
+            try:
+                results = await self._get_annas().search(query, **kwargs)
+                if results:
+                    return results
+                logger.info("Anna's Archive returned no results")
+            except Exception as e:
+                logger.warning(f"Anna's Archive search failed: {e}")
 
-                # Fallback to LibGen if enabled
-                if self.config.fallback_enabled:
-                    logger.info("Falling back to LibGen")
-                    return await self._get_libgen().search(query, **kwargs)
-                return []
+            # Fallback to LibGen if enabled
+            if self.config.fallback_enabled:
+                logger.info("Falling back to LibGen")
+                return await self._get_libgen().search(query, **kwargs)
+            return []
 
         # Direct LibGen search
         return await self._get_libgen().search(query, **kwargs)

--- a/test_files/annas/search_results.html
+++ b/test_files/annas/search_results.html
@@ -1,0 +1,434 @@
+<!doctype html>
+<!-- Trimmed from real annas-archive.gl search results, captured 2026-08-11.
+     Four records chosen deliberately:
+       1. complete record (year, author, publisher, multi-source provenance)
+       2. NO year  - the segment whose absence breaks positional parsing
+       3. djvu with several upstream sources
+       4. single-source provenance
+     Only the result cards are kept; page chrome is stripped. -->
+<html><body><main>
+<div class="max-w-full overflow-hidden flex flex-col justify-around">
+<div>
+<div class="line-clamp-[2] overflow-hidden break-words text-[9px] text-gray-500 font-mono">lgli/Georg Wilhelm Friedrich Hegel - Phenomenology of spirit (1977, ).azw3</div>
+<a class="line-clamp-[3] overflow-hidden break-words js-vim-focus custom-a text-[#2563eb] inline-block outline-offset-[-2px] outline-2 rounded-[3px] focus:outline font-semibold text-lg leading-[1.2] hover:opacity-80 mt-1" href="/md5/818bb275a80ff302848a2a4154b07202">Phenomenology of spirit</a><a class="line-clamp-[2] overflow-hidden break-words block custom-a text-sm hover:opacity-70 leading-[1.2] mt-1" href="/search?q=Georg Wilhelm Friedrich Hegel"><span class="icon-[mdi--user-edit] text-base align-sub"></span> Georg Wilhelm Friedrich Hegel</a><a class="line-clamp-[2] overflow-hidden break-words block custom-a text-sm hover:opacity-70 leading-[1.2] mt-1" href="/search?q=Oxford University Press"><span class="icon-[mdi--company] text-base align-sub"></span> Oxford University Press, 1977;2023</a> </div>
+<div>
+<div class="line-clamp-[5]"></div><!-- Only to make sure Tailwind generates it -->
+<div class="relative"><div class="line-clamp-[2] overflow-hidden break-words text-sm text-gray-600 mt-2 mb-2 leading-[1.3]">Not toc, which with Hegel would make this quite painful. Long is a fair description.</div> <a class="hidden js-aarecord-list-read-more absolute bottom-[-1px] right-0 text-xs bg-white pl-[6px] pr-1 py-[2px]" href="#" onclick="this.parentElement.children[0].classList.remove('line-clamp-[2]'); this.parentElement.children[0].classList.add('line-clamp-[5]'); this.parentNode.removeChild(this); event.preventDefault(); return false;">Read more…</a> <script>window.addReadMoreButton(document.currentScript.parentElement);</script></div> </div>
+<div class="text-gray-800 dark:text-slate-400 font-semibold text-sm leading-[1.2] mt-2">English [en] · AZW3 · 0.6MB · 1977 · 📘 Book (non-fiction) · 🚀/lgli/zlib    · <a class="custom-a text-[#2563eb] inline-block outline-offset-[-2px] outline-2 rounded-[3px] focus:outline font-semibold text-sm leading-none hover:opacity-80 relative" href="#"><span class="text-[15px] align-text-bottom inline-block icon-[pepicons-pencil--bookmark-filled] mr-[1px]"></span><!--TODO:TRANSLATE-->Save<script>
+      (function() {
+        var scriptParent = document.currentScript.parentElement;
+        scriptParent.addEventListener("click", (event) => {
+          var aarecord_id = "md5:818bb275a80ff302848a2a4154b07202";
+          var leftPos = 0;
+          var innerStyles = 'width: calc(100% - 16px); margin-left: 8px'
+          if (document.body.clientWidth > 800) {
+            leftPos = (scriptParent.getBoundingClientRect().left + window.scrollX);
+            innerStyles = 'transform: translateX(-100%); max-width: ' + (scriptParent.getBoundingClientRect().left + window.scrollX) + 'px';
+          }
+
+          var reloadNode = document.createElement('div');
+          document.body.appendChild(reloadNode);
+          reloadNode.innerHTML = '<div class="absolute left-0 top-0 right-0 bottom-0" style="background:rgba(0,0,0,0.2); z-index: 9999999"><div role="dialog" class="js-lists-popover-inner absolute p-4 cursor-auto bg-white shadow-xl rounded-lg" style="left: ' + leftPos + 'px; top: ' + (scriptParent.getBoundingClientRect().top + window.scrollY) + 'px; ' + innerStyles + '"><span class="leading-none align-[-3px] text-[#555] inline-block icon-[svg-spinners--ring-resize]"></span></span></div></div>'
+
+          fetch("/dyn/lists/" + aarecord_id + '?is_popover=true').then((response) => response.ok ? response.text() : 'Error 921857').then((text) => {
+            reloadNode.querySelector('.js-lists-popover-inner').innerHTML = text;
+            window.executeScriptElements(reloadNode);
+
+            function closePopover() {
+              document.body.removeChild(reloadNode);
+              document.removeEventListener("keydown", escapeHandler, true);
+            }
+
+            var escapeHandler = function(e) {
+              if (e.key === "Escape") {
+                closePopover();
+              }
+            };
+            document.addEventListener("keydown", escapeHandler, true);
+
+            reloadNode.querySelector('.js-list-popover-close').addEventListener('click', function(event) {
+              closePopover();
+              event.preventDefault();
+              return false;
+            });
+
+            reloadNode.querySelector('.js-list-popover-close').focus();
+          });
+          event.preventDefault();
+          document.activeElement.blur();
+          return false;
+        });
+      })();
+    </script></a>
+<span class="text-xs text-gray-500"><script>
+      (function() {
+        var scriptParent = document.currentScript.parentElement;
+
+        const md5 = "818bb275a80ff302848a2a4154b07202";
+
+        // # "text/css" for DDOS-GUARD caching.
+        fetch("/dyn/md5/inline_info/" + md5, { headers: { 'Accept': 'text/css' } }).then((response) => response.json()).then((json) => {
+          const icons = [
+            // TODO:TRANSLATE
+            ` · <span title="Downloads" class="whitespace-nowrap"><span class='text-[14px] align-text-bottom inline-block icon-[typcn--download] mr-[3px]'></span>${json.downloads_total.toLocaleString()}</span> <span title="Downloads">`,
+            // TODO:TRANSLATE
+            json.great_quality_count && `<span title="Great quality" class="whitespace-nowrap text-yellow-500"><span class='text-[14px] align-text-bottom inline-block icon-[material-symbols--star] mr-[2px]'></span>${json.great_quality_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.lists_count && `<span title="Lists" class="whitespace-nowrap"><span class='text-[14px] align-[-3px] inline-block icon-[pepicons-pencil--bookmark-filled] mr-[2px]'></span>${json.lists_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.comments_count && `<span title="Comments" class="whitespace-nowrap"><span class='text-[14px] align-[-3px] icon-[mdi--comment] mr-[4px]'></span>${json.comments_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.reports_count && `<span title="File issues" class="whitespace-nowrap text-red-500"><span class='text-[14px] align-text-bottom inline-block icon-[material-symbols--warning] mr-[2px]'></span>${json.reports_count.toLocaleString()}</span></span>`,
+          ]
+          scriptParent.innerHTML = '<span class="align-text-bottom">' + icons.filter(Boolean).join(` · `) + '</span>';
+        });
+      })();
+    </script></span>
+</div>
+<div class="hidden">base score: 11048.0, final score: 167395.81</div>
+</div>
+<div class="max-w-full overflow-hidden flex flex-col justify-around">
+<div>
+<div class="line-clamp-[2] overflow-hidden break-words text-[9px] text-gray-500 font-mono">upload/motw_a1d_2025_10/a1d/brb/Georg Friedrich Hegel/Phenomenology of Spirit (3956)/Phenomenology of Spirit - Georg Friedrich Hegel.pdf</div>
+<a class="line-clamp-[3] overflow-hidden break-words js-vim-focus custom-a text-[#2563eb] inline-block outline-offset-[-2px] outline-2 rounded-[3px] focus:outline font-semibold text-lg leading-[1.2] hover:opacity-80 mt-1" href="/md5/78064a300cc915ac4fb39701b78ab6a7">Phenomenology of Spirit</a><a class="line-clamp-[2] overflow-hidden break-words block custom-a text-sm hover:opacity-70 leading-[1.2] mt-1" href="/search?q=Georg Friedrich Hegel"><span class="icon-[mdi--user-edit] text-base align-sub"></span> Georg Friedrich Hegel</a> </div>
+<div>
+<div class="line-clamp-[5]"></div><!-- Only to make sure Tailwind generates it -->
+<div class="relative"><div class="line-clamp-[2] overflow-hidden break-words text-sm text-gray-600 mt-2 mb-2 leading-[1.3]">Contents 2
+Preface 5
+1. 5
+2. 6
+3. 7
+4. 8
+5. 9
+6. 9
+7. 10
+8. 11
+9. 12
+10. 12
+11. 14
+12. 14
+13. 15
+14. 16
+15. 16
+16. 18
+17. 19
+18. 20
+19. 20
+20. 21
+21. 21
+22. 22
+23. 23
+24. 24
+25. 25
+26. 26
+27. 27
+28. 28
+29. 29
+30. 30
+31. 31
+32. 32
+33. 33
+34. 35
+35. 35
+36. 35
+37. 36
+38. 37
+39. 38
+40. 39
+41. 40
+42. 40
+43. 41
+44. 42
+45. 42
+46. 44
+47. 45
+48. 46
+49. 47
+50. 48
+51. 49
+52. 52
+53. 52
+54. 54
+55. 55
+56. 56
+57. 57
+58. 57
+59. 58
+60. 59
+61. 61
+62. 62
+63. 63
+64. 63
+Introduction 73
+A: CONSCIOUSNESS 90
+I: Sense-certainty or the “this” andmeaning something 90
+II: Perception; or the thing and illusion 102
+III: Force and the understanding;appearance and the supersensible world 120
+B: Self-consciousness 158
+IV: The truth of self-certainty 158
+A: Self-sufficiency and non-selfsufficiencyof self-consciousness; masteryand servitude 168
+B: Freedom of self-consciousness:stoicism, skepticism, and the unhappyconsciousness 181
+C: (AA) REASON 210
+V: The certainty and truth of reason 210
+A: Observing reason 219
+a: Observation of nature 222
+b: Observation of self-consciousness inits purity and in its relation to externalactuality: logical and psychological laws 271
+c: Observation of the relation of selfconsciousnessto its immediate actuality:physiognomy and phrenology 279
+B: The actualization of rational selfconsciousnessby way of itself 317
+a: Pleasure and necessity 327
+b: The law of the heart, and the insanity of self-conceit 332
+c: Virtue and the way of the world 343
+C: Individuality, which in its own eyes isreal in and for itself 354
+a: The spiritual realm of animals anddeception; or the thing that matters (dieSache selbst) 357
+b: Law-giving reason 380
+c: Reason as testing laws 386
+(BB) Spirit 396
+VI: Spirit 396
+A: True spirit, ethical life 400
+a: The ethical world, the human anddivine law, man and woman 401
+b: Ethical action, human and divineknowledge, guilt and fate 419
+c. The state of legality 435
+B: Spirit alienated from itself: culturalmaturation 441
+I: The world of self-alienated spirit 445
+a: Cultural maturation and its realm ofactuality 446
+b: Faith and pure insight 481
+II: The Enlightenment 492
+a: The struggle of the Enlightenmentwith superstition 494
+b: The truth of the enlightenment 526
+III: Absolute freedom and terror 535
+C: Spirit Certain of Itself: Morality 548
+a: The Moral Worldview 550</div> <a class="hidden js-aarecord-list-read-more absolute bottom-[-1px] right-0 text-xs bg-white pl-[6px] pr-1 py-[2px]" href="#" onclick="this.parentElement.children[0].classList.remove('line-clamp-[2]'); this.parentElement.children[0].classList.add('line-clamp-[5]'); this.parentNode.removeChild(this); event.preventDefault(); return false;">Read more…</a> <script>window.addReadMoreButton(document.currentScript.parentElement);</script></div> </div>
+<div class="text-gray-800 dark:text-slate-400 font-semibold text-sm leading-[1.2] mt-2">English [en] · PDF · 6.7MB · 📗 Book (unknown) · 🚀/upload    · <a class="custom-a text-[#2563eb] inline-block outline-offset-[-2px] outline-2 rounded-[3px] focus:outline font-semibold text-sm leading-none hover:opacity-80 relative" href="#"><span class="text-[15px] align-text-bottom inline-block icon-[pepicons-pencil--bookmark-filled] mr-[1px]"></span><!--TODO:TRANSLATE-->Save<script>
+      (function() {
+        var scriptParent = document.currentScript.parentElement;
+        scriptParent.addEventListener("click", (event) => {
+          var aarecord_id = "md5:78064a300cc915ac4fb39701b78ab6a7";
+          var leftPos = 0;
+          var innerStyles = 'width: calc(100% - 16px); margin-left: 8px'
+          if (document.body.clientWidth > 800) {
+            leftPos = (scriptParent.getBoundingClientRect().left + window.scrollX);
+            innerStyles = 'transform: translateX(-100%); max-width: ' + (scriptParent.getBoundingClientRect().left + window.scrollX) + 'px';
+          }
+
+          var reloadNode = document.createElement('div');
+          document.body.appendChild(reloadNode);
+          reloadNode.innerHTML = '<div class="absolute left-0 top-0 right-0 bottom-0" style="background:rgba(0,0,0,0.2); z-index: 9999999"><div role="dialog" class="js-lists-popover-inner absolute p-4 cursor-auto bg-white shadow-xl rounded-lg" style="left: ' + leftPos + 'px; top: ' + (scriptParent.getBoundingClientRect().top + window.scrollY) + 'px; ' + innerStyles + '"><span class="leading-none align-[-3px] text-[#555] inline-block icon-[svg-spinners--ring-resize]"></span></span></div></div>'
+
+          fetch("/dyn/lists/" + aarecord_id + '?is_popover=true').then((response) => response.ok ? response.text() : 'Error 921857').then((text) => {
+            reloadNode.querySelector('.js-lists-popover-inner').innerHTML = text;
+            window.executeScriptElements(reloadNode);
+
+            function closePopover() {
+              document.body.removeChild(reloadNode);
+              document.removeEventListener("keydown", escapeHandler, true);
+            }
+
+            var escapeHandler = function(e) {
+              if (e.key === "Escape") {
+                closePopover();
+              }
+            };
+            document.addEventListener("keydown", escapeHandler, true);
+
+            reloadNode.querySelector('.js-list-popover-close').addEventListener('click', function(event) {
+              closePopover();
+              event.preventDefault();
+              return false;
+            });
+
+            reloadNode.querySelector('.js-list-popover-close').focus();
+          });
+          event.preventDefault();
+          document.activeElement.blur();
+          return false;
+        });
+      })();
+    </script></a>
+<span class="text-xs text-gray-500"><script>
+      (function() {
+        var scriptParent = document.currentScript.parentElement;
+
+        const md5 = "78064a300cc915ac4fb39701b78ab6a7";
+
+        // # "text/css" for DDOS-GUARD caching.
+        fetch("/dyn/md5/inline_info/" + md5, { headers: { 'Accept': 'text/css' } }).then((response) => response.json()).then((json) => {
+          const icons = [
+            // TODO:TRANSLATE
+            ` · <span title="Downloads" class="whitespace-nowrap"><span class='text-[14px] align-text-bottom inline-block icon-[typcn--download] mr-[3px]'></span>${json.downloads_total.toLocaleString()}</span> <span title="Downloads">`,
+            // TODO:TRANSLATE
+            json.great_quality_count && `<span title="Great quality" class="whitespace-nowrap text-yellow-500"><span class='text-[14px] align-text-bottom inline-block icon-[material-symbols--star] mr-[2px]'></span>${json.great_quality_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.lists_count && `<span title="Lists" class="whitespace-nowrap"><span class='text-[14px] align-[-3px] inline-block icon-[pepicons-pencil--bookmark-filled] mr-[2px]'></span>${json.lists_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.comments_count && `<span title="Comments" class="whitespace-nowrap"><span class='text-[14px] align-[-3px] icon-[mdi--comment] mr-[4px]'></span>${json.comments_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.reports_count && `<span title="File issues" class="whitespace-nowrap text-red-500"><span class='text-[14px] align-text-bottom inline-block icon-[material-symbols--warning] mr-[2px]'></span>${json.reports_count.toLocaleString()}</span></span>`,
+          ]
+          scriptParent.innerHTML = '<span class="align-text-bottom">' + icons.filter(Boolean).join(` · `) + '</span>';
+        });
+      })();
+    </script></span>
+</div>
+<div class="hidden">base score: 10961.0, final score: 167330.03</div>
+</div>
+<div class="max-w-full overflow-hidden flex flex-col justify-around">
+<div>
+<div class="line-clamp-[2] overflow-hidden break-words text-[9px] text-gray-500 font-mono">lgli/P_Physics/PQm_Quantum mechanics/Joos. Decoherence through interaction with the environment (1996)(T)(144s)_PQm_.djvu</div>
+<a class="line-clamp-[3] overflow-hidden break-words js-vim-focus custom-a text-[#2563eb] inline-block outline-offset-[-2px] outline-2 rounded-[3px] focus:outline font-semibold text-lg leading-[1.2] hover:opacity-80 mt-1" href="/md5/7f9bce5fe568a6ef77301b5b29f736fa">Decoherence through interaction with the environment</a><a class="line-clamp-[2] overflow-hidden break-words block custom-a text-sm hover:opacity-70 leading-[1.2] mt-1" href="/search?q=Joos."><span class="icon-[mdi--user-edit] text-base align-sub"></span> Joos.</a><a class="line-clamp-[2] overflow-hidden break-words block custom-a text-sm hover:opacity-70 leading-[1.2] mt-1" href="/search?q="><span class="icon-[mdi--company] text-base align-sub"></span> 1996</a> </div>
+<div>
+<div class="line-clamp-[5]"></div><!-- Only to make sure Tailwind generates it -->
+</div>
+<div class="text-gray-800 dark:text-slate-400 font-semibold text-sm leading-[1.2] mt-2">English [en] · DJVU · 1.7MB · 1996 · 📘 Book (non-fiction) · 🚀/lgli/lgrs/nexusstc/zlib    · <a class="custom-a text-[#2563eb] inline-block outline-offset-[-2px] outline-2 rounded-[3px] focus:outline font-semibold text-sm leading-none hover:opacity-80 relative" href="#"><span class="text-[15px] align-text-bottom inline-block icon-[pepicons-pencil--bookmark-filled] mr-[1px]"></span><!--TODO:TRANSLATE-->Save<script>
+      (function() {
+        var scriptParent = document.currentScript.parentElement;
+        scriptParent.addEventListener("click", (event) => {
+          var aarecord_id = "md5:7f9bce5fe568a6ef77301b5b29f736fa";
+          var leftPos = 0;
+          var innerStyles = 'width: calc(100% - 16px); margin-left: 8px'
+          if (document.body.clientWidth > 800) {
+            leftPos = (scriptParent.getBoundingClientRect().left + window.scrollX);
+            innerStyles = 'transform: translateX(-100%); max-width: ' + (scriptParent.getBoundingClientRect().left + window.scrollX) + 'px';
+          }
+
+          var reloadNode = document.createElement('div');
+          document.body.appendChild(reloadNode);
+          reloadNode.innerHTML = '<div class="absolute left-0 top-0 right-0 bottom-0" style="background:rgba(0,0,0,0.2); z-index: 9999999"><div role="dialog" class="js-lists-popover-inner absolute p-4 cursor-auto bg-white shadow-xl rounded-lg" style="left: ' + leftPos + 'px; top: ' + (scriptParent.getBoundingClientRect().top + window.scrollY) + 'px; ' + innerStyles + '"><span class="leading-none align-[-3px] text-[#555] inline-block icon-[svg-spinners--ring-resize]"></span></span></div></div>'
+
+          fetch("/dyn/lists/" + aarecord_id + '?is_popover=true').then((response) => response.ok ? response.text() : 'Error 921857').then((text) => {
+            reloadNode.querySelector('.js-lists-popover-inner').innerHTML = text;
+            window.executeScriptElements(reloadNode);
+
+            function closePopover() {
+              document.body.removeChild(reloadNode);
+              document.removeEventListener("keydown", escapeHandler, true);
+            }
+
+            var escapeHandler = function(e) {
+              if (e.key === "Escape") {
+                closePopover();
+              }
+            };
+            document.addEventListener("keydown", escapeHandler, true);
+
+            reloadNode.querySelector('.js-list-popover-close').addEventListener('click', function(event) {
+              closePopover();
+              event.preventDefault();
+              return false;
+            });
+
+            reloadNode.querySelector('.js-list-popover-close').focus();
+          });
+          event.preventDefault();
+          document.activeElement.blur();
+          return false;
+        });
+      })();
+    </script></a>
+<span class="text-xs text-gray-500"><script>
+      (function() {
+        var scriptParent = document.currentScript.parentElement;
+
+        const md5 = "7f9bce5fe568a6ef77301b5b29f736fa";
+
+        // # "text/css" for DDOS-GUARD caching.
+        fetch("/dyn/md5/inline_info/" + md5, { headers: { 'Accept': 'text/css' } }).then((response) => response.json()).then((json) => {
+          const icons = [
+            // TODO:TRANSLATE
+            ` · <span title="Downloads" class="whitespace-nowrap"><span class='text-[14px] align-text-bottom inline-block icon-[typcn--download] mr-[3px]'></span>${json.downloads_total.toLocaleString()}</span> <span title="Downloads">`,
+            // TODO:TRANSLATE
+            json.great_quality_count && `<span title="Great quality" class="whitespace-nowrap text-yellow-500"><span class='text-[14px] align-text-bottom inline-block icon-[material-symbols--star] mr-[2px]'></span>${json.great_quality_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.lists_count && `<span title="Lists" class="whitespace-nowrap"><span class='text-[14px] align-[-3px] inline-block icon-[pepicons-pencil--bookmark-filled] mr-[2px]'></span>${json.lists_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.comments_count && `<span title="Comments" class="whitespace-nowrap"><span class='text-[14px] align-[-3px] icon-[mdi--comment] mr-[4px]'></span>${json.comments_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.reports_count && `<span title="File issues" class="whitespace-nowrap text-red-500"><span class='text-[14px] align-text-bottom inline-block icon-[material-symbols--warning] mr-[2px]'></span>${json.reports_count.toLocaleString()}</span></span>`,
+          ]
+          scriptParent.innerHTML = '<span class="align-text-bottom">' + icons.filter(Boolean).join(` · `) + '</span>';
+        });
+      })();
+    </script></span>
+</div>
+<div class="hidden">base score: 11050.0, final score: 41.90942</div>
+</div>
+<div class="max-w-full overflow-hidden flex flex-col justify-around">
+<div>
+<div class="line-clamp-[2] overflow-hidden break-words text-[9px] text-gray-500 font-mono">zlib/no-category/Hegel, Georg Wilhelm Friedrich, 1770-1831, Miller, A. V. (Arnold Vincent), 1899-, Findlay, John Niemeyer/Phenomenology of spirit_121877806.pdf</div>
+<a class="line-clamp-[3] overflow-hidden break-words js-vim-focus custom-a text-[#2563eb] inline-block outline-offset-[-2px] outline-2 rounded-[3px] focus:outline font-semibold text-lg leading-[1.2] hover:opacity-80 mt-1" href="/md5/6eebf3d2e3b4bc515240f250b7ccf353">Phenomenology of spirit</a><a class="line-clamp-[2] overflow-hidden break-words block custom-a text-sm hover:opacity-70 leading-[1.2] mt-1" href="/search?q=Hegel, Georg Wilhelm Friedrich, 1770-1831, Miller, A. V. (Arnold Vincent), 1899-, Findlay, John Niemeyer"><span class="icon-[mdi--user-edit] text-base align-sub"></span> Hegel, Georg Wilhelm Friedrich, 1770-1831, Miller, A. V. (Arnold Vincent), 1899-, Findlay, John Niemeyer</a><a class="line-clamp-[2] overflow-hidden break-words block custom-a text-sm hover:opacity-70 leading-[1.2] mt-1" href="/search?q=Oxford : Clarendon Press"><span class="icon-[mdi--company] text-base align-sub"></span> Oxford : Clarendon Press, 1979</a> </div>
+<div>
+<div class="line-clamp-[5]"></div><!-- Only to make sure Tailwind generates it -->
+<div class="relative"><div class="line-clamp-[2] overflow-hidden break-words text-sm text-gray-600 mt-2 mb-2 leading-[1.3]">This brilliant study of the stages in the mind's necessary progress from immediate sense-consciousness to the position of a scientific philosophy includes an introductory essay and a paragraph-by-paragraph analysis of the text to help the reader understand this most difficult and most influential of Hegel's works., Series: Galaxy Books, Cover title, Hegel's phenomenology of spirit, This translation originally published, 1977. - Translation of, 'Phänomenologie des Geistes'. 5th ed. / edited by J. Hoffmeister. Hamburg , Felix Meiner, 1952, Includes index</div> <a class="hidden js-aarecord-list-read-more absolute bottom-[-1px] right-0 text-xs bg-white pl-[6px] pr-1 py-[2px]" href="#" onclick="this.parentElement.children[0].classList.remove('line-clamp-[2]'); this.parentElement.children[0].classList.add('line-clamp-[5]'); this.parentNode.removeChild(this); event.preventDefault(); return false;">Read more…</a> <script>window.addReadMoreButton(document.currentScript.parentElement);</script></div> </div>
+<div class="text-gray-800 dark:text-slate-400 font-semibold text-sm leading-[1.2] mt-2">English [en] · PDF · 34.1MB · 1979 · 📗 Book (unknown) · zlib    · <a class="custom-a text-[#2563eb] inline-block outline-offset-[-2px] outline-2 rounded-[3px] focus:outline font-semibold text-sm leading-none hover:opacity-80 relative" href="#"><span class="text-[15px] align-text-bottom inline-block icon-[pepicons-pencil--bookmark-filled] mr-[1px]"></span><!--TODO:TRANSLATE-->Save<script>
+      (function() {
+        var scriptParent = document.currentScript.parentElement;
+        scriptParent.addEventListener("click", (event) => {
+          var aarecord_id = "md5:6eebf3d2e3b4bc515240f250b7ccf353";
+          var leftPos = 0;
+          var innerStyles = 'width: calc(100% - 16px); margin-left: 8px'
+          if (document.body.clientWidth > 800) {
+            leftPos = (scriptParent.getBoundingClientRect().left + window.scrollX);
+            innerStyles = 'transform: translateX(-100%); max-width: ' + (scriptParent.getBoundingClientRect().left + window.scrollX) + 'px';
+          }
+
+          var reloadNode = document.createElement('div');
+          document.body.appendChild(reloadNode);
+          reloadNode.innerHTML = '<div class="absolute left-0 top-0 right-0 bottom-0" style="background:rgba(0,0,0,0.2); z-index: 9999999"><div role="dialog" class="js-lists-popover-inner absolute p-4 cursor-auto bg-white shadow-xl rounded-lg" style="left: ' + leftPos + 'px; top: ' + (scriptParent.getBoundingClientRect().top + window.scrollY) + 'px; ' + innerStyles + '"><span class="leading-none align-[-3px] text-[#555] inline-block icon-[svg-spinners--ring-resize]"></span></span></div></div>'
+
+          fetch("/dyn/lists/" + aarecord_id + '?is_popover=true').then((response) => response.ok ? response.text() : 'Error 921857').then((text) => {
+            reloadNode.querySelector('.js-lists-popover-inner').innerHTML = text;
+            window.executeScriptElements(reloadNode);
+
+            function closePopover() {
+              document.body.removeChild(reloadNode);
+              document.removeEventListener("keydown", escapeHandler, true);
+            }
+
+            var escapeHandler = function(e) {
+              if (e.key === "Escape") {
+                closePopover();
+              }
+            };
+            document.addEventListener("keydown", escapeHandler, true);
+
+            reloadNode.querySelector('.js-list-popover-close').addEventListener('click', function(event) {
+              closePopover();
+              event.preventDefault();
+              return false;
+            });
+
+            reloadNode.querySelector('.js-list-popover-close').focus();
+          });
+          event.preventDefault();
+          document.activeElement.blur();
+          return false;
+        });
+      })();
+    </script></a>
+<span class="text-xs text-gray-500"><script>
+      (function() {
+        var scriptParent = document.currentScript.parentElement;
+
+        const md5 = "6eebf3d2e3b4bc515240f250b7ccf353";
+
+        // # "text/css" for DDOS-GUARD caching.
+        fetch("/dyn/md5/inline_info/" + md5, { headers: { 'Accept': 'text/css' } }).then((response) => response.json()).then((json) => {
+          const icons = [
+            // TODO:TRANSLATE
+            ` · <span title="Downloads" class="whitespace-nowrap"><span class='text-[14px] align-text-bottom inline-block icon-[typcn--download] mr-[3px]'></span>${json.downloads_total.toLocaleString()}</span> <span title="Downloads">`,
+            // TODO:TRANSLATE
+            json.great_quality_count && `<span title="Great quality" class="whitespace-nowrap text-yellow-500"><span class='text-[14px] align-text-bottom inline-block icon-[material-symbols--star] mr-[2px]'></span>${json.great_quality_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.lists_count && `<span title="Lists" class="whitespace-nowrap"><span class='text-[14px] align-[-3px] inline-block icon-[pepicons-pencil--bookmark-filled] mr-[2px]'></span>${json.lists_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.comments_count && `<span title="Comments" class="whitespace-nowrap"><span class='text-[14px] align-[-3px] icon-[mdi--comment] mr-[4px]'></span>${json.comments_count.toLocaleString()}</span></span>`,
+            // TODO:TRANSLATE
+            json.reports_count && `<span title="File issues" class="whitespace-nowrap text-red-500"><span class='text-[14px] align-text-bottom inline-block icon-[material-symbols--warning] mr-[2px]'></span>${json.reports_count.toLocaleString()}</span></span>`,
+          ]
+          scriptParent.innerHTML = '<span class="align-text-bottom">' + icons.filter(Boolean).join(` · `) + '</span>';
+        });
+      })();
+    </script></span>
+</div>
+<div class="hidden">base score: 11060.0, final score: 1.67396</div>
+</div>
+</main></body></html>

--- a/test_files/annas/search_results.html
+++ b/test_files/annas/search_results.html
@@ -1,12 +1,25 @@
 <!doctype html>
 <!-- Trimmed from real annas-archive.gl search results, captured 2026-08-11.
+     Whole result ROWS are kept, not just the title block, because each record
+     renders TWO /md5/ anchors - a cover image with empty text, then the title -
+     and that pair IS the bug this fixture exists to pin (#78). A fixture with
+     only the title anchor would stay green against the broken implementation.
      Four records chosen deliberately:
        1. complete record (year, author, publisher, multi-source provenance)
        2. NO year  - the segment whose absence breaks positional parsing
        3. djvu with several upstream sources
-       4. single-source provenance
-     Only the result cards are kept; page chrome is stripped. -->
+       4. single-source provenance -->
 <html><body><main>
+<div class="flex pt-3 pb-3 border-b last:border-b-0 border-gray-100">
+<a class="custom-a block mr-2 sm:mr-4 hover:opacity-80" href="/md5/818bb275a80ff302848a2a4154b07202">
+<div class="w-20 h-[7.5rem] sm:w-24 sm:h-36 rounded shadow relative overflow-hidden text-left" id="list_cover_aarecord_id__md5:818bb275a80ff302848a2a4154b07202">
+<img alt="" class="w-full h-full object-cover transition-transform relative z-10 rounded" decoding="async" loading="lazy" onerror="this.parentNode.querySelector('.js-aarecord-list-fallback-cover').classList.remove('hidden'); this.parentNode.removeChild(this)" referrerpolicy="no-referrer" src="https://covers.z-lib.sk/covers400/collections/userbooks/de05fe55863700e9692ff163638bcaa36fe0bfcd5f417956f0cac5771306a7d3.jpg"/>
+<div class="absolute top-0 left-0 w-full h-full p-2 flex flex-col text-[7pt] leading-[1.1] break-words overflow-hidden select-none hidden js-aarecord-list-fallback-cover" style="background-color: hsl(130, 30%, 90%)">
+<div class="font-bold text-violet-900 line-clamp-[5]" data-content="Phenomenology of spirit"></div>
+<div class="font-bold text-amber-900 line-clamp-[2] mt-2" data-content="Georg Wilhelm Friedrich Hegel"></div>
+</div>
+</div>
+</a>
 <div class="max-w-full overflow-hidden flex flex-col justify-around">
 <div>
 <div class="line-clamp-[2] overflow-hidden break-words text-[9px] text-gray-500 font-mono">lgli/Georg Wilhelm Friedrich Hegel - Phenomenology of spirit (1977, ).azw3</div>
@@ -87,6 +100,17 @@
 </div>
 <div class="hidden">base score: 11048.0, final score: 167395.81</div>
 </div>
+</div>
+<div class="flex pt-3 pb-3 border-b last:border-b-0 border-gray-100">
+<a class="custom-a block mr-2 sm:mr-4 hover:opacity-80" href="/md5/78064a300cc915ac4fb39701b78ab6a7">
+<div class="w-20 h-[7.5rem] sm:w-24 sm:h-36 rounded shadow relative overflow-hidden text-left" id="list_cover_aarecord_id__md5:78064a300cc915ac4fb39701b78ab6a7">
+<img alt="" class="w-full h-full object-cover transition-transform relative z-10 rounded" decoding="async" loading="lazy" onerror="this.parentNode.querySelector('.js-aarecord-list-fallback-cover').classList.remove('hidden'); this.parentNode.removeChild(this)" referrerpolicy="no-referrer" src=""/>
+<div class="absolute top-0 left-0 w-full h-full p-2 flex flex-col text-[7pt] leading-[1.1] break-words overflow-hidden select-none hidden js-aarecord-list-fallback-cover" style="background-color: hsl(105, 60%, 90%)">
+<div class="font-bold text-violet-900 line-clamp-[5]" data-content="Phenomenology of Spirit"></div>
+<div class="font-bold text-amber-900 line-clamp-[2] mt-2" data-content="Georg Friedrich Hegel"></div>
+</div>
+</div>
+</a>
 <div class="max-w-full overflow-hidden flex flex-col justify-around">
 <div>
 <div class="line-clamp-[2] overflow-hidden break-words text-[9px] text-gray-500 font-mono">upload/motw_a1d_2025_10/a1d/brb/Georg Friedrich Hegel/Phenomenology of Spirit (3956)/Phenomenology of Spirit - Georg Friedrich Hegel.pdf</div>
@@ -271,6 +295,17 @@ a: The Moral Worldview 550</div> <a class="hidden js-aarecord-list-read-more abs
 </div>
 <div class="hidden">base score: 10961.0, final score: 167330.03</div>
 </div>
+</div>
+<div class="flex pt-3 pb-3 border-b last:border-b-0 border-gray-100">
+<a class="custom-a block mr-2 sm:mr-4 hover:opacity-80" href="/md5/7f9bce5fe568a6ef77301b5b29f736fa">
+<div class="w-20 h-[7.5rem] sm:w-24 sm:h-36 rounded shadow relative overflow-hidden text-left" id="list_cover_aarecord_id__md5:7f9bce5fe568a6ef77301b5b29f736fa">
+<img alt="" class="w-full h-full object-cover transition-transform relative z-10 rounded" decoding="async" loading="lazy" onerror="this.parentNode.querySelector('.js-aarecord-list-fallback-cover').classList.remove('hidden'); this.parentNode.removeChild(this)" referrerpolicy="no-referrer" src="https://covers.z-lib.sk/covers400/collections/genesis/971faf1caeb3dd0f63d44447482be10b1e10fb667c7da1a5588b062d527f2d3c.jpg"/>
+<div class="absolute top-0 left-0 w-full h-full p-2 flex flex-col text-[7pt] leading-[1.1] break-words overflow-hidden select-none hidden js-aarecord-list-fallback-cover" style="background-color: hsl(285, 60%, 90%)">
+<div class="font-bold text-violet-900 line-clamp-[5]" data-content="Decoherence through interaction with the environment"></div>
+<div class="font-bold text-amber-900 line-clamp-[2] mt-2" data-content="Joos."></div>
+</div>
+</div>
+</a>
 <div class="max-w-full overflow-hidden flex flex-col justify-around">
 <div>
 <div class="line-clamp-[2] overflow-hidden break-words text-[9px] text-gray-500 font-mono">lgli/P_Physics/PQm_Quantum mechanics/Joos. Decoherence through interaction with the environment (1996)(T)(144s)_PQm_.djvu</div>
@@ -351,6 +386,17 @@ a: The Moral Worldview 550</div> <a class="hidden js-aarecord-list-read-more abs
 </div>
 <div class="hidden">base score: 11050.0, final score: 41.90942</div>
 </div>
+</div>
+<div class="flex pt-3 pb-3 border-b last:border-b-0 border-gray-100">
+<a class="custom-a block mr-2 sm:mr-4 hover:opacity-80" href="/md5/6eebf3d2e3b4bc515240f250b7ccf353">
+<div class="w-20 h-[7.5rem] sm:w-24 sm:h-36 rounded shadow relative overflow-hidden text-left" id="list_cover_aarecord_id__md5:6eebf3d2e3b4bc515240f250b7ccf353">
+<img alt="" class="w-full h-full object-cover transition-transform relative z-10 rounded" decoding="async" loading="lazy" onerror="this.parentNode.querySelector('.js-aarecord-list-fallback-cover').classList.remove('hidden'); this.parentNode.removeChild(this)" referrerpolicy="no-referrer" src="https://covers.z-lib.sk/covers400/collections/internet-archive/797436dfe3b34fcac3a54fe1b9e117c83a8e5e3ee6c3b4495d338cc0ab5baa6f.jpg"/>
+<div class="absolute top-0 left-0 w-full h-full p-2 flex flex-col text-[7pt] leading-[1.1] break-words overflow-hidden select-none hidden js-aarecord-list-fallback-cover" style="background-color: hsl(330, 60%, 90%)">
+<div class="font-bold text-violet-900 line-clamp-[5]" data-content="Phenomenology of spirit"></div>
+<div class="font-bold text-amber-900 line-clamp-[2] mt-2" data-content="Hegel, Georg Wilhelm Friedrich, 1770-1831, Miller, A. V. (Arnold Vincent), 1899-, Findlay, John Niemeyer"></div>
+</div>
+</div>
+</a>
 <div class="max-w-full overflow-hidden flex flex-col justify-around">
 <div>
 <div class="line-clamp-[2] overflow-hidden break-words text-[9px] text-gray-500 font-mono">zlib/no-category/Hegel, Georg Wilhelm Friedrich, 1770-1831, Miller, A. V. (Arnold Vincent), 1899-, Findlay, John Niemeyer/Phenomenology of spirit_121877806.pdf</div>
@@ -430,5 +476,6 @@ a: The Moral Worldview 550</div> <a class="hidden js-aarecord-list-read-more abs
     </script></span>
 </div>
 <div class="hidden">base score: 11060.0, final score: 1.67396</div>
+</div>
 </div>
 </main></body></html>


### PR DESCRIPTION
Ships the two halves of one bug together. The router gate fix was written weeks ago and parked deliberately — landing it alone would have exposed 50 results every one of which read `"Unknown"`.

Closes #74. Implements the decision recorded on #78.

## The gate (#74)

`SourceRouter._get_annas()` returned `None` without `ANNAS_SECRET_KEY`, so the `if annas:` guard was skipped and control fell to the unconditional LibGen return at the end of `search()`. Nothing logged that the requested source had been dropped.

Anna's search is credential-free HTML scraping. The key is needed only by `get_download_url`, which already raises a clear error without it. The gate sat at adapter construction rather than at the one method that actually needs credentials.

The adapter is now built unconditionally. **`auto` deliberately still prefers LibGen when no key is set** — LibGen returns a resolvable download link, and that behaviour is now pinned by a test so a future change to the gate cannot quietly reroute `auto` as a side effect.

## The extraction (#78, option E)

Each record renders **two** `/md5/` anchors — a cover image with empty text, then the title — and deduping by first kept the cover. Only text-bearing anchors are selected now. Measured over 100 records across two unrelated queries: every md5 group has exactly two anchors and exactly one bears text.

Full metadata comes from the `·`-separated strip:

```
English [en] · PDF · 5.6MB · 2008 · 📕 Book (fiction) · 🚀/lgli/lgrs/nexusstc/zlib
```

**Matched by pattern, never by index.** Two traps, both pinned by tests:

- **Year is absent from ~9% of records.** Positional parsing would shift extension into the year slot on exactly those records — a corruption that looks like working code, since the other 91% stay correct.
- **A bare `[A-Z0-9]{2,5}` extension pattern also matches a four-digit year.** The extension pattern requires a leading letter.

Author and publisher are read from their semantic icon markers rather than position — 98/100 vs 95/100 for a positional heuristic, and immune to the generated-class churn that would break a class-name selector.

## Upstream provenance

The strip's last segment names which other sources hold the same file. Verified this means *retrievable*, not merely *ingested from*:

| Sample | LibGen resolves? |
|---|---|
| 3 records marked `/lgli` | **3/3 resolved** (one via `li → vg` failover) |
| 2 records not marked | **0/2 — failed on every mirror** |

Surfaced as `extra["also_available_on"]` and **nothing more**. How it is reported is #96; cross-source dedup is #52. Source-comparison logic inside a single source's adapter is what invariant 4 forbids.

Practical consequence: a record marked `/lgli` never needs the rate-limited Anna's route, because LibGen serves it free and unlimited.

## A test that encoded the bug

`test_no_annas_adapter_without_key` asserted the adapter was `None` without a key — the exact behaviour #74 identifies as wrong. Replaced with tests for the corrected behaviour, including one asserting an explicit `source="annas"` never silently reaches LibGen.

## Fixture

`test_files/annas/search_results.html` is trimmed from a live capture rather than hand-written, because the pre-existing mock did not reproduce the two-anchor markup that caused the bug. Four records chosen deliberately, including one with **no year**. 29 KB, plain text, not LFS.

## Verification

- 1062 Python tests pass; ruff clean
- Live, with no API key: `source="annas"` returns **50 `annas_archive` results** with real titles, authors, years, formats and sizes — previously LibGen results titled `"Unknown"`

```
Phenomenology of spirit                | Hegel, Georg Wilhelm Fri | 1979 | pdf  | 34.1MB | also=['zlib']
Phenomenology of Spirit (Galaxy Books) | by G.W.F. Hegel; transla | 2014 | epub | 0.7MB  | also=['lgli', 'lgrs', 'zlib']
```

## Not covered

Whether provenance markers go stale when a file leaves an upstream source is **unchecked** — the 5-record sample says nothing about decay. Tracked in the v1.5 map's fog (#95).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Purpose

Fix explicit `source="annas"` routing without requiring `ANNAS_SECRET_KEY`. Expand Anna’s Archive metadata extraction for keyless searches.

## Main changes

- Always construct the Anna’s Archive adapter.
- Route explicit `source="annas"` searches to Anna’s Archive without credentials.
- Preserve LibGen-first behavior for `source="auto"` when no key is configured.
- Keep `ANNAS_SECRET_KEY` required for `get_download_url`.
- Select text-bearing `/md5/` title links instead of cover-image links.
- Parse language, format, size, year, content type, author, and publisher from result cards.
- Support metadata segments in different orders, missing size segments, missing years, and years before 1500.
- Expose upstream source hints through `extra["also_available_on"]`.
- Update documentation to describe keyless-search metadata and the non-guaranteed nature of `also_available_on`.

## Verification

- Added fixture-based end-to-end `search()` tests for metadata extraction and anchor selection.
- Added routing tests for keyless explicit Anna’s searches and LibGen-first automatic selection.
- Added coverage for duplicate anchors, missing metadata, provenance fields, and pre-1500 years.

## Review risks

- The metadata parser depends on Anna’s Archive HTML structure, marker text, and metadata-strip patterns. HTML changes upstream may reduce extraction accuracy.
- The fixture tests do not provide live upstream verification.
- No type-check or separate runtime verification is reported in the change summary.

## Boundaries

- This PR does not change download behavior.
- Fallback behavior remains controlled by `fallback_enabled`.
- `also_available_on` is informational and does not guarantee availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->