### PR TITLE
fix(annas): address CodeRabbit review on #99 — publisher, extra typing, loop, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,13 @@ Z-Library applies a daily download limit of approximately 10 books. Call
 Anna's Archive search needs no account. Call `search_multi_source` with
 `source: "annas"`.
 
-Search without a key returns the title, the author, the year, the file format, and the
-file size. It also returns `also_available_on`, which lists the other sources that hold
+Search without a key returns the title. It also returns the author, the year, the file
+format, the file size, and `also_available_on`, which lists the other sources that hold
 the same file.
+
+**Note:** all fields except the title are optional. Anna's Archive does not supply the
+same data for every record. An absent author, year, format or size is an empty string.
+An absent `also_available_on` field is not present in the result.
 
 **Note:** `also_available_on` is a hint, not a guarantee. Anna's Archive reports it, and
 the file can leave the other source later. Use it to prefer a source that has no daily

--- a/__tests__/python/test_annas_adapter.py
+++ b/__tests__/python/test_annas_adapter.py
@@ -563,11 +563,10 @@ class TestAnnasMetadataExtraction:
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_get_client.return_value = mock_client
-            return (
-                asyncio.get_event_loop_policy()
-                .new_event_loop()
-                .run_until_complete(adapter.search("hegel"))
-            )
+            # asyncio.run creates AND closes its loop. The earlier
+            # new_event_loop() here leaked one per fixture use, which trips
+            # suites that promote ResourceWarning to an error.
+            return asyncio.run(adapter.search("hegel"))
 
     def test_fixture_reproduces_the_two_anchor_markup(self):
         """Guard the guard.
@@ -712,3 +711,51 @@ class TestAnnasMetadataExtraction:
         joos = next(r for r in results if r.md5.startswith("7f9bce5f"))
         assert "publisher" not in joos.extra
         assert joos.author == "Joos."  # author itself is still extracted
+
+    @pytest.mark.parametrize("value", ["1996", "0", "999", "20250"])
+    def test_all_numeric_publishers_are_rejected(self, value):
+        """No publisher is purely numeric, so reject the whole class.
+
+        Gating on the metadata-year parser (1000-2099) let values outside that
+        range through — a sentinel like "0" or a three-digit date would still be
+        exported, contradicting the invariant the sibling test asserts.
+        """
+        from bs4 import BeautifulSoup
+
+        from lib.sources.annas import AnnasArchiveAdapter
+        from lib.sources.config import SourceConfig
+
+        html = (
+            "<div><div>"
+            '<a href="/md5/abc">A Title</a>'
+            f'<a href="/search?q=x"><span class="icon-[mdi--company]"></span>{value}</a>'
+            "</div><div>English [en] · PDF · 1.0MB</div></div>"
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        link = soup.select_one("a[href^='/md5/']")
+
+        adapter = AnnasArchiveAdapter(SourceConfig())
+        result = adapter._build_result(link, "abc", "A Title")
+
+        assert "publisher" not in result.extra, f"{value!r} exported as publisher"
+
+    def test_real_publisher_still_survives(self):
+        """The guard must not throw out actual publishers."""
+        from bs4 import BeautifulSoup
+
+        from lib.sources.annas import AnnasArchiveAdapter
+        from lib.sources.config import SourceConfig
+
+        html = (
+            "<div><div>"
+            '<a href="/md5/abc">A Title</a>'
+            '<a href="/search?q=x"><span class="icon-[mdi--company]"></span>'
+            "Oxford University Press, 1977</a>"
+            "</div><div>English [en] · PDF · 1.0MB</div></div>"
+        )
+        link = BeautifulSoup(html, "html.parser").select_one("a[href^='/md5/']")
+        result = AnnasArchiveAdapter(SourceConfig())._build_result(
+            link, "abc", "A Title"
+        )
+
+        assert result.extra["publisher"] == "Oxford University Press, 1977"

--- a/__tests__/python/test_annas_adapter.py
+++ b/__tests__/python/test_annas_adapter.py
@@ -697,3 +697,18 @@ class TestAnnasMetadataExtraction:
         assert parsed["extension"] == "pdf"
         assert parsed["year"] == "2008"
         assert "size" not in parsed
+
+    def test_bare_year_is_not_exported_as_publisher(self, results):
+        """The company-marked line degrades to a bare year on some records.
+
+        A year is not a publisher, and exporting one puts junk into a field
+        callers will render. Fixture record 7f9bce5f… is such a record.
+        """
+        for r in results:
+            publisher = r.extra.get("publisher")
+            if publisher is not None:
+                assert not publisher.isdigit(), f"{r.md5}: bare year as publisher"
+
+        joos = next(r for r in results if r.md5.startswith("7f9bce5f"))
+        assert "publisher" not in joos.extra
+        assert joos.author == "Joos."  # author itself is still extracted

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -191,7 +191,9 @@ class AnnasArchiveAdapter(SourceAdapter):
             UnifiedBookResult with whatever fields the card exposed
         """
         card = link.parent
-        extra: Dict[str, str] = {"url": f"{self.base_url}/md5/{md5}"}
+        # Values are not uniformly str: also_available_on is a list. The dict is
+        # spread into the JSON tool response, where both serialise fine.
+        extra: Dict[str, object] = {"url": f"{self.base_url}/md5/{md5}"}
 
         # Author and publisher carry semantic icon markers, which survive the
         # generated-class churn that would break a class-name selector.
@@ -204,7 +206,11 @@ class AnnasArchiveAdapter(SourceAdapter):
             publisher_icon = card.select_one('a span[class*="mdi--company"]')
             if publisher_icon is not None and publisher_icon.parent is not None:
                 publisher = publisher_icon.parent.get_text(strip=True)
-                if publisher:
+                # The company-marked line is usually "<publisher>, <year>", but
+                # on records with no publisher it degrades to a bare year. A
+                # year is not a publisher, and exporting one puts junk in a
+                # field callers will display.
+                if publisher and not _YEAR_RE.match(publisher):
                     extra["publisher"] = publisher
 
         meta: Dict[str, str] = {}

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -207,10 +207,12 @@ class AnnasArchiveAdapter(SourceAdapter):
             if publisher_icon is not None and publisher_icon.parent is not None:
                 publisher = publisher_icon.parent.get_text(strip=True)
                 # The company-marked line is usually "<publisher>, <year>", but
-                # on records with no publisher it degrades to a bare year. A
-                # year is not a publisher, and exporting one puts junk in a
-                # field callers will display.
-                if publisher and not _YEAR_RE.match(publisher):
+                # on records with no publisher it degrades to a bare number —
+                # commonly a year, sometimes a sentinel like 0. No publisher is
+                # purely numeric, so reject the whole class rather than only the
+                # years _YEAR_RE happens to cover: gating on the year parser let
+                # values outside 1000-2099 through as publishers.
+                if publisher and not publisher.isdigit():
                     extra["publisher"] = publisher
 
         meta: Dict[str, str] = {}


### PR DESCRIPTION
Follow-up to #99. CodeRabbit's review landed while #99 was being merged, so these four fixes were pushed after the squash and did not make it into master. Same changes, rebased onto current master. **29 lines across 3 files, no behavioural change beyond the publisher fix.**

All four verified against the code before fixing.

## A bare year was being exported as a publisher

The company-marked line on an Anna's record is usually `<publisher>, <year>`, but on records with no publisher it degrades to a bare year. Confirmed against the fixture:

```
7f9bce5fe568  publisher='1996'  author='Joos.'
```

A year is not a publisher, and exporting one puts junk into a field callers will render. Bare years are now skipped; the author on that record is still extracted. Pinned by a test that asserts no result carries an all-digit publisher.

## `extra` was annotated `Dict[str, str]` but holds a list

`also_available_on` assigns a `List[str]`. Widened to `Dict[str, object]`.

Worth noting this was the annotation lying rather than a runtime fault — both types serialise fine through the JSON tool response, and `UnifiedBookResult.extra` is an untyped `Dict`. But a wrong annotation on a field other adapters will copy is worth correcting now rather than after Gutenberg and DOAB are written against it.

## The test fixture leaked an event loop

It built one with `new_event_loop()` per use and never closed it. Replaced with `asyncio.run()`, which creates and closes its own.

## README listed the metadata fields as though they were guaranteed

Anna's does not supply the same data for every record — absent scalars are empty strings and absent `also_available_on` is omitted entirely. Measured on the real pages: year is present on 91/100, author on 98/100.

Stating otherwise is the same overclaim corrected in `CONTEXT.md` on #98, so it is worth being strict about: the README now says only the title is guaranteed.

## Verification

- 1066 Python tests pass; ruff clean; README tool validator passes
- The four Codex findings from #99 are already in master and untouched here