### PR TITLE
fix(sources): bound all multi-source network calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 # Node/TypeScript
-node_modules/
+# No trailing slash: a worktree may carry node_modules as a symlink to the main
+# checkout, and `node_modules/` matches only a real directory.
+node_modules
+
+# Husky's generated hook shims. Husky writes these on `npm install`; only the
+# hook sources in .husky/ itself are source.
+.husky/_/
 coverage/
 dist/
 build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,10 @@ Two behavioural decisions that are easy to reverse by accident:
 
 The full tool list lives in `README.md` and is checked against the code by
 `scripts/validate-readme-tools.sh` in CI — add a tool, update the README in the same
-commit or `docs-check` fails. Retry and circuit-breaker tuning is in
+commit or `docs-check` fails. Retry, timeout, and circuit-breaker tuning is in
 [docs/RETRY_CONFIGURATION.md](docs/RETRY_CONFIGURATION.md); the implementations are
-`src/lib/retry-manager.ts` and `src/lib/circuit-breaker.ts`.
+`src/lib/retry-manager.ts`, `src/lib/circuit-breaker.ts`,
+`src/lib/python-runner.ts`, `lib/sources/config.py`, and `lib/sources/net.py`.
 
 Z-Library publishes no public API. Since the Phase 7 EAPI migration (Feb 2026), access
 goes through undocumented **JSON** endpoints (`/eapi/book/search`, `/eapi/user/login`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that version's CHANGELOG section, and fails the release if the section is absent.
   Previously a tag published to npm and GHCR while the Releases page silently fell
   behind — v1.4.0 shipped that way, and v1.2.0 had gone four months unnoticed (#108).
+- **Provider-attributed failures.** An unreachable source now returns a prompt
+  error naming the provider, the host, and a reason code — `dns_failure` and
+  `connect_timeout` are distinguished, because they call for different fixes
+  (update the mirror list vs. try another mirror). Reachability failures are
+  marked non-retryable, so the retry layer stops multiplying a wait against a
+  host that is not answering.
+- **A DNS + TCP pre-flight probe** before each provider request, so a dead host
+  costs one bounded probe instead of a full request budget. Cached per
+  (host, port) for the life of the call, so LibGen's three-mirror walk probes
+  each host once. Disable with `BOOK_SOURCE_PREFLIGHT=false`.
+- **LibGen search now walks all three mirrors** (`li → vg → la`), matching what
+  `download_book_to_file` already did.
+- Timeout configuration: `BOOK_SOURCE_CONNECT_TIMEOUT`,
+  `BOOK_SOURCE_READ_TIMEOUT`, `BOOK_SOURCE_TOTAL_TIMEOUT`,
+  `BOOK_SOURCE_PREFLIGHT`, `BOOK_SOURCE_PREFLIGHT_TIMEOUT`,
+  `PYTHON_BRIDGE_TIMEOUT`, `PYTHON_BRIDGE_LONG_TIMEOUT`,
+  `PYTHON_BRIDGE_KILL_GRACE`. A malformed value falls back to its default
+  rather than disabling the timeout. See
+  [docs/RETRY_CONFIGURATION.md](docs/RETRY_CONFIGURATION.md) for how the Python
+  and Node budgets compose.
 
 ### Fixed
 
+- **`search_multi_source` could hang forever, and leave the Python process
+  behind when it did.** Three defects compounded: the vendored
+  `libgen_api_enhanced` calls `requests.get` with no `timeout=` (and catches a
+  `Timeout` that therefore can never fire), the LibGen adapter ran that through
+  `asyncio.to_thread` — whose worker threads are non-daemon and joined at
+  interpreter shutdown, so an abandoned request kept the whole process alive —
+  and the Node side used `PythonShell.run`, which returns a promise with no
+  deadline and no handle on the child, so a cancelled MCP call could only
+  abandon it. Observed on 2026-08-11 as three `python_bridge.py search…`
+  processes still running, the oldest 9h10m old, belonging to a session that
+  had already exited. Every outbound call in `lib/sources/` is now bounded, and
+  the subprocess tree is killed on timeout, client cancellation, and server
+  shutdown.
+- **Cancelling a tool call now ends the work.** Every tool forwards the MCP
+  request's abort signal down to the subprocess, so a client that gives up
+  stops the Python process rather than leaving it to run out its budget with
+  nobody waiting for the result.
+- **`get_download_limits` reported `"unknown"` instead of real numbers.** It
+  read `downloads_today_limit` / `downloads_today_left` from the EAPI profile;
+  the endpoint sends `downloads_limit` / `downloads_today`. The unit test
+  passed throughout because its fixture had been written to match the code
+  rather than the service. The response now also carries `downloads_today`.
 - `SourceRouter` honours an explicit `source="annas"` and Anna's search extracts full
   metadata — authors, publisher, year, language, format, size, and upstream provenance —
   parsed by pattern rather than position, since year is absent from roughly 9% of
@@ -53,6 +95,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependency bumps: `@modelcontextprotocol/sdk` 1.25.3 → 1.30.0, `opencv-python-headless`
   4.13 → 5.0, `libgen-api-enhanced` 1.2.4 → 1.3, `cffi` 2.0.0 → 2.1.1, `yarl` 1.22.0 →
   1.24.5, `pytest-benchmark` 5.1.0 → 5.2.3, plus dev-tooling and CI action updates.
+- **An explicit `source` is no longer silently rerouted.** `source="annas"` that
+  fails now raises with the provider and reason named, instead of returning
+  LibGen's results. Fallback remains the behaviour of `source="auto"`, which is
+  what asks for it. This extends the fix in #74 from the empty-result case to
+  the network-failure case — silent rerouting is how a request tagged
+  `source="annas"` came to hang inside LibGen's search.
+- An empty result from `search_multi_source` now means every provider answered
+  and none matched. Previously a network failure with fallback disabled also
+  returned an empty list, making an outage indistinguishable from no results.
 
 ## [1.4.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A DNS + TCP pre-flight probe** before each provider request, so a dead host
   costs one bounded probe instead of a full request budget. Cached per
   (host, port) for the life of the call, so LibGen's three-mirror walk probes
-  each host once. Disable with `BOOK_SOURCE_PREFLIGHT=false`.
+  each host once. It targets the port and scheme the real request will use, and
+  **skips itself entirely when `HTTP_PROXY`/`HTTPS_PROXY` applies** (honouring
+  `NO_PROXY`) — a direct socket cannot represent a proxied request, and a probe
+  that vetoes a request the real client could have completed is worse than no
+  probe. Disable with `BOOK_SOURCE_PREFLIGHT=false`.
+- `BOOK_SOURCE_TOTAL_TIMEOUT` is now genuinely enforced for Anna's, not just
+  LibGen. `httpx.Timeout` bounds each phase separately and restarts its read
+  deadline on every chunk, so a host trickling bytes never tripped it; a
+  wall-clock deadline now covers the whole operation.
 - **LibGen search now walks all three mirrors** (`li → vg → la`), matching what
   `download_book_to_file` already did.
 - Timeout configuration: `BOOK_SOURCE_CONNECT_TIMEOUT`,
@@ -104,6 +112,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An empty result from `search_multi_source` now means every provider answered
   and none matched. Previously a network failure with fallback disabled also
   returned an empty list, making an outage indistinguishable from no results.
+  This holds for partial walks too: one provider answering empty while another
+  is unreachable raises, rather than reporting "no matches" about a provider
+  that was never successfully searched.
+- Client cancellations no longer count toward the Python bridge circuit
+  breaker. Five aborted searches would otherwise open the shared breaker and
+  fail every unrelated tool for `CIRCUIT_BREAKER_TIMEOUT` — turning a user's
+  own impatience into an outage. `CircuitBreaker` gained an `isFailure` option
+  for this.
 
 ## [1.4.0] - 2026-08-10
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,6 +1,6 @@
 # Z-Library MCP - Issues & Technical Debt
 
-<!-- Last Verified: 2026-07-24 -->
+<!-- Last Verified: 2026-08-11 -->
 
 > **Contributing?** This file is the maintainer's internal issue ledger (history,
 > evidence, resolutions). For anything you want to report or pick up, use
@@ -106,6 +106,67 @@ tests then failed with assertions resembling detection regressions
 (`assert 'ERROR' == 'MIXED'`) rather than naming the real cause.
 **Resolution** (2026-07-24): `require_real_fixture()` in `__tests__/python/conftest.py`
 skips with the cause and the fix (`git lfs pull`).
+
+### ISSUE-NET-001: Multi-Source Search Hung Forever on an Unreachable Provider [RESOLVED]
+**Severity**: Was High
+**Discovered**: 2026-08-11, on dionysus
+**Impact**: `search_multi_source` had no network deadline anywhere in its path.
+When a provider was unreachable the call never returned and never errored; the
+MCP client eventually abandoned it, and the Python subprocess kept running with
+nothing waiting on it. Three `python_bridge.py search...` processes were found
+alive simultaneously — elapsed 9h10m, 8h43m and 30m, the two long ones left over
+from a session that had already exited. A `source=libgen` call was aborted by the
+client at its 1800s idle timeout with no response and no progress.
+**Root cause** (three defects, each independently sufficient):
+1. `libgen_api_enhanced/search_request.py:177` calls `requests.get(...)` with no
+   `timeout=`, and catches a `requests.exceptions.Timeout` that can therefore
+   never fire. A host that drops SYNs blocks it forever.
+2. `LibgenAdapter.search` ran that call through `asyncio.to_thread`, whose worker
+   threads are non-daemon and are joined at interpreter shutdown — so an
+   abandoned request kept the entire process alive.
+3. `PythonShell.run` in `src/lib/zlibrary-api.ts` returned a promise with no
+   timeout and no handle on the child, so a client-side cancellation could only
+   abandon the promise, never kill the process.
+An explicit `source="annas"` also fell back to LibGen on failure, which is how a
+request tagged `annas` came to hang inside LibGen's un-timed search.
+**Provider state at the time** (measured, this host): `annas-archive.org` had no
+DNS record at all and `.se`/`.li` failed DNS in ~15ms; `libgen.is` resolved to
+193.218.118.42 but every TCP connect timed out, as did `libgen.rs` and
+`libgen.st`. General egress was fine (example.com and archive.org both 200), and
+the Z-Library EAPI path was unaffected.
+**Resolution**: `lib/sources/net.py` adds a pre-flight DNS+TCP probe that
+distinguishes `dns_failure` from `connect_timeout`, an httpx timeout builder
+covering every phase, and `run_bounded`, which runs uncancellable third-party
+calls on a **daemon** thread under a wall-clock budget. `lib/sources/errors.py`
+attributes every failure to a provider, host and stable reason code, surfaced to
+the MCP caller as `details` in the error envelope. LibGen search now walks the
+same mirror list as `get_download_url`. Router fallback is tied to
+`source=auto`; an explicit source raises rather than silently rerouting, and a
+reachable provider with no matches still returns `[]`. On the Node side,
+`src/lib/python-runner.ts` replaces `PythonShell.run` with a runner that enforces
+`PYTHON_BRIDGE_TIMEOUT`, escalates SIGTERM to SIGKILL, honours the MCP request's
+AbortSignal, and reaps any surviving child at server exit.
+**Tests**: `__tests__/python/test_source_net.py`,
+`__tests__/python/test_multi_source_timeouts.py`,
+`__tests__/python-runner.test.js` (spawns real subprocesses and asserts the pid
+is gone, since a mock cannot show what happens to an OS process).
+
+### ISSUE-API-003: get_download_limits Always Returned "unknown" [RESOLVED]
+**Severity**: Was Medium
+**Discovered**: 2026-08-11
+**Impact**: The tool returned `{"daily_limit": "unknown", "daily_remaining":
+"unknown"}` on every call, so callers could not tell whether quota remained
+before spending it — the only question the tool exists to answer.
+**Root cause**: `get_download_limits` read `downloads_today_limit` and
+`downloads_today_left` from `/eapi/user/profile`. The endpoint has never sent
+those names; it sends `downloads_limit` and `downloads_today` (verified against a
+live response 2026-08-11). Both lookups fell through to the `"unknown"` default.
+The unit test passed throughout because its fixture had been written to match the
+code rather than the service.
+**Resolution**: read the real field names, derive `daily_remaining` clamped at
+zero (the server counts a download when issued and can report `downloads_today`
+above the cap), and log a warning naming the response keys if `downloads_limit`
+disappears again. The test fixture now mirrors a captured live response.
 
 ### ISSUE-API-001: Z-Library Cloudflare Bot Protection [RESOLVED]
 **Severity**: Was CRITICAL

--- a/README.md
+++ b/README.md
@@ -418,6 +418,12 @@ All API operations include automatic retry with exponential backoff and circuit 
 
 See [docs/RETRY_CONFIGURATION.md](docs/RETRY_CONFIGURATION.md) for details.
 
+Multi-source search, URL resolution, and complete file transfers have separate
+finite wall-clock budgets. On POSIX, aborting a bridge call cooperatively cancels
+Python cleanup before process-group escalation, so partial download artifacts are
+removed. Permanent Anna credential and quota errors fail immediately without
+consuming retry or shared circuit-breaker health budgets.
+
 ## Development
 
 ### Running Tests

--- a/__tests__/circuit-breaker.test.js
+++ b/__tests__/circuit-breaker.test.js
@@ -266,4 +266,60 @@ describe('Circuit Breaker', () => {
       expect(breaker.getState()).toBe('CLOSED');
     });
   });
+
+  describe('Failure classification (isFailure)', () => {
+    /**
+     * Not every rejection is evidence the dependency is unhealthy. A caller
+     * that cancels its own request has learned nothing about the far side, and
+     * counting those lets a user's own impatience open a shared breaker and
+     * fail every unrelated call for the whole timeout window.
+     */
+    const cancelled = () => Object.assign(new Error('aborted by the caller'), {
+      context: { reason: 'aborted' },
+    });
+
+    test('counts every rejection by default', async () => {
+      const breaker = new CircuitBreaker({ threshold: 2 });
+      const failing = () => Promise.reject(cancelled());
+
+      await expect(breaker.execute(failing)).rejects.toThrow();
+      await expect(breaker.execute(failing)).rejects.toThrow();
+
+      expect(breaker.getState()).toBe('OPEN');
+    });
+
+    test('excluded rejections never open the circuit', async () => {
+      const breaker = new CircuitBreaker({
+        threshold: 2,
+        isFailure: (error) => error?.context?.reason !== 'aborted',
+      });
+      const failing = () => Promise.reject(cancelled());
+
+      for (let i = 0; i < 10; i += 1) {
+        await expect(breaker.execute(failing)).rejects.toThrow('aborted by the caller');
+      }
+
+      expect(breaker.getState()).toBe('CLOSED');
+      expect(breaker.getFailureCount()).toBe(0);
+    });
+
+    test('the error still propagates to the caller', async () => {
+      const breaker = new CircuitBreaker({ isFailure: () => false });
+      await expect(breaker.execute(() => Promise.reject(cancelled())))
+        .rejects.toThrow('aborted by the caller');
+    });
+
+    test('a real failure alongside cancellations still counts', async () => {
+      const breaker = new CircuitBreaker({
+        threshold: 2,
+        isFailure: (error) => error?.context?.reason !== 'aborted',
+      });
+
+      await expect(breaker.execute(() => Promise.reject(cancelled()))).rejects.toThrow();
+      await expect(breaker.execute(() => Promise.reject(new Error('host down')))).rejects.toThrow();
+      expect(breaker.getState()).toBe('CLOSED');
+      await expect(breaker.execute(() => Promise.reject(new Error('host down')))).rejects.toThrow();
+      expect(breaker.getState()).toBe('OPEN');
+    });
+  });
 });

--- a/__tests__/index-handlers-extended.test.js
+++ b/__tests__/index-handlers-extended.test.js
@@ -62,10 +62,13 @@ describe('Tool Handlers - Extended Coverage', () => {
       const validatedArgs = toolRegistry.process_document_for_rag.schema.parse(args);
       const response = await handler(validatedArgs);
 
-      expect(mockProcessDoc).toHaveBeenCalledWith({
-        filePath: '/input/doc.epub',
-        outputFormat: 'markdown',
-      });
+      expect(mockProcessDoc).toHaveBeenCalledWith(
+        {
+          filePath: '/input/doc.epub',
+          outputFormat: 'markdown',
+        },
+        { signal: undefined },
+      );
       expect(response).toEqual({
         processed_file_path: '/output/doc.txt',
         metadata_file_path: '/output/doc.metadata.json',
@@ -102,7 +105,7 @@ describe('Tool Handlers - Extended Coverage', () => {
       const validatedArgs = toolRegistry.get_book_metadata.schema.parse(args);
       const response = await handler(validatedArgs);
 
-      expect(mockGetMeta).toHaveBeenCalledWith('123', 'abc', ['terms']);
+      expect(mockGetMeta).toHaveBeenCalledWith('123', 'abc', ['terms'], { signal: undefined });
       expect(response).toEqual({
         title: 'Test Book', author: 'Author', terms: ['philosophy'],
       });
@@ -131,14 +134,17 @@ describe('Tool Handlers - Extended Coverage', () => {
       const validatedArgs = toolRegistry.search_by_term.schema.parse(args);
       const response = await handler(validatedArgs);
 
-      expect(mockSearchTerm).toHaveBeenCalledWith({
-        term: 'phenomenology',
-        yearFrom: 1900,
-        yearTo: 2020,
-        languages: ['english'],
-        extensions: ['pdf'],
-        limit: 15,
-      });
+      expect(mockSearchTerm).toHaveBeenCalledWith(
+        {
+          term: 'phenomenology',
+          yearFrom: 1900,
+          yearTo: 2020,
+          languages: ['english'],
+          extensions: ['pdf'],
+          limit: 15,
+        },
+        { signal: undefined },
+      );
       expect(response).toEqual([{ title: 'Phenomenology Book' }]);
     });
 
@@ -165,15 +171,18 @@ describe('Tool Handlers - Extended Coverage', () => {
       const validatedArgs = toolRegistry.search_by_author.schema.parse(args);
       const response = await handler(validatedArgs);
 
-      expect(mockSearchAuthor).toHaveBeenCalledWith({
-        author: 'Hegel',
-        exact: true,
-        yearFrom: 1800,
-        yearTo: 1900,
-        languages: ['german'],
-        extensions: ['epub'],
-        limit: 10,
-      });
+      expect(mockSearchAuthor).toHaveBeenCalledWith(
+        {
+          author: 'Hegel',
+          exact: true,
+          yearFrom: 1800,
+          yearTo: 1900,
+          languages: ['german'],
+          extensions: ['epub'],
+          limit: 10,
+        },
+        { signal: undefined },
+      );
       expect(response).toEqual([{ title: 'Hegel Book' }]);
     });
 
@@ -200,12 +209,15 @@ describe('Tool Handlers - Extended Coverage', () => {
       const validatedArgs = toolRegistry.fetch_booklist.schema.parse(args);
       const response = await handler(validatedArgs);
 
-      expect(mockFetchList).toHaveBeenCalledWith({
-        booklistId: 'bl1',
-        booklistHash: 'hash1',
-        topic: 'philosophy',
-        page: 2,
-      });
+      expect(mockFetchList).toHaveBeenCalledWith(
+        {
+          booklistId: 'bl1',
+          booklistHash: 'hash1',
+          topic: 'philosophy',
+          page: 2,
+        },
+        { signal: undefined },
+      );
       expect(response).toEqual({ books: [{ title: 'Listed Book' }], total: 1 });
     });
 
@@ -235,13 +247,16 @@ describe('Tool Handlers - Extended Coverage', () => {
       const validatedArgs = toolRegistry.search_advanced.schema.parse(args);
       const response = await handler(validatedArgs);
 
-      expect(mockAdvanced).toHaveBeenCalledWith({
-        query: 'being and time',
-        exact: true,
-        yearFrom: 1927,
-        yearTo: 1927,
-        count: 5,
-      });
+      expect(mockAdvanced).toHaveBeenCalledWith(
+        {
+          query: 'being and time',
+          exact: true,
+          yearFrom: 1927,
+          yearTo: 1927,
+          count: 5,
+        },
+        { signal: undefined },
+      );
       expect(response).toEqual({
         exact_matches: [{ title: 'Exact' }],
         fuzzy_matches: [{ title: 'Fuzzy' }],
@@ -271,11 +286,16 @@ describe('Tool Handlers - Extended Coverage', () => {
       const validatedArgs = toolRegistry.search_multi_source.schema.parse(args);
       const response = await handler(validatedArgs);
 
-      expect(mockMulti).toHaveBeenCalledWith({
-        query: 'philosophy',
-        source: 'libgen',
-        count: 20,
-      });
+      // Second argument carries the MCP request's abort signal, so a
+      // cancelled call can kill the bridge subprocess rather than orphan it.
+      expect(mockMulti).toHaveBeenCalledWith(
+        {
+          query: 'philosophy',
+          source: 'libgen',
+          count: 20,
+        },
+        { signal: undefined },
+      );
       expect(response).toEqual([{ title: 'Multi Book', source: 'libgen' }]);
     });
 
@@ -435,5 +455,45 @@ describe('Tool Handlers - Extended Coverage', () => {
 
       expect(response).toEqual({ error: { message: 'Failed to search multi-source' } });
     });
+  });
+
+  /**
+   * Cancellation has to reach the subprocess, not just the promise. Wiring it
+   * on one tool and not the rest is how a cancelled download went on running
+   * for its full budget with nobody waiting for the result, so this asserts
+   * the signal arrives for every tool that spawns the bridge.
+   */
+  describe('client cancellation reaches every bridge-backed tool', () => {
+    const CASES = [
+      ['search_books', 'searchBooks', { query: 'x' }, 1],
+      ['full_text_search', 'fullTextSearch', { query: 'x' }, 1],
+      ['get_download_history', 'getDownloadHistory', {}, 1],
+      ['get_download_limits', 'getDownloadLimits', {}, 0],
+      ['download_book_to_file', 'downloadBookToFile', { bookDetails: { id: '1' } }, 1],
+      ['process_document_for_rag', 'processDocumentForRag', { file_path: '/a.epub' }, 1],
+      ['get_book_metadata', 'getBookMetadata', { bookId: '1', bookHash: 'h' }, 3],
+      ['search_by_term', 'searchByTerm', { term: 't' }, 1],
+      ['search_by_author', 'searchByAuthor', { author: 'a' }, 1],
+      ['fetch_booklist', 'fetchBooklist', { booklistId: '1', booklistHash: 'h', topic: 't' }, 1],
+      ['search_advanced', 'searchAdvanced', { query: 'x' }, 1],
+      ['search_multi_source', 'searchMultiSource', { query: 'x' }, 1],
+    ];
+
+    test.each(CASES)(
+      '%s forwards the abort signal to the API layer',
+      async (toolName, apiName, rawArgs, optionsIndex) => {
+        const spy = jest.fn().mockResolvedValue({});
+        const { toolRegistry } = await setupWithMocks({ [apiName]: spy });
+
+        const entry = toolRegistry[toolName];
+        const validated = entry.schema ? entry.schema.parse(rawArgs) : rawArgs;
+        const controller = new AbortController();
+
+        await entry.handler(validated, { signal: controller.signal });
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][optionsIndex]).toEqual({ signal: controller.signal });
+      },
+    );
   });
 });

--- a/__tests__/index-handlers-extended.test.js
+++ b/__tests__/index-handlers-extended.test.js
@@ -109,6 +109,35 @@ describe('Tool Handlers - Extended Coverage', () => {
     });
   });
 
+  describe('downloadBookToFile handler', () => {
+    test('preserves structured provider details on failure', async () => {
+      // Mutation caught: returning a message-only envelope discards the
+      // provider, host, and reason needed to choose a useful recovery.
+      const details = {
+        operation: 'download',
+        failures: [
+          { provider: 'libgen', host: 'libgen.li', reason: 'connect_timeout' },
+        ],
+      };
+      const error = Object.assign(new Error('Download sources failed'), {
+        context: { details },
+      });
+      const mockDownload = jest.fn().mockRejectedValue(error);
+      const { toolRegistry } = await setupWithMocks({ downloadBookToFile: mockDownload });
+      const args = toolRegistry.download_book_to_file.schema.parse({
+        bookDetails: {
+          md5: '0123456789abcdef0123456789abcdef',
+          title: 'Test Book',
+          source: 'libgen',
+        },
+      });
+
+      await expect(toolRegistry.download_book_to_file.handler(args)).resolves.toEqual({
+        error: { message: 'Download sources failed', details },
+      });
+    });
+  });
+
   describe('getBookMetadata handler', () => {
     test('should call zlibApi.getBookMetadata with correct args on success', async () => {
       const mockGetMeta = jest.fn().mockResolvedValue({

--- a/__tests__/index-handlers-extended.test.js
+++ b/__tests__/index-handlers-extended.test.js
@@ -37,11 +37,27 @@ describe('Tool Handlers - Extended Coverage', () => {
     };
 
     const mocks = { ...defaults, ...overrides };
+    const registeredTools = new Map();
+    const mockServer = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      tool: jest.fn((...args) => registeredTools.set(args[0], args[4])),
+      close: jest.fn(),
+    };
 
     jest.unstable_mockModule('../lib/zlibrary-api.js', () => mocks);
+    jest.unstable_mockModule('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+      McpServer: jest.fn(() => mockServer),
+    }));
+    jest.unstable_mockModule('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+      StdioServerTransport: jest.fn(() => ({})),
+    }));
+    jest.unstable_mockModule('../lib/venv-manager.js', () => ({
+      ensureVenvReady: jest.fn().mockResolvedValue(undefined),
+      getManagedPythonPath: jest.fn().mockResolvedValue('/fake/python'),
+    }));
 
-    const { toolRegistry, handlers } = await import('../dist/index.js');
-    return { toolRegistry, handlers, mocks };
+    const { toolRegistry, handlers, start } = await import('../dist/index.js');
+    return { toolRegistry, handlers, start, registeredTools, mocks };
   }
 
   describe('processDocumentForRag handler', () => {
@@ -309,6 +325,55 @@ describe('Tool Handlers - Extended Coverage', () => {
       const response = await handler(validatedArgs);
 
       expect(response).toEqual({ error: { message: 'Multi-source failed' } });
+    });
+
+    test('should retain structured provider details on failure', async () => {
+      const details = {
+        failures: [
+          { provider: 'annas', host: 'annas-archive.gl', reason: 'dns_failure' },
+          { provider: 'libgen', host: 'libgen.li', reason: 'connect_timeout' },
+        ],
+      };
+      const error = Object.assign(new Error('All sources failed'), {
+        context: { details },
+      });
+      const mockMulti = jest.fn().mockRejectedValue(error);
+      const { toolRegistry } = await setupWithMocks({ searchMultiSource: mockMulti });
+
+      const handler = toolRegistry.search_multi_source.handler;
+      const args = toolRegistry.search_multi_source.schema.parse({ query: 'test' });
+
+      await expect(handler(args)).resolves.toEqual({
+        error: { message: 'All sources failed', details },
+      });
+    });
+
+    test('should preserve provider details in the MCP error response', async () => {
+      const details = {
+        provider: 'annas',
+        host: 'annas-archive.gl',
+        reason: 'dns_failure',
+      };
+      const error = Object.assign(new Error('Anna source failed'), {
+        context: { details },
+      });
+      const mockMulti = jest.fn().mockRejectedValue(error);
+      const { start, registeredTools } = await setupWithMocks({ searchMultiSource: mockMulti });
+      await start({ testing: true });
+
+      const callback = registeredTools.get('search_multi_source');
+      const response = await callback({ query: 'test' }, {});
+
+      expect(response).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: 'Error from tool "search_multi_source": Anna source failed',
+          },
+        ],
+        structuredContent: { error: { message: 'Anna source failed', details } },
+        isError: true,
+      });
     });
   });
 

--- a/__tests__/index-handlers-extended.test.js
+++ b/__tests__/index-handlers-extended.test.js
@@ -136,6 +136,7 @@ describe('Tool Handlers - Extended Coverage', () => {
         error: { message: 'Download sources failed', details },
       });
     });
+
   });
 
   describe('getBookMetadata handler', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -222,7 +222,7 @@ describe('Tool Handlers (Direct)', () => {
 
      const response = await handler(validatedArgs);
 
-     expect(mockSearchBooks).toHaveBeenCalledWith(validatedArgs);
+     expect(mockSearchBooks).toHaveBeenCalledWith(validatedArgs, { signal: undefined });
      expect(response).toEqual(mockResult);
 
      // Error case
@@ -259,7 +259,7 @@ describe('Tool Handlers (Direct)', () => {
 
        const response = await handler(validatedArgs);
 
-       expect(mockDownloadBookToFile).toHaveBeenCalledWith(validatedArgs);
+       expect(mockDownloadBookToFile).toHaveBeenCalledWith(validatedArgs, { signal: undefined });
        expect(response).toEqual(mockResult);
 
       // Error case
@@ -295,7 +295,7 @@ describe('Tool Handlers (Direct)', () => {
 
        const response = await handler(validatedArgs);
 
-       expect(mockFullTextSearch).toHaveBeenCalledWith(validatedArgs);
+       expect(mockFullTextSearch).toHaveBeenCalledWith(validatedArgs, { signal: undefined });
         expect(response).toEqual(mockResult);
 
        const error = new Error('FullText Error');
@@ -330,7 +330,7 @@ describe('Tool Handlers (Direct)', () => {
 
        const response = await handler(validatedArgs);
 
-       expect(mockGetDownloadHistory).toHaveBeenCalledWith(validatedArgs);
+       expect(mockGetDownloadHistory).toHaveBeenCalledWith(validatedArgs, { signal: undefined });
        expect(response).toEqual(mockResult);
 
        const error = new Error('History Error');
@@ -365,7 +365,7 @@ describe('Tool Handlers (Direct)', () => {
 
        const response = await handler(validatedArgs);
 
-       expect(mockGetDownloadLimits).toHaveBeenCalledWith();
+       expect(mockGetDownloadLimits).toHaveBeenCalledWith({ signal: undefined });
        expect(response).toEqual(mockResult);
 
        const error = new Error('Limits Error');

--- a/__tests__/python-bridge.test.js
+++ b/__tests__/python-bridge.test.js
@@ -1,124 +1,79 @@
-import { jest, describe, beforeEach, test, expect } from '@jest/globals';
-// Top-level import of spawn removed - will be mocked and imported dynamically
-import * as path from 'path';
-
-// Top-level import and mock removed - will use inline unstable_mockModule + dynamic import
+import { jest, describe, test, expect } from '@jest/globals';
 
 describe('Python Bridge', () => {
-  beforeEach(() => {
-    // jest.* calls moved inside tests
-    // jest.resetModules(); // Moved inside tests
-    // jest.clearAllMocks(); // Moved inside tests
+  async function setup({
+    bridgeResult = [JSON.stringify({ success: true, data: 'test data' })],
+    bridgeError,
+    venvError,
+  } = {}) {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    jest.unstable_mockModule('../lib/venv-manager.js', () => ({
+      getManagedPythonPath: venvError
+        ? jest.fn().mockRejectedValue(venvError)
+        : jest.fn().mockResolvedValue('/mock/venv/python'),
+    }));
+    jest.unstable_mockModule('../lib/python-runner.js', () => ({
+      runPythonBridge: bridgeError
+        ? jest.fn().mockRejectedValue(bridgeError)
+        : jest.fn().mockResolvedValue(bridgeResult),
+    }));
+    jest.unstable_mockModule('child_process', () => ({
+      spawn: jest.fn(() => {
+        throw new Error('raw spawn used');
+      }),
+    }));
+
+    return import('../lib/python-bridge.js');
+  }
+
+  test('uses the owned runner instead of creating an unmanaged subprocess', async () => {
+    // Mutation caught: replacing runPythonBridge with a direct child_process.spawn
+    // bypasses timeout, abort, registry, and process-tree cleanup.
+    const pythonBridge = await setup({
+      bridgeResult: [JSON.stringify({ success: true, data: 'owned' })],
+    });
+
+    await expect(
+      pythonBridge.callPythonFunction('test_function', { arg: 'value' }),
+    ).resolves.toEqual({ success: true, data: 'owned' });
   });
 
-  test('should call Python function and parse result successfully', async () => {
-    // --- Setup Mocks for this test ---
-    jest.resetModules(); // Reset modules for this specific test
-    jest.clearAllMocks(); // Clear mocks for this specific test
-    const mockStdoutSuccess = { on: jest.fn((event, callback) => { if (event === 'data') { callback(Buffer.from(JSON.stringify({ success: true, data: 'test data' }))); } return mockStdoutSuccess; }) };
-    const mockStderrSuccess = { on: jest.fn().mockReturnThis() };
-    const mockProcessSuccess = { stdout: mockStdoutSuccess, stderr: mockStderrSuccess, on: jest.fn((event, callback) => { if (event === 'close') { process.nextTick(() => callback(0)); } return mockProcessSuccess; }) }; // Simulate async close
+  test('parses a successful result from the owned runner', async () => {
+    const pythonBridge = await setup();
 
-    jest.unstable_mockModule('../lib/venv-manager.js', () => ({ // Mock venv-manager
-      getManagedPythonPath: jest.fn().mockResolvedValue('/mock/venv/python'),
-    }));
-    jest.unstable_mockModule('child_process', () => ({ // Mock child_process
-      spawn: jest.fn().mockReturnValue(mockProcessSuccess),
-    }));
-
-    // --- Dynamic Imports AFTER Mocks ---
-    const { spawn } = await import('child_process');
-    const venvManager = await import('../lib/venv-manager.js'); // Import mocked venv-manager
-    const pythonBridge = await import('../lib/python-bridge.js');
-
-    // --- Act ---
-    const result = await pythonBridge.callPythonFunction('test_function', ['arg1', 'arg2']);
-
-    // --- Assert ---
-    // Use dynamic path resolution instead of hardcoded path for portability
-    const expectedScriptPath = path.resolve(process.cwd(), 'lib', 'python_bridge.py');
-    expect(spawn).toHaveBeenCalledWith('/mock/venv/python', [expectedScriptPath, 'test_function', JSON.stringify(['arg1', 'arg2'])]);
-
-    expect(result).toEqual({ success: true, data: 'test data' });
+    await expect(
+      pythonBridge.callPythonFunction('test_function', ['arg1', 'arg2']),
+    ).resolves.toEqual({ success: true, data: 'test data' });
   });
 
-  test('should handle Python process errors', async () => {
-    // --- Setup Mocks for this test ---
-    jest.resetModules(); // Reset modules for this specific test
-    jest.clearAllMocks(); // Clear mocks for this specific test
-    const mockStdoutError = { on: jest.fn().mockReturnThis() };
-    const mockStderrError = { on: jest.fn((event, callback) => { if (event === 'data') { callback(Buffer.from('Python error message')); } return mockStderrError; }) };
-    const mockProcessError = { stdout: mockStdoutError, stderr: mockStderrError, on: jest.fn((event, callback) => { if (event === 'close') { process.nextTick(() => callback(1)); } return mockProcessError; }) }; // Simulate async close with error code
+  test('preserves the public non-zero-exit error shape', async () => {
+    const bridgeError = Object.assign(new Error('process exited with code 1'), {
+      exitCode: 1,
+      stderr: 'Python error message',
+      stdout: '',
+    });
+    const pythonBridge = await setup({ bridgeError });
 
-    jest.unstable_mockModule('../lib/venv-manager.js', () => ({ // Mock venv-manager
-      getManagedPythonPath: jest.fn().mockResolvedValue('/mock/venv/python'),
-    }));
-    jest.unstable_mockModule('child_process', () => ({ // Mock child_process
-      spawn: jest.fn().mockReturnValue(mockProcessError),
-    }));
-
-    // --- Dynamic Imports AFTER Mocks ---
-    const { spawn } = await import('child_process');
-    const venvManager = await import('../lib/venv-manager.js'); // Import mocked venv-manager
-    const pythonBridge = await import('../lib/python-bridge.js');
-
-    // --- Act & Assert ---
-    await expect(pythonBridge.callPythonFunction('test_function', ['arg1']))
-      .rejects.toThrow('Python process exited with code 1: Python error message');
-    expect(spawn).toHaveBeenCalled(); // Ensure spawn was called
+    await expect(pythonBridge.callPythonFunction('test_function', ['arg1'])).rejects.toThrow(
+      'Python process exited with code 1: Python error message. Raw stdout:',
+    );
   });
 
-  test('should handle JSON parse errors', async () => {
-    // --- Setup Mocks for this test ---
-    jest.resetModules(); // Reset modules for this specific test
-    jest.clearAllMocks(); // Clear mocks for this specific test
-    const mockStdoutInvalidJson = { on: jest.fn((event, callback) => { if (event === 'data') { callback(Buffer.from('Invalid JSON{')); } return mockStdoutInvalidJson; }) };
-    const mockStderrInvalidJson = { on: jest.fn().mockReturnThis() };
-    const mockProcessInvalidJson = { stdout: mockStdoutInvalidJson, stderr: mockStderrInvalidJson, on: jest.fn((event, callback) => { if (event === 'close') { process.nextTick(() => callback(0)); } return mockProcessInvalidJson; }) };
+  test('preserves the public JSON parse error shape', async () => {
+    const pythonBridge = await setup({ bridgeResult: ['Invalid JSON{'] });
 
-    jest.unstable_mockModule('../lib/venv-manager.js', () => ({ // Mock venv-manager
-      getManagedPythonPath: jest.fn().mockResolvedValue('/mock/venv/python'),
-    }));
-    jest.unstable_mockModule('child_process', () => ({ // Mock child_process
-      spawn: jest.fn().mockReturnValue(mockProcessInvalidJson),
-    }));
-
-    // --- Dynamic Imports AFTER Mocks ---
-    const { spawn } = await import('child_process');
-    const venvManager = await import('../lib/venv-manager.js'); // Import mocked venv-manager
-    const pythonBridge = await import('../lib/python-bridge.js');
-
-    // --- Act & Assert ---
-    await expect(pythonBridge.callPythonFunction('test_function', []))
-      // Update regex to match the actual error format from python-bridge.ts
-      .rejects.toThrow(/^Failed to parse Python result JSON: .*?\. Raw output:.*?\. Stderr:.*?$/);
-    expect(spawn).toHaveBeenCalled();
+    await expect(pythonBridge.callPythonFunction('test_function', [])).rejects.toThrow(
+      /^Failed to parse Python result JSON: .*?\. Raw output: Invalid JSON\{\. Stderr: $/,
+    );
   });
 
-  test('should handle Python process spawn error', async () => {
-    // --- Setup Mocks for this test ---
-    jest.resetModules(); // Reset modules for this specific test
-    jest.clearAllMocks(); // Clear mocks for this specific test
-    const mockSpawnError = new Error('Failed to spawn process');
-    const mockProcessSpawnError = { stdout: { on: jest.fn().mockReturnThis() }, stderr: { on: jest.fn().mockReturnThis() }, on: jest.fn((event, callback) => { if (event === 'error') { process.nextTick(() => callback(mockSpawnError)); } return mockProcessSpawnError; }) }; // Simulate async error
+  test('propagates managed-Python setup failures without spawning', async () => {
+    const pythonBridge = await setup({ venvError: new Error('Failed to get venv path') });
 
-    jest.unstable_mockModule('../lib/venv-manager.js', () => ({ // Mock venv-manager
-      // Simulate getManagedPythonPath failing itself
-      getManagedPythonPath: jest.fn().mockRejectedValue(new Error('Failed to get venv path')),
-    }));
-    jest.unstable_mockModule('child_process', () => ({ // Mock child_process (spawn won't be called if getManagedPythonPath fails)
-      spawn: jest.fn(),
-    }));
-
-    // --- Dynamic Imports AFTER Mocks ---
-    const { spawn } = await import('child_process');
-    const venvManager = await import('../lib/venv-manager.js'); // Import mocked venv-manager
-    const pythonBridge = await import('../lib/python-bridge.js');
-
-    // --- Act & Assert ---
-    await expect(pythonBridge.callPythonFunction('test_function', []))
-      // getManagedPythonPath rejection propagates directly (no wrapper)
-      .rejects.toThrow('Failed to get venv path');
-    // spawn is NOT called when getManagedPythonPath rejects, so no assertion needed here.
+    await expect(pythonBridge.callPythonFunction('test_function', [])).rejects.toThrow(
+      'Failed to get venv path',
+    );
   });
 });

--- a/__tests__/python-bridge.test.js
+++ b/__tests__/python-bridge.test.js
@@ -85,6 +85,30 @@ describe('Python Bridge', () => {
     expect(error.retryable).toBe(false);
   });
 
+  test('treats all-permanent quota/configuration aggregates as non-retryable', async () => {
+    const { pythonBridge } = await setup();
+    const details = {
+      failures: [
+        { provider: 'annas', reason: 'configuration_error' },
+        { provider: 'annas', reason: 'quota_exhausted' },
+      ],
+    };
+
+    expect(pythonBridge.isBridgeDetailRetryable(details)).toBe(false);
+  });
+
+  test('does not flatten mixed permanent/transient aggregates to permanent', async () => {
+    const { pythonBridge } = await setup();
+    const details = {
+      failures: [
+        { provider: 'annas', reason: 'quota_exhausted' },
+        { provider: 'libgen', reason: 'http_error' },
+      ],
+    };
+
+    expect(pythonBridge.isBridgeDetailRetryable(details)).toBe(true);
+  });
+
   test('preserves the public JSON parse error shape', async () => {
     const { pythonBridge } = await setup({ bridgeResult: ['Invalid JSON{'] });
 

--- a/__tests__/python-bridge.test.js
+++ b/__tests__/python-bridge.test.js
@@ -14,10 +14,12 @@ describe('Python Bridge', () => {
         ? jest.fn().mockRejectedValue(venvError)
         : jest.fn().mockResolvedValue('/mock/venv/python'),
     }));
+    const runPythonBridge = bridgeError
+      ? jest.fn().mockRejectedValue(bridgeError)
+      : jest.fn().mockResolvedValue(bridgeResult);
     jest.unstable_mockModule('../lib/python-runner.js', () => ({
-      runPythonBridge: bridgeError
-        ? jest.fn().mockRejectedValue(bridgeError)
-        : jest.fn().mockResolvedValue(bridgeResult),
+      runPythonBridge,
+      LONG_BRIDGE_TIMEOUT_MS: 2400000,
     }));
     jest.unstable_mockModule('child_process', () => ({
       spawn: jest.fn(() => {
@@ -25,13 +27,13 @@ describe('Python Bridge', () => {
       }),
     }));
 
-    return import('../lib/python-bridge.js');
+    return { pythonBridge: await import('../lib/python-bridge.js'), runPythonBridge };
   }
 
   test('uses the owned runner instead of creating an unmanaged subprocess', async () => {
     // Mutation caught: replacing runPythonBridge with a direct child_process.spawn
     // bypasses timeout, abort, registry, and process-tree cleanup.
-    const pythonBridge = await setup({
+    const { pythonBridge } = await setup({
       bridgeResult: [JSON.stringify({ success: true, data: 'owned' })],
     });
 
@@ -41,7 +43,7 @@ describe('Python Bridge', () => {
   });
 
   test('parses a successful result from the owned runner', async () => {
-    const pythonBridge = await setup();
+    const { pythonBridge } = await setup();
 
     await expect(
       pythonBridge.callPythonFunction('test_function', ['arg1', 'arg2']),
@@ -54,7 +56,7 @@ describe('Python Bridge', () => {
       stderr: 'Python error message',
       stdout: '',
     });
-    const pythonBridge = await setup({ bridgeError });
+    const { pythonBridge } = await setup({ bridgeError });
 
     await expect(pythonBridge.callPythonFunction('test_function', ['arg1'])).rejects.toThrow(
       'Python process exited with code 1: Python error message. Raw stdout:',
@@ -75,7 +77,7 @@ describe('Python Bridge', () => {
       })}`,
       stdout: '',
     });
-    const pythonBridge = await setup({ bridgeError });
+    const { pythonBridge } = await setup({ bridgeError });
 
     const error = await pythonBridge.callPythonFunction('download_book', {}).catch((err) => err);
 
@@ -84,7 +86,7 @@ describe('Python Bridge', () => {
   });
 
   test('preserves the public JSON parse error shape', async () => {
-    const pythonBridge = await setup({ bridgeResult: ['Invalid JSON{'] });
+    const { pythonBridge } = await setup({ bridgeResult: ['Invalid JSON{'] });
 
     await expect(pythonBridge.callPythonFunction('test_function', [])).rejects.toThrow(
       /^Failed to parse Python result JSON: .*?\. Raw output: Invalid JSON\{\. Stderr: $/,
@@ -92,10 +94,37 @@ describe('Python Bridge', () => {
   });
 
   test('propagates managed-Python setup failures without spawning', async () => {
-    const pythonBridge = await setup({ venvError: new Error('Failed to get venv path') });
+    const { pythonBridge } = await setup({ venvError: new Error('Failed to get venv path') });
 
     await expect(pythonBridge.callPythonFunction('test_function', [])).rejects.toThrow(
       'Failed to get venv path',
     );
+  });
+
+  test.each(['download_book', 'process_document'])(
+    'uses the long bridge default for %s',
+    async (functionName) => {
+      const { pythonBridge, runPythonBridge } = await setup();
+
+      await pythonBridge.callPythonFunction(functionName, {});
+
+      expect(runPythonBridge.mock.calls[0][2].timeoutMs).toBe(2400000);
+    },
+  );
+
+  test('leaves ordinary bridge calls on the runner default', async () => {
+    const { pythonBridge, runPythonBridge } = await setup();
+
+    await pythonBridge.callPythonFunction('search', {});
+
+    expect(runPythonBridge.mock.calls[0][2].timeoutMs).toBeUndefined();
+  });
+
+  test('preserves an explicit timeout override for a long-running call', async () => {
+    const { pythonBridge, runPythonBridge } = await setup();
+
+    await pythonBridge.callPythonFunction('download_book', {}, { timeoutMs: 1234 });
+
+    expect(runPythonBridge.mock.calls[0][2].timeoutMs).toBe(1234);
   });
 });

--- a/__tests__/python-bridge.test.js
+++ b/__tests__/python-bridge.test.js
@@ -61,6 +61,28 @@ describe('Python Bridge', () => {
     );
   });
 
+  test('preserves a structured provider envelope on non-zero exit', async () => {
+    const details = {
+      operation: 'download',
+      failures: [{ provider: 'libgen', host: 'libgen.li', reason: 'connect_timeout' }],
+    };
+    const bridgeError = Object.assign(new Error('process exited with code 1'), {
+      exitCode: 1,
+      stderr: `diagnostic\n${JSON.stringify({
+        error: 'download failed on every source',
+        type: 'AllSourcesFailedError',
+        details,
+      })}`,
+      stdout: '',
+    });
+    const pythonBridge = await setup({ bridgeError });
+
+    const error = await pythonBridge.callPythonFunction('download_book', {}).catch((err) => err);
+
+    expect(error.context.details).toEqual(details);
+    expect(error.retryable).toBe(false);
+  });
+
   test('preserves the public JSON parse error shape', async () => {
     const pythonBridge = await setup({ bridgeResult: ['Invalid JSON{'] });
 

--- a/__tests__/python-runner.test.js
+++ b/__tests__/python-runner.test.js
@@ -29,6 +29,7 @@ const maybe = PYTHON ? describe : describe.skip;
 
 let tmpDir;
 let runner;
+let baselineProcessListeners;
 
 /** True if the OS still knows about this pid. */
 function isAlive(pid) {
@@ -53,11 +54,19 @@ async function waitFor(predicate, timeoutMs = 8000) {
 maybe('python-runner', () => {
   beforeEach(async () => {
     jest.resetModules();
+    baselineProcessListeners = new Map(
+      ['exit', 'SIGINT', 'SIGTERM'].map((event) => [event, new Set(process.rawListeners(event))]),
+    );
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zlib-runner-'));
     runner = await import('../lib/python-runner.js');
   });
 
   afterEach(() => {
+    for (const [event, baseline] of baselineProcessListeners) {
+      for (const listener of process.rawListeners(event)) {
+        if (!baseline.has(listener)) process.removeListener(event, listener);
+      }
+    }
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -197,6 +206,42 @@ maybe('python-runner', () => {
       if (descendantPid > 0 && isAlive(descendantPid)) {
         process.kill(descendantPid, 'SIGKILL');
       }
+    }
+  });
+
+  test('a bridge that ignores SIGTERM is force-killed after the grace period', async () => {
+    if (process.platform === 'win32') return;
+
+    const pidFile = path.join(tmpDir, 'ignores-term.pid');
+    const name = script(
+      'ignores-term.py',
+      [
+        'import os, pathlib, signal, time',
+        'signal.signal(signal.SIGTERM, signal.SIG_IGN)',
+        `pathlib.Path(${JSON.stringify(pidFile)}).write_text(str(os.getpid()))`,
+        'time.sleep(600)',
+        '',
+      ].join('\n'),
+    );
+    let pid = -1;
+
+    const error = await runner
+      .runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { timeoutMs: 300, label: 'sigkill-escalation-test' },
+      )
+      .catch((err) => err);
+
+    try {
+      expect(error.code).toBe('TIMEOUT');
+      expect(await waitFor(() => fs.existsSync(pidFile))).toBe(true);
+      pid = Number(fs.readFileSync(pidFile, 'utf8'));
+      expect(pid).toBeGreaterThan(0);
+      expect(isAlive(pid)).toBe(true);
+      expect(await waitFor(() => !isAlive(pid), runner.KILL_GRACE_MS + 3000)).toBe(true);
+    } finally {
+      if (pid > 0 && isAlive(pid)) process.kill(pid, 'SIGKILL');
     }
   });
 

--- a/__tests__/python-runner.test.js
+++ b/__tests__/python-runner.test.js
@@ -538,13 +538,18 @@ describe('python-runner budget configuration', () => {
     });
 
     expect(mod.DEFAULT_BRIDGE_TIMEOUT_MS).toBe(240000);
-    expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBe(1800000);
+    expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBe(2400000);
     expect(mod.KILL_GRACE_MS).toBe(3000);
   });
 
   test('honours a valid override', async () => {
     const mod = await importWith({ PYTHON_BRIDGE_TIMEOUT: '90000' });
     expect(mod.DEFAULT_BRIDGE_TIMEOUT_MS).toBe(90000);
+  });
+
+  test('honours a valid long-operation override', async () => {
+    const mod = await importWith({ PYTHON_BRIDGE_LONG_TIMEOUT: '2700000' });
+    expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBe(2700000);
   });
 
   // A malformed value must never SHORTEN the budget. parseInt is not enough of
@@ -574,7 +579,7 @@ describe('python-runner budget configuration', () => {
       });
 
       expect(mod.DEFAULT_BRIDGE_TIMEOUT_MS).toBe(240000);
-      expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBe(1800000);
+      expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBe(2400000);
       expect(mod.KILL_GRACE_MS).toBe(3000);
     },
   );
@@ -587,5 +592,22 @@ describe('python-runner budget configuration', () => {
       PYTHON_BRIDGE_LONG_TIMEOUT: undefined,
     });
     expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBeGreaterThan(mod.DEFAULT_BRIDGE_TIMEOUT_MS);
+  });
+
+  test('the long default covers resolution, transfer, OCR, and finalization', async () => {
+    const mod = await importWith({ PYTHON_BRIDGE_LONG_TIMEOUT: undefined });
+
+    const libgenResolutionSeconds = 3 * (2 * 5 + 45);
+    const transferSeconds = 1500;
+    const ocrSeconds = 600;
+    const finalizationHeadroomSeconds = 135;
+
+    expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBe(
+      (libgenResolutionSeconds +
+        transferSeconds +
+        ocrSeconds +
+        finalizationHeadroomSeconds) *
+        1000,
+    );
   });
 });

--- a/__tests__/python-runner.test.js
+++ b/__tests__/python-runner.test.js
@@ -2,7 +2,8 @@ import { jest, describe, beforeEach, afterEach, test, expect } from '@jest/globa
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawn } from 'child_process';
+import { pathToFileURL } from 'url';
 
 jest.setTimeout(30000);
 
@@ -53,6 +54,16 @@ async function waitFor(predicate, timeoutMs = 8000) {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   return predicate();
+}
+
+/** Observe child exit without missing an event that fired before registration. */
+function waitForExit(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolve) => {
+    child.once('exit', (code, signal) => resolve({ code, signal }));
+  });
 }
 
 maybe('python-runner', () => {
@@ -333,6 +344,165 @@ maybe('python-runner', () => {
       expect(await waitFor(() => !isAlive(pid), runner.KILL_GRACE_MS + 3000)).toBe(true);
     } finally {
       if (pid > 0 && isAlive(pid)) process.kill(pid, 'SIGKILL');
+    }
+  });
+
+  test('installed signal hooks reject new work and accelerate cleanup on a second signal', async () => {
+    if (process.platform === 'win32') return;
+
+    const pidFile = path.join(tmpDir, 'in-process-shutdown.pid');
+    const name = script(
+      'in-process-shutdown.py',
+      [
+        'import os, pathlib, signal, time',
+        'signal.signal(signal.SIGTERM, signal.SIG_IGN)',
+        `pathlib.Path(${JSON.stringify(pidFile)}).write_text(str(os.getpid()))`,
+        'time.sleep(600)',
+        '',
+      ].join('\n'),
+    );
+    const run = runner
+      .runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { timeoutMs: 60000, label: 'in-process-shutdown-test' },
+      )
+      .catch((error) => error);
+    const realKill = process.kill.bind(process);
+    const selfSignals = [];
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (pid === process.pid) {
+        selfSignals.push(signal);
+        return true;
+      }
+      return realKill(pid, signal);
+    });
+    let pid = -1;
+
+    try {
+      expect(await waitFor(() => fs.existsSync(pidFile))).toBe(true);
+      pid = Number(fs.readFileSync(pidFile, 'utf8'));
+
+      process.emit('SIGTERM', 'SIGTERM');
+      await expect(
+        runner.runPythonBridge(name, {
+          mode: 'text',
+          pythonPath: PYTHON,
+          scriptPath: tmpDir,
+        }),
+      ).rejects.toThrow(/shutting down/i);
+      expect(isAlive(pid)).toBe(true);
+
+      process.emit('SIGTERM', 'SIGTERM');
+      expect(await waitFor(() => !isAlive(pid))).toBe(true);
+      expect(await waitFor(() => selfSignals.includes('SIGTERM'))).toBe(true);
+      expect(runner.liveChildCount()).toBe(0);
+      await run;
+    } finally {
+      killSpy.mockRestore();
+      if (pid > 0 && isAlive(pid)) realKill(pid, 'SIGKILL');
+    }
+  });
+
+  test('server shutdown waits for TERM-grace-KILL and rejects new bridge work', async () => {
+    if (process.platform === 'win32') return;
+
+    const descendantFile = path.join(tmpDir, 'shutdown-descendant.pid');
+    const rejectionFile = path.join(tmpDir, 'shutdown-rejection.txt');
+    script(
+      'shutdown-tree.py',
+      [
+        'import pathlib, subprocess, sys, time',
+        'child = subprocess.Popen([sys.executable, "-c", "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(600)"], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, close_fds=True)',
+        `pathlib.Path(${JSON.stringify(descendantFile)}).write_text(str(child.pid))`,
+        'time.sleep(600)',
+        '',
+      ].join('\n'),
+    );
+    script('shutdown-new-work.py', 'print("must not spawn")\n');
+    const runnerUrl = pathToFileURL(path.resolve('dist/lib/python-runner.js')).href;
+    const childCode = [
+      `import * as runner from ${JSON.stringify(runnerUrl)};`,
+      `import fs from 'fs';`,
+      `const options = { mode: 'text', pythonPath: ${JSON.stringify(PYTHON)}, scriptPath: ${JSON.stringify(tmpDir)} };`,
+      `runner.runPythonBridge('shutdown-tree.py', options, { timeoutMs: 60000 }).catch(() => {});`,
+      `while (!fs.existsSync(${JSON.stringify(descendantFile)})) await new Promise(r => setTimeout(r, 10));`,
+      `process.on('SIGTERM', async () => {`,
+      `  try { await runner.runPythonBridge('shutdown-new-work.py', options); }`,
+      `  catch (error) { fs.writeFileSync(${JSON.stringify(rejectionFile)}, error.message); }`,
+      `});`,
+      `process.kill(process.pid, 'SIGTERM');`,
+      `await new Promise(() => {});`,
+    ].join('\n');
+    const node = spawn(process.execPath, ['--input-type=module', '--eval', childCode], {
+      env: { ...process.env, PYTHON_BRIDGE_KILL_GRACE: '150' },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let descendantPid = -1;
+
+    try {
+      expect(await waitFor(() => fs.existsSync(descendantFile))).toBe(true);
+      descendantPid = Number(fs.readFileSync(descendantFile, 'utf8'));
+
+      const result = await waitForExit(node);
+
+      expect(result).toEqual({ code: null, signal: 'SIGTERM' });
+      expect(await waitFor(() => !isAlive(descendantPid), 3000)).toBe(true);
+      expect(fs.readFileSync(rejectionFile, 'utf8')).toMatch(/shutting down/i);
+    } finally {
+      if (node.exitCode === null && node.signalCode === null) node.kill('SIGKILL');
+      if (descendantPid > 0 && isAlive(descendantPid)) process.kill(descendantPid, 'SIGKILL');
+    }
+  });
+
+  test('a second shutdown signal skips the remaining grace period', async () => {
+    if (process.platform === 'win32') return;
+
+    const descendantFile = path.join(tmpDir, 'second-signal-descendant.pid');
+    script(
+      'second-signal-tree.py',
+      [
+        'import pathlib, signal, subprocess, sys, time',
+        'signal.signal(signal.SIGTERM, signal.SIG_IGN)',
+        'child = subprocess.Popen([sys.executable, "-c", "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(600)"], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, close_fds=True)',
+        `pathlib.Path(${JSON.stringify(descendantFile)}).write_text(str(child.pid))`,
+        'time.sleep(600)',
+        '',
+      ].join('\n'),
+    );
+    const runnerUrl = pathToFileURL(path.resolve('dist/lib/python-runner.js')).href;
+    const childCode = [
+      `import * as runner from ${JSON.stringify(runnerUrl)};`,
+      `import fs from 'fs';`,
+      `const options = { mode: 'text', pythonPath: ${JSON.stringify(PYTHON)}, scriptPath: ${JSON.stringify(tmpDir)} };`,
+      `runner.runPythonBridge('second-signal-tree.py', options, { timeoutMs: 60000 }).catch(() => {});`,
+      `while (!fs.existsSync(${JSON.stringify(descendantFile)})) await new Promise(r => setTimeout(r, 10));`,
+      `await new Promise(() => {});`,
+    ].join('\n');
+    const node = spawn(process.execPath, ['--input-type=module', '--eval', childCode], {
+      env: { ...process.env, PYTHON_BRIDGE_KILL_GRACE: '2000' },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let descendantPid = -1;
+
+    try {
+      expect(await waitFor(() => fs.existsSync(descendantFile))).toBe(true);
+      descendantPid = Number(fs.readFileSync(descendantFile, 'utf8'));
+      node.kill('SIGTERM');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(node.exitCode).toBeNull();
+      expect(node.signalCode).toBeNull();
+
+      const secondSignalAt = Date.now();
+      node.kill('SIGTERM');
+      const result = await waitForExit(node);
+
+      expect(result).toEqual({ code: null, signal: 'SIGTERM' });
+      expect(Date.now() - secondSignalAt).toBeLessThan(1000);
+      expect(await waitFor(() => !isAlive(descendantPid))).toBe(true);
+    } finally {
+      if (node.exitCode === null && node.signalCode === null) node.kill('SIGKILL');
+      if (descendantPid > 0 && isAlive(descendantPid)) process.kill(descendantPid, 'SIGKILL');
     }
   });
 

--- a/__tests__/python-runner.test.js
+++ b/__tests__/python-runner.test.js
@@ -290,10 +290,24 @@ describe('python-runner budget configuration', () => {
     expect(mod.DEFAULT_BRIDGE_TIMEOUT_MS).toBe(90000);
   });
 
-  // parseInt('abc') is NaN and setTimeout(fn, NaN) fires on the next tick, so
-  // a typo here would kill every bridge call instantly rather than loosen the
-  // budget. Falling back to the default is the only safe reading.
-  test.each([['abc'], ['0'], ['-1'], [''], ['   ']])(
+  // A malformed value must never SHORTEN the budget. parseInt is not enough of
+  // a guard on its own: it stops at the first character it cannot use, so
+  // '1.5' and '1e6' both yield 1 — a 1ms deadline that kills every bridge call
+  // instantly — and '240000abc' silently yields 240000. Falling back to the
+  // default is the only safe reading of any of these.
+  test.each([
+    ['abc'],
+    ['0'],
+    ['-1'],
+    [''],
+    ['   '],
+    ['1.5'],
+    ['1e6'],
+    ['240000abc'],
+    ['0x10'],
+    ['+240000'],
+    ['Infinity'],
+  ])(
     'falls back to the default for the nonsense value %p',
     async (raw) => {
       const mod = await importWith({

--- a/__tests__/python-runner.test.js
+++ b/__tests__/python-runner.test.js
@@ -91,9 +91,17 @@ maybe('python-runner', () => {
   test('kills the child when the wall-clock budget expires', async () => {
     // A script with no timeout of its own, standing in for the un-timed
     // requests.get inside libgen_api_enhanced.
-    const name = script('hang.py', 'import time\ntime.sleep(600)\n');
+    const pidFile = path.join(tmpDir, 'hang.pid');
+    const name = script(
+      'hang.py',
+      [
+        'import os, pathlib, time',
+        `pathlib.Path(${JSON.stringify(pidFile)}).write_text(str(os.getpid()))`,
+        'time.sleep(600)',
+        '',
+      ].join('\n'),
+    );
 
-    let capturedPid;
     const promise = runner
       .runPythonBridge(
         name,
@@ -102,9 +110,8 @@ maybe('python-runner', () => {
       )
       .catch((err) => err);
 
-    // Give the child a moment to exist so its pid can be captured.
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    capturedPid = lastSpawnedPid();
+    expect(await waitFor(() => fs.existsSync(pidFile))).toBe(true);
+    const capturedPid = Number(fs.readFileSync(pidFile, 'utf8'));
 
     const error = await promise;
 
@@ -261,6 +268,26 @@ maybe('python-runner', () => {
 
     expect(runner.liveChildCount()).toBe(before);
   });
+
+  test.each([Infinity, Number.NaN, 0, -1, 1.5])(
+    'falls back to the default budget for the invalid direct override %p',
+    async (timeoutMs) => {
+      // Mutation caught: passing timeoutMs straight to setTimeout makes these
+      // values fire after 1ms instead of using the finite default budget.
+      const name = script(
+        `invalid-timeout-${String(timeoutMs).replace(/\W/g, '_')}.py`,
+        'import time\ntime.sleep(0.05)\nprint("done")\n',
+      );
+
+      await expect(
+        runner.runPythonBridge(
+          name,
+          { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+          { timeoutMs, label: 'invalid-direct-timeout-test' },
+        ),
+      ).resolves.toEqual(['done']);
+    },
+  );
 
   test('killAllPythonChildren reaps children still running', async () => {
     const name = script('hang4.py', 'import time\ntime.sleep(600)\n');

--- a/__tests__/python-runner.test.js
+++ b/__tests__/python-runner.test.js
@@ -35,6 +35,10 @@ let baselineProcessListeners;
 function isAlive(pid) {
   try {
     process.kill(pid, 0);
+    if (process.platform === 'linux') {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+      if (stat.slice(stat.lastIndexOf(')') + 2).startsWith('Z ')) return false;
+    }
     return true;
   } catch {
     return false;
@@ -169,7 +173,7 @@ maybe('python-runner', () => {
       'tree.py',
       [
         'import os, pathlib, subprocess, sys, time',
-        'child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(600)"])',
+        'child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(600)"], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, close_fds=True)',
         `pathlib.Path(${JSON.stringify(pidFile)}).write_text(f"{os.getpid()} {child.pid}")`,
         'time.sleep(600)',
         '',
@@ -216,6 +220,86 @@ maybe('python-runner', () => {
     }
   });
 
+  test('keeps a descendant-only process group owned after the bridge parent exits', async () => {
+    if (process.platform === 'win32') return;
+
+    const pidFile = path.join(tmpDir, 'descendant-only.pid');
+    const name = script(
+      'parent-exits-on-term.py',
+      [
+        'import pathlib, subprocess, sys, time',
+        'child = subprocess.Popen([sys.executable, "-c", "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(600)"], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, close_fds=True)',
+        `pathlib.Path(${JSON.stringify(pidFile)}).write_text(str(child.pid))`,
+        'time.sleep(600)',
+        '',
+      ].join('\n'),
+    );
+    let descendantPid = -1;
+
+    try {
+      const error = await runner
+        .runPythonBridge(
+          name,
+          { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+          { timeoutMs: 300, label: 'descendant-only-test' },
+        )
+        .catch((err) => err);
+      expect(await waitFor(() => fs.existsSync(pidFile))).toBe(true);
+      descendantPid = Number(fs.readFileSync(pidFile, 'utf8'));
+      expect(error.code).toBe('TIMEOUT');
+      expect(isAlive(descendantPid)).toBe(true);
+      expect(runner.liveChildCount()).toBe(1);
+
+      expect(runner.killAllPythonChildren('SIGKILL')).toBe(1);
+      expect(await waitFor(() => !isAlive(descendantPid))).toBe(true);
+      expect(await waitFor(() => runner.liveChildCount() === 0)).toBe(true);
+    } finally {
+      if (descendantPid > 0 && isAlive(descendantPid)) {
+        process.kill(descendantPid, 'SIGKILL');
+      }
+    }
+  });
+
+  test('automatically reaps a surviving descendant after a successful parent exit', async () => {
+    if (process.platform === 'win32') return;
+
+    const pidFile = path.join(tmpDir, 'successful-parent-descendant.pid');
+    const name = script(
+      'successful-parent-with-descendant.py',
+      [
+        'import pathlib, subprocess, sys',
+        'child = subprocess.Popen([sys.executable, "-c", "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(600)"], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, close_fds=True)',
+        `pathlib.Path(${JSON.stringify(pidFile)}).write_text(str(child.pid))`,
+        'print("complete")',
+        '',
+      ].join('\n'),
+    );
+    let descendantPid = -1;
+
+    try {
+      await expect(
+        runner.runPythonBridge(
+          name,
+          { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+          { timeoutMs: 60000, label: 'successful-parent-descendant-test' },
+        ),
+      ).resolves.toEqual(['complete']);
+      descendantPid = Number(fs.readFileSync(pidFile, 'utf8'));
+      expect(isAlive(descendantPid)).toBe(true);
+
+      expect(
+        await waitFor(
+          () => !isAlive(descendantPid) && runner.liveChildCount() === 0,
+          runner.KILL_GRACE_MS + 3000,
+        ),
+      ).toBe(true);
+    } finally {
+      if (descendantPid > 0 && isAlive(descendantPid)) {
+        process.kill(descendantPid, 'SIGKILL');
+      }
+    }
+  });
+
   test('a bridge that ignores SIGTERM is force-killed after the grace period', async () => {
     if (process.platform === 'win32') return;
 
@@ -249,6 +333,52 @@ maybe('python-runner', () => {
       expect(await waitFor(() => !isAlive(pid), runner.KILL_GRACE_MS + 3000)).toBe(true);
     } finally {
       if (pid > 0 && isAlive(pid)) process.kill(pid, 'SIGKILL');
+    }
+  });
+
+  test('keeps an unkillable process tree registered until it actually exits', async () => {
+    if (process.platform === 'win32') return;
+
+    const pidFile = path.join(tmpDir, 'survives-kill.pid');
+    const name = script(
+      'survives-kill.py',
+      [
+        'import os, pathlib, signal, time',
+        'signal.signal(signal.SIGTERM, signal.SIG_IGN)',
+        `pathlib.Path(${JSON.stringify(pidFile)}).write_text(str(os.getpid()))`,
+        'time.sleep(600)',
+        '',
+      ].join('\n'),
+    );
+    const realKill = process.kill.bind(process);
+    let pid = -1;
+    let killSpy;
+    const promise = runner
+      .runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { timeoutMs: 300, label: 'surviving-tree-test' },
+      )
+      .catch((err) => err);
+
+    try {
+      expect(await waitFor(() => fs.existsSync(pidFile))).toBe(true);
+      pid = Number(fs.readFileSync(pidFile, 'utf8'));
+      killSpy = jest.spyOn(process, 'kill').mockImplementation((target, signal) => {
+        if (target === -pid && signal === 'SIGKILL') return true;
+        return realKill(target, signal);
+      });
+
+      const error = await promise;
+      expect(error.code).toBe('TIMEOUT');
+      await new Promise((resolve) => setTimeout(resolve, runner.KILL_GRACE_MS + 300));
+
+      expect(isAlive(pid)).toBe(true);
+      expect(runner.liveChildCount()).toBe(1);
+    } finally {
+      killSpy?.mockRestore();
+      if (pid > 0 && isAlive(pid)) realKill(-pid, 'SIGKILL');
+      await waitFor(() => runner.liveChildCount() === 0);
     }
   });
 

--- a/__tests__/python-runner.test.js
+++ b/__tests__/python-runner.test.js
@@ -1,0 +1,320 @@
+import { jest, describe, beforeEach, afterEach, test, expect } from '@jest/globals';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+jest.setTimeout(30000);
+
+/**
+ * Tests for the bounded, killable bridge runner.
+ *
+ * These spawn a real Python child rather than mocking PythonShell: the whole
+ * point of the module is what happens to an operating-system process when its
+ * caller gives up, and a mock cannot show that. The bug being guarded against
+ * left three python_bridge.py processes alive on dionysus 2026-08-11, the
+ * oldest 9h10m old, after the sessions that started them had exited.
+ */
+
+const PYTHON = ['python3', 'python'].find((candidate) => {
+  try {
+    execFileSync(candidate, ['-c', 'pass'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+});
+
+const maybe = PYTHON ? describe : describe.skip;
+
+let tmpDir;
+let runner;
+
+/** True if the OS still knows about this pid. */
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Wait until `predicate()` holds, or the deadline passes. */
+async function waitFor(predicate, timeoutMs = 8000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return predicate();
+}
+
+maybe('python-runner', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zlib-runner-'));
+    runner = await import('../lib/python-runner.js');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Write a throwaway script into the temp script dir. */
+  function script(name, body) {
+    fs.writeFileSync(path.join(tmpDir, name), body);
+    return name;
+  }
+
+  test('returns the child stdout lines on success', async () => {
+    const name = script('ok.py', 'print("hello")\nprint("world")\n');
+
+    const lines = await runner.runPythonBridge(name, {
+      mode: 'text',
+      pythonPath: PYTHON,
+      scriptPath: tmpDir,
+    });
+
+    expect(lines).toEqual(['hello', 'world']);
+  });
+
+  test('kills the child when the wall-clock budget expires', async () => {
+    // A script with no timeout of its own, standing in for the un-timed
+    // requests.get inside libgen_api_enhanced.
+    const name = script('hang.py', 'import time\ntime.sleep(600)\n');
+
+    let capturedPid;
+    const promise = runner
+      .runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { timeoutMs: 500, label: 'hang-test' },
+      )
+      .catch((err) => err);
+
+    // Give the child a moment to exist so its pid can be captured.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    capturedPid = lastSpawnedPid();
+
+    const error = await promise;
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.code).toBe('TIMEOUT');
+    expect(error.message).toMatch(/hang-test/);
+    expect(capturedPid).toBeGreaterThan(0);
+    expect(await waitFor(() => !isAlive(capturedPid))).toBe(true);
+  });
+
+  test('a timed-out call is fatal, so the retry layer does not multiply it', async () => {
+    const { isRetryableError } = await import('../lib/retry-manager.js');
+    const name = script('hang2.py', 'import time\ntime.sleep(600)\n');
+
+    const error = await runner
+      .runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { timeoutMs: 300 },
+      )
+      .catch((err) => err);
+
+    expect(error.fatal).toBe(true);
+    expect(isRetryableError(error)).toBe(false);
+  });
+
+  test('an abort signal kills the child instead of orphaning it', async () => {
+    const name = script('hang3.py', 'import time\ntime.sleep(600)\n');
+    const controller = new AbortController();
+
+    const promise = runner
+      .runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { timeoutMs: 60000, signal: controller.signal, label: 'abort-test' },
+      )
+      .catch((err) => err);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const pid = lastSpawnedPid();
+    controller.abort();
+
+    const error = await promise;
+
+    expect(error.code).toBe('TIMEOUT');
+    expect(error.message).toMatch(/aborted/);
+    expect(await waitFor(() => !isAlive(pid))).toBe(true);
+  });
+
+  test('does not spawn anything when the caller has already aborted', async () => {
+    const name = script('never.py', 'print("should not run")\n');
+    const controller = new AbortController();
+    controller.abort();
+
+    const before = runner.liveChildCount();
+    await expect(
+      runner.runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow(/aborted before it started/);
+
+    expect(runner.liveChildCount()).toBe(before);
+  });
+
+  test('killAllPythonChildren reaps children still running', async () => {
+    const name = script('hang4.py', 'import time\ntime.sleep(600)\n');
+
+    const promise = runner
+      .runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { timeoutMs: 60000 },
+      )
+      .catch((err) => err);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const pid = lastSpawnedPid();
+    expect(runner.liveChildCount()).toBe(1);
+
+    const killed = runner.killAllPythonChildren('SIGKILL');
+
+    expect(killed).toBe(1);
+    expect(await waitFor(() => !isAlive(pid))).toBe(true);
+    await promise;
+    expect(runner.liveChildCount()).toBe(0);
+  });
+
+  test('deregisters the child after a normal run', async () => {
+    const name = script('quick.py', 'print("{}")\n');
+
+    await runner.runPythonBridge(name, {
+      mode: 'text',
+      pythonPath: PYTHON,
+      scriptPath: tmpDir,
+    });
+
+    expect(runner.liveChildCount()).toBe(0);
+  });
+
+  test('captures the child stderr in the failure', async () => {
+    const name = script(
+      'fails.py',
+      'import sys\nsys.stderr.write("boom on stderr\\n")\nsys.exit(1)\n',
+    );
+
+    const error = await runner
+      .runPythonBridge(name, {
+        mode: 'text',
+        pythonPath: PYTHON,
+        scriptPath: tmpDir,
+      })
+      .catch((err) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error.stderr)).toContain('boom on stderr');
+  });
+
+  test('killAllPythonChildren is a no-op with nothing running', () => {
+    expect(runner.liveChildCount()).toBe(0);
+    expect(runner.killAllPythonChildren()).toBe(0);
+  });
+
+  test('installExitHooks is idempotent', () => {
+    const before = process.listenerCount('exit');
+
+    runner.installExitHooks();
+    runner.installExitHooks();
+    runner.installExitHooks();
+
+    expect(process.listenerCount('exit')).toBeLessThanOrEqual(before + 1);
+  });
+});
+
+/**
+ * The pid of the most recently spawned python child of this process.
+ *
+ * Read from the OS rather than from the runner, so the assertion is about a
+ * real process and not about bookkeeping that could itself be wrong.
+ */
+function lastSpawnedPid() {
+  try {
+    const out = execFileSync('pgrep', ['-P', String(process.pid)], {
+      encoding: 'utf8',
+    });
+    const pids = out
+      .split('\n')
+      .map((line) => parseInt(line.trim(), 10))
+      .filter((pid) => Number.isInteger(pid));
+    return pids.length > 0 ? pids[pids.length - 1] : -1;
+  } catch {
+    return -1;
+  }
+}
+
+/**
+ * Budget parsing, which needs no Python child: a fresh import per case, since
+ * the budgets are module-level constants read from the environment once.
+ */
+describe('python-runner budget configuration', () => {
+  const saved = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  /** Import the runner with the given env vars applied. */
+  async function importWith(env) {
+    jest.resetModules();
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return import('../lib/python-runner.js');
+  }
+
+  test('uses the documented defaults when unset', async () => {
+    const mod = await importWith({
+      PYTHON_BRIDGE_TIMEOUT: undefined,
+      PYTHON_BRIDGE_LONG_TIMEOUT: undefined,
+      PYTHON_BRIDGE_KILL_GRACE: undefined,
+    });
+
+    expect(mod.DEFAULT_BRIDGE_TIMEOUT_MS).toBe(240000);
+    expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBe(1800000);
+    expect(mod.KILL_GRACE_MS).toBe(3000);
+  });
+
+  test('honours a valid override', async () => {
+    const mod = await importWith({ PYTHON_BRIDGE_TIMEOUT: '90000' });
+    expect(mod.DEFAULT_BRIDGE_TIMEOUT_MS).toBe(90000);
+  });
+
+  // parseInt('abc') is NaN and setTimeout(fn, NaN) fires on the next tick, so
+  // a typo here would kill every bridge call instantly rather than loosen the
+  // budget. Falling back to the default is the only safe reading.
+  test.each([['abc'], ['0'], ['-1'], [''], ['   ']])(
+    'falls back to the default for the nonsense value %p',
+    async (raw) => {
+      const mod = await importWith({
+        PYTHON_BRIDGE_TIMEOUT: raw,
+        PYTHON_BRIDGE_LONG_TIMEOUT: raw,
+        PYTHON_BRIDGE_KILL_GRACE: raw,
+      });
+
+      expect(mod.DEFAULT_BRIDGE_TIMEOUT_MS).toBe(240000);
+      expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBe(1800000);
+      expect(mod.KILL_GRACE_MS).toBe(3000);
+    },
+  );
+
+  test('the long budget exceeds the ordinary one by default', async () => {
+    // A download or an OCR pass is slow, not hung. Sharing the search budget
+    // would turn a slow success into a killed subprocess.
+    const mod = await importWith({
+      PYTHON_BRIDGE_TIMEOUT: undefined,
+      PYTHON_BRIDGE_LONG_TIMEOUT: undefined,
+    });
+    expect(mod.LONG_BRIDGE_TIMEOUT_MS).toBeGreaterThan(mod.DEFAULT_BRIDGE_TIMEOUT_MS);
+  });
+});

--- a/__tests__/python-runner.test.js
+++ b/__tests__/python-runner.test.js
@@ -145,6 +145,61 @@ maybe('python-runner', () => {
     expect(await waitFor(() => !isAlive(pid))).toBe(true);
   });
 
+  test('an abort signal kills descendants spawned by the bridge', async () => {
+    if (process.platform === 'win32') return;
+
+    const pidFile = path.join(tmpDir, 'tree.pids');
+    const name = script(
+      'tree.py',
+      [
+        'import os, pathlib, subprocess, sys, time',
+        'child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(600)"])',
+        `pathlib.Path(${JSON.stringify(pidFile)}).write_text(f"{os.getpid()} {child.pid}")`,
+        'time.sleep(600)',
+        '',
+      ].join('\n'),
+    );
+    const controller = new AbortController();
+    let parentPid = -1;
+    let descendantPid = -1;
+
+    const promise = runner
+      .runPythonBridge(
+        name,
+        { mode: 'text', pythonPath: PYTHON, scriptPath: tmpDir },
+        { timeoutMs: 60000, signal: controller.signal, label: 'tree-abort-test' },
+      )
+      .catch((err) => err);
+
+    try {
+      expect(await waitFor(() => fs.existsSync(pidFile))).toBe(true);
+      [parentPid, descendantPid] = fs
+        .readFileSync(pidFile, 'utf8')
+        .split(' ')
+        .map(Number);
+      expect(parentPid).toBeGreaterThan(0);
+      expect(descendantPid).toBeGreaterThan(0);
+      expect(isAlive(descendantPid)).toBe(true);
+
+      controller.abort();
+      const error = await promise;
+
+      expect(error.code).toBe('TIMEOUT');
+      expect(await waitFor(() => !isAlive(parentPid))).toBe(true);
+      expect(await waitFor(() => !isAlive(descendantPid), 1500)).toBe(true);
+    } finally {
+      // RED leaves the grandchild alive; do not leak the regression fixture.
+      if (!controller.signal.aborted) controller.abort();
+      await promise;
+      if (parentPid > 0 && isAlive(parentPid)) {
+        process.kill(parentPid, 'SIGKILL');
+      }
+      if (descendantPid > 0 && isAlive(descendantPid)) {
+        process.kill(descendantPid, 'SIGKILL');
+      }
+    }
+  });
+
   test('does not spawn anything when the caller has already aborted', async () => {
     const name = script('never.py', 'print("should not run")\n');
     const controller = new AbortController();

--- a/__tests__/python/conftest.py
+++ b/__tests__/python/conftest.py
@@ -50,3 +50,31 @@ def _clear_pymupdf_cache():
         _clear_textpage_cache()
     except ImportError:
         pass
+
+
+@pytest.fixture(autouse=True)
+def _no_preflight_probes(request, monkeypatch):
+    """Keep the multi-source pre-flight probe off the network in unit tests.
+
+    The source adapters probe DNS and TCP before searching, so a test that
+    mocks only the HTTP client would otherwise make a real connection to
+    whatever hostname its fixture config names — slow, flaky, and dependent on
+    the machine's egress. Tests that mean to exercise the probe itself opt back
+    in with `@pytest.mark.real_preflight`.
+    """
+    if request.node.get_closest_marker("real_preflight"):
+        return
+    try:
+        from lib.sources import net
+    except ImportError:
+        return
+
+    async def _skip(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(net, "probe_host", _skip)
+    for module_name in ("lib.sources.annas", "lib.sources.libgen"):
+        module = sys.modules.get(module_name)
+        if module is not None and hasattr(module, "probe_host"):
+            monkeypatch.setattr(module, "probe_host", _skip)
+    net.reset_probe_cache()

--- a/__tests__/python/test_annas_adapter.py
+++ b/__tests__/python/test_annas_adapter.py
@@ -15,6 +15,7 @@ from bs4 import BeautifulSoup
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from lib.sources.models import SourceType
+from lib.sources.errors import ProviderConfigurationError
 
 pytestmark = pytest.mark.unit
 
@@ -492,6 +493,61 @@ class TestSecretKeyHostAllowlist:
             result = await adapter.get_download_url("abc123def456")
 
         assert result.url == MOCK_FAST_DOWNLOAD_RESPONSE["download_url"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_rejected_key_is_a_permanent_configuration_error(self, status):
+        """Only auth failures from the trusted keyed endpoint are permanent."""
+        import httpx
+
+        from lib.sources.annas import AnnasArchiveAdapter
+        from lib.sources.config import SourceConfig
+
+        adapter = AnnasArchiveAdapter(
+            SourceConfig(
+                annas_secret_key="rejected-key",
+                annas_base_url="https://annas-archive.gl",
+            )
+        )
+        request = httpx.Request(
+            "GET", "https://annas-archive.gl/dyn/api/fast_download.json"
+        )
+        mock_client = AsyncMock()
+        mock_client.get.return_value = httpx.Response(status, request=request)
+
+        with patch.object(adapter, "_get_client", return_value=mock_client):
+            with pytest.raises(ProviderConfigurationError) as excinfo:
+                await adapter.get_download_url("abc123def456")
+
+        assert excinfo.value.provider == "annas"
+        assert excinfo.value.reason == "configuration_error"
+
+    @pytest.mark.asyncio
+    async def test_non_auth_fast_download_status_keeps_http_classification(self):
+        """A 503 is provider health evidence, not a rejected credential."""
+        import httpx
+
+        from lib.sources.annas import AnnasArchiveAdapter
+        from lib.sources.config import SourceConfig
+        from lib.sources.errors import ProviderResponseError
+
+        adapter = AnnasArchiveAdapter(
+            SourceConfig(
+                annas_secret_key="test-key",
+                annas_base_url="https://annas-archive.gl",
+            )
+        )
+        request = httpx.Request(
+            "GET", "https://annas-archive.gl/dyn/api/fast_download.json"
+        )
+        mock_client = AsyncMock()
+        mock_client.get.return_value = httpx.Response(503, request=request)
+
+        with patch.object(adapter, "_get_client", return_value=mock_client):
+            with pytest.raises(ProviderResponseError) as excinfo:
+                await adapter.get_download_url("abc123def456")
+
+        assert excinfo.value.reason == "http_error"
 
     @pytest.mark.asyncio
     async def test_search_still_allowed_on_unknown_host(self):

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -84,8 +84,14 @@ class TestLibgenAdapterSearch:
             assert results == []
 
     @pytest.mark.asyncio
-    async def test_search_uses_asyncio_to_thread(self, config, mock_book):
-        """Search should wrap sync call in asyncio.to_thread()."""
+    async def test_search_runs_under_a_wall_clock_budget(self, config, mock_book):
+        """Search must go through run_bounded, not asyncio.to_thread.
+
+        libgen_api_enhanced calls requests.get with no timeout, and
+        asyncio.to_thread's workers are joined at interpreter exit — together
+        that kept whole bridge processes alive for hours after their MCP call
+        was gone. The blocking call has to run somewhere it can be abandoned.
+        """
         from lib.sources.libgen import LibgenAdapter
 
         adapter = LibgenAdapter(config)
@@ -95,17 +101,39 @@ class TestLibgenAdapterSearch:
             mock_instance.search_title.return_value = [mock_book]
             mock_search_class.return_value = mock_instance
 
-            with patch("lib.sources.libgen.asyncio.to_thread") as mock_to_thread:
-                # Make to_thread actually call the function
-                async def call_func(func, *args, **kwargs):
-                    return func(*args, **kwargs)
+            with patch("lib.sources.libgen.run_bounded") as mock_run_bounded:
 
-                mock_to_thread.side_effect = call_func
+                async def call_func(func, timeout, **kwargs):
+                    call_func.timeout = timeout
+                    return func()
+
+                mock_run_bounded.side_effect = call_func
 
                 await adapter.search("python")
 
-                # Verify to_thread was called
-                mock_to_thread.assert_called_once()
+                mock_run_bounded.assert_called_once()
+                assert call_func.timeout == config.total_timeout
+
+    @pytest.mark.asyncio
+    async def test_search_does_not_use_asyncio_to_thread(self, config, mock_book):
+        """asyncio.to_thread must not reappear in the search path.
+
+        Regression guard for the orphaned-process bug: to_thread's pool threads
+        are non-daemon, so an abandoned request keeps the interpreter alive.
+        """
+        from lib.sources.libgen import LibgenAdapter
+
+        adapter = LibgenAdapter(config)
+
+        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
+            mock_instance = MagicMock()
+            mock_instance.search_title.return_value = [mock_book]
+            mock_search_class.return_value = mock_instance
+
+            with patch("asyncio.to_thread") as mock_to_thread:
+                await adapter.search("python")
+
+            mock_to_thread.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_search_handles_missing_attributes(self, config):

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -368,7 +368,7 @@ class TestLibgenAdapterDownload:
 
     @pytest.mark.asyncio
     async def test_resolution_walk_obeys_each_mirrors_total_deadline(self, adapter):
-        """A trickling CDN must not defer failure to the 30-minute bridge budget."""
+        """A trickling CDN must not defer failure to the outer bridge budget."""
         adapter.config.total_timeout = 0.02
 
         async def trickle(*_args, **_kwargs):

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -282,6 +282,39 @@ class TestLibgenAdapterDownload:
         assert result.url.startswith("https://libgen.vg/")
 
     @pytest.mark.asyncio
+    async def test_range_ignoring_probe_stops_after_the_inspection_window(
+        self, adapter
+    ):
+        """A 200 probe must not buffer the complete book before accepting it."""
+
+        class LargeBookStream(httpx.AsyncByteStream):
+            def __init__(self):
+                self.chunks_read = 0
+
+            async def __aiter__(self):
+                for index in range(64):
+                    self.chunks_read += 1
+                    prefix = b"%PDF" if index == 0 else b"xxxx"
+                    yield prefix + (b"x" * 1020)
+
+        body = LargeBookStream()
+
+        def handler(request):
+            if "ads.php" in request.url.path:
+                return httpx.Response(200, text=ADS_PAGE_WITH_KEY)
+            return httpx.Response(
+                200,
+                stream=body,
+                headers={"content-type": "application/pdf"},
+            )
+
+        with self._patched_client(handler):
+            result = await adapter.get_download_url(MD5)
+
+        assert result.url.startswith("https://libgen.li/")
+        assert body.chunks_read <= 3
+
+    @pytest.mark.asyncio
     async def test_cdn_transport_failure_retains_its_host_and_reason(self, adapter):
         """A failed byte probe is transport evidence, not a protocol response."""
 

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 
 from lib.sources.config import SourceConfig
+from lib.sources.errors import AllSourcesFailedError, ProviderUnreachableError
 from lib.sources.models import SourceType
 
 pytestmark = pytest.mark.unit
@@ -281,6 +282,28 @@ class TestLibgenAdapterDownload:
         assert result.url.startswith("https://libgen.vg/")
 
     @pytest.mark.asyncio
+    async def test_cdn_transport_failure_retains_its_host_and_reason(self, adapter):
+        """A failed byte probe is transport evidence, not a protocol response."""
+
+        def handler(request):
+            if "ads.php" in request.url.path:
+                return httpx.Response(200, text=ADS_PAGE_WITH_KEY)
+            raise httpx.ConnectTimeout("cdn stalled", request=request)
+
+        with self._patched_client(handler):
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await adapter.get_download_url(MD5)
+
+        assert [failure.host for failure in excinfo.value.failures] == [
+            "libgen.li",
+            "libgen.vg",
+            "libgen.la",
+        ]
+        assert {failure.reason for failure in excinfo.value.failures} == {
+            "connect_timeout"
+        }
+
+    @pytest.mark.asyncio
     async def test_expired_key_bounce_is_treated_as_failure(self, adapter):
         """An expired key 307s back to ads.php rather than erroring."""
 
@@ -310,8 +333,31 @@ class TestLibgenAdapterDownload:
             return httpx.Response(200, text=ADS_PAGE_NO_KEY)
 
         with self._patched_client(handler):
-            with pytest.raises(ValueError, match="No LibGen mirror"):
+            with pytest.raises(AllSourcesFailedError, match="every source"):
                 await adapter.get_download_url(MD5)
+
+    @pytest.mark.asyncio
+    async def test_retains_each_unreachable_mirror_as_a_structured_failure(
+        self, adapter
+    ):
+        """A failed mirror walk must keep the host and stable reason per attempt."""
+
+        async def unreachable(mirror):
+            host = f"libgen.{mirror}"
+            raise ProviderUnreachableError("libgen", host, reason="connect_timeout")
+
+        with patch.object(adapter, "_preflight", side_effect=unreachable):
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await adapter.get_download_url(MD5)
+
+        assert [failure.host for failure in excinfo.value.failures] == [
+            "libgen.li",
+            "libgen.vg",
+            "libgen.la",
+        ]
+        assert {failure.reason for failure in excinfo.value.failures} == {
+            "connect_timeout"
+        }
 
     @pytest.mark.asyncio
     async def test_tries_configured_mirror_first_without_duplicates(self, adapter):
@@ -334,7 +380,7 @@ class TestLibgenAdapterDownload:
             patch.object(adapter, "_resolve_key", new=AsyncMock(return_value="KEY")),
             patch.object(adapter, "_serves_bytes", side_effect=trickle),
         ):
-            with pytest.raises(ValueError, match="No LibGen mirror"):
+            with pytest.raises(AllSourcesFailedError, match="every source"):
                 await asyncio.wait_for(adapter.get_download_url(MD5), timeout=0.2)
 
 

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -5,7 +5,8 @@ returning UnifiedBookResult with source=LIBGEN and wrapping sync
 LibgenSearch calls in asyncio.to_thread().
 """
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
@@ -318,6 +319,23 @@ class TestLibgenAdapterDownload:
         adapter.mirror = "vg"
 
         assert adapter._mirror_candidates() == ["vg", "li", "la"]
+
+    @pytest.mark.asyncio
+    async def test_resolution_walk_obeys_each_mirrors_total_deadline(self, adapter):
+        """A trickling CDN must not defer failure to the 30-minute bridge budget."""
+        adapter.config.total_timeout = 0.02
+
+        async def trickle(*_args, **_kwargs):
+            await asyncio.sleep(30)
+
+        with (
+            patch.object(adapter, "_preflight", new=AsyncMock(return_value=None)),
+            patch.object(adapter, "_rate_limit", new=AsyncMock(return_value=None)),
+            patch.object(adapter, "_resolve_key", new=AsyncMock(return_value="KEY")),
+            patch.object(adapter, "_serves_bytes", side_effect=trickle),
+        ):
+            with pytest.raises(ValueError, match="No LibGen mirror"):
+                await asyncio.wait_for(adapter.get_download_url(MD5), timeout=0.2)
 
 
 class TestLibgenAdapterRateLimiting:

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -8,6 +8,7 @@ reason, and an explicitly requested source is never silently swapped.
 """
 
 import asyncio
+import math
 import socket
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -57,12 +58,15 @@ class TestConfigTimeouts:
         assert config.connect_timeout > 0
         assert config.read_timeout > 0
         assert config.total_timeout > 0
+        assert config.download_timeout > config.total_timeout
+        assert math.isfinite(config.download_timeout)
         assert config.preflight_timeout > 0
 
     def test_env_overrides_are_honoured(self, monkeypatch):
         monkeypatch.setenv("BOOK_SOURCE_CONNECT_TIMEOUT", "3.5")
         monkeypatch.setenv("BOOK_SOURCE_READ_TIMEOUT", "12")
         monkeypatch.setenv("BOOK_SOURCE_TOTAL_TIMEOUT", "20")
+        monkeypatch.setenv("BOOK_SOURCE_DOWNLOAD_TIMEOUT", "900")
         monkeypatch.setenv("BOOK_SOURCE_PREFLIGHT", "false")
 
         config = get_source_config()
@@ -70,7 +74,21 @@ class TestConfigTimeouts:
         assert config.connect_timeout == 3.5
         assert config.read_timeout == 12.0
         assert config.total_timeout == 20.0
+        assert config.download_timeout == 900.0
         assert config.preflight_enabled is False
+
+    @pytest.mark.parametrize(
+        "bad", ["0", "-5", "abc", "", "inf", "Infinity", "1e999", "nan"]
+    )
+    def test_invalid_download_budget_falls_back_to_a_finite_default(
+        self, monkeypatch, bad
+    ):
+        monkeypatch.setenv("BOOK_SOURCE_DOWNLOAD_TIMEOUT", bad)
+
+        config = get_source_config()
+
+        assert config.download_timeout == 1500.0
+        assert math.isfinite(config.download_timeout)
 
     @pytest.mark.parametrize(
         "bad", ["0", "-5", "abc", "", "inf", "Infinity", "1e999", "nan"]

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -7,6 +7,7 @@ prevent a repeat — every path is bounded, every failure names its provider and
 reason, and an explicitly requested source is never silently swapped.
 """
 
+import asyncio
 import socket
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,6 +21,7 @@ from lib.sources.config import SourceConfig, get_source_config
 from lib.sources.errors import (
     AllSourcesFailedError,
     ProviderResponseError,
+    ProviderTimeoutError,
     ProviderUnreachableError,
 )
 from lib.sources.libgen import LibgenAdapter
@@ -70,13 +72,15 @@ class TestConfigTimeouts:
         assert config.total_timeout == 20.0
         assert config.preflight_enabled is False
 
-    @pytest.mark.parametrize("bad", ["0", "-5", "abc", ""])
+    @pytest.mark.parametrize(
+        "bad", ["0", "-5", "abc", "", "inf", "Infinity", "1e999", "nan"]
+    )
     def test_nonsense_falls_back_to_the_default_not_to_unbounded(
         self, monkeypatch, bad
     ):
         monkeypatch.setenv("BOOK_SOURCE_CONNECT_TIMEOUT", bad)
         config = get_source_config()
-        assert config.connect_timeout > 0
+        assert config.connect_timeout == 10.0
 
 
 class TestLibgenSearchIsBounded:
@@ -253,6 +257,30 @@ class TestAnnasSearchIsBounded:
 
         assert excinfo.value.reason == "http_error"
         assert excinfo.value.unreachable is False
+
+    @pytest.mark.asyncio
+    async def test_total_deadline_reason_survives_adapter_classification(
+        self, fast_config
+    ):
+        """The outer wall-clock timeout is already a fully attributed error."""
+        adapter = AnnasArchiveAdapter(fast_config)
+
+        async def trickle(*_args, **_kwargs):
+            await asyncio.sleep(30)
+
+        client = AsyncMock()
+        client.get.side_effect = trickle
+
+        with patch("lib.sources.annas.probe_host", new=AsyncMock(return_value=None)):
+            with patch.object(
+                adapter, "_get_client", new=AsyncMock(return_value=client)
+            ):
+                with pytest.raises(ProviderTimeoutError) as excinfo:
+                    await adapter.search("hegel")
+
+        assert excinfo.value.provider == "annas"
+        assert excinfo.value.host == "annas-archive.gl"
+        assert excinfo.value.reason == "search_timeout"
 
 
 class TestRouterSourceSelection:

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -1,0 +1,378 @@
+"""Adapter and router behaviour when a provider is unreachable.
+
+Regression suite for the 2026-08-11 hang: `search_multi_source` had no network
+deadline, so an unroutable LibGen mirror blocked the bridge indefinitely and
+left the Python process orphaned. These tests assert the three properties that
+prevent a repeat — every path is bounded, every failure names its provider and
+reason, and an explicitly requested source is never silently swapped.
+"""
+
+import socket
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lib.sources import net
+from lib.sources.annas import AnnasArchiveAdapter
+from lib.sources.config import SourceConfig, get_source_config
+from lib.sources.errors import (
+    AllSourcesFailedError,
+    ProviderResponseError,
+    ProviderUnreachableError,
+)
+from lib.sources.libgen import LibgenAdapter
+from lib.sources.models import SourceType, UnifiedBookResult
+from lib.sources.router import SourceRouter
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_cache():
+    net.reset_probe_cache()
+    yield
+    net.reset_probe_cache()
+
+
+@pytest.fixture
+def fast_config():
+    """Short budgets so a test that regresses fails quickly instead of hanging."""
+    return SourceConfig(
+        connect_timeout=0.2,
+        read_timeout=0.2,
+        total_timeout=0.3,
+        preflight_timeout=0.2,
+    )
+
+
+class TestConfigTimeouts:
+    """Timeouts must be configurable and can never resolve to 'no timeout'."""
+
+    def test_defaults_are_all_positive(self):
+        config = get_source_config()
+        assert config.connect_timeout > 0
+        assert config.read_timeout > 0
+        assert config.total_timeout > 0
+        assert config.preflight_timeout > 0
+
+    def test_env_overrides_are_honoured(self, monkeypatch):
+        monkeypatch.setenv("BOOK_SOURCE_CONNECT_TIMEOUT", "3.5")
+        monkeypatch.setenv("BOOK_SOURCE_READ_TIMEOUT", "12")
+        monkeypatch.setenv("BOOK_SOURCE_TOTAL_TIMEOUT", "20")
+        monkeypatch.setenv("BOOK_SOURCE_PREFLIGHT", "false")
+
+        config = get_source_config()
+
+        assert config.connect_timeout == 3.5
+        assert config.read_timeout == 12.0
+        assert config.total_timeout == 20.0
+        assert config.preflight_enabled is False
+
+    @pytest.mark.parametrize("bad", ["0", "-5", "abc", ""])
+    def test_nonsense_falls_back_to_the_default_not_to_unbounded(
+        self, monkeypatch, bad
+    ):
+        monkeypatch.setenv("BOOK_SOURCE_CONNECT_TIMEOUT", bad)
+        config = get_source_config()
+        assert config.connect_timeout > 0
+
+
+class TestLibgenSearchIsBounded:
+    """LibGen search is the path that hung; it gets the closest scrutiny."""
+
+    @pytest.mark.asyncio
+    async def test_unreachable_mirror_fails_fast_without_calling_the_library(
+        self, fast_config
+    ):
+        """The blocking third-party call must never be entered for a dead host.
+
+        libgen_api_enhanced issues requests.get with no timeout, so once that
+        call starts it can only be abandoned. The probe is what keeps us out.
+        """
+        adapter = LibgenAdapter(fast_config)
+
+        async def _unreachable(provider, host, **_kwargs):
+            raise ProviderUnreachableError(provider, host, reason="connect_timeout")
+
+        with (
+            patch("lib.sources.libgen.probe_host", side_effect=_unreachable),
+            patch("lib.sources.libgen.LibgenSearch") as mock_search_class,
+        ):
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await adapter.search("hegel")
+
+            mock_search_class.assert_not_called()
+
+        assert all(f.provider == "libgen" for f in excinfo.value.failures)
+        assert {f.reason for f in excinfo.value.failures} == {"connect_timeout"}
+
+    @pytest.mark.asyncio
+    async def test_all_mirrors_are_tried_before_giving_up(self, fast_config):
+        adapter = LibgenAdapter(fast_config)
+        probed = []
+
+        async def _unreachable(provider, host, **_kwargs):
+            probed.append(host)
+            raise ProviderUnreachableError(provider, host, reason="dns_failure")
+
+        with patch("lib.sources.libgen.probe_host", side_effect=_unreachable):
+            with pytest.raises(AllSourcesFailedError):
+                await adapter.search("hegel")
+
+        assert probed == ["libgen.li", "libgen.vg", "libgen.la"]
+
+    @pytest.mark.asyncio
+    async def test_failover_to_a_working_mirror(self, fast_config):
+        """One dead mirror must not mean no results."""
+        adapter = LibgenAdapter(fast_config)
+
+        async def _first_mirror_dead(provider, host, **_kwargs):
+            if host == "libgen.li":
+                raise ProviderUnreachableError(provider, host, reason="connect_timeout")
+
+        book = MagicMock(md5="abc", title="Phenomenology", author="Hegel")
+
+        with (
+            patch("lib.sources.libgen.probe_host", side_effect=_first_mirror_dead),
+            patch("lib.sources.libgen.LibgenSearch") as mock_search_class,
+        ):
+            mock_search_class.return_value.search_title.return_value = [book]
+            results = await adapter.search("hegel")
+
+        assert len(results) == 1
+        assert results[0].source == SourceType.LIBGEN
+        assert mock_search_class.call_args.kwargs["mirror"] == "vg"
+
+    @pytest.mark.asyncio
+    async def test_a_blocking_library_call_cannot_outlast_the_budget(self, fast_config):
+        """The core regression: an un-timed requests.get must not hang the bridge."""
+        adapter = LibgenAdapter(fast_config)
+
+        def _hang(*_args, **_kwargs):
+            time.sleep(30)
+
+        with (
+            patch("lib.sources.libgen.probe_host", new=AsyncMock(return_value=None)),
+            patch("lib.sources.libgen.LibgenSearch") as mock_search_class,
+        ):
+            mock_search_class.return_value.search_title.side_effect = _hang
+
+            began = time.monotonic()
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await adapter.search("hegel")
+            elapsed = time.monotonic() - began
+
+        # Three mirrors x 0.3s budget, generously bounded.
+        assert elapsed < 10, f"took {elapsed:.1f}s; the budget is not being enforced"
+        assert {f.reason for f in excinfo.value.failures} == {"search_timeout"}
+
+    @pytest.mark.asyncio
+    async def test_empty_results_are_not_an_error(self, fast_config):
+        adapter = LibgenAdapter(fast_config)
+
+        with (
+            patch("lib.sources.libgen.probe_host", new=AsyncMock(return_value=None)),
+            patch("lib.sources.libgen.LibgenSearch") as mock_search_class,
+        ):
+            mock_search_class.return_value.search_title.return_value = []
+            assert await adapter.search("nothing matches this") == []
+
+
+class TestAnnasSearchIsBounded:
+    """Anna's had a timeout already; what it lacked was attribution."""
+
+    @pytest.mark.asyncio
+    async def test_client_uses_the_configured_budgets(self):
+        config = SourceConfig(connect_timeout=4.0, read_timeout=9.0)
+        adapter = AnnasArchiveAdapter(config)
+
+        client = await adapter._get_client()
+        try:
+            assert client.timeout.connect == 4.0
+            assert client.timeout.read == 9.0
+        finally:
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_dns_failure_names_the_provider_and_host(self, fast_config):
+        adapter = AnnasArchiveAdapter(fast_config)
+
+        async def _unreachable(provider, host, **_kwargs):
+            raise ProviderUnreachableError(
+                provider, host, "Name or service not known", reason="dns_failure"
+            )
+
+        with patch("lib.sources.annas.probe_host", side_effect=_unreachable):
+            with pytest.raises(ProviderUnreachableError) as excinfo:
+                await adapter.search("hegel")
+
+        assert excinfo.value.provider == "annas"
+        assert excinfo.value.host == "annas-archive.gl"
+        assert excinfo.value.reason == "dns_failure"
+        assert "annas-archive.gl" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_is_classified_not_swallowed(self, fast_config):
+        adapter = AnnasArchiveAdapter(fast_config)
+        exc = httpx.ConnectError("boom")
+        exc.__cause__ = socket.gaierror(-2, "Name or service not known")
+
+        with patch("lib.sources.annas.probe_host", new=AsyncMock(return_value=None)):
+            with patch.object(adapter, "_get_client") as mock_get_client:
+                mock_client = AsyncMock()
+                mock_client.get.side_effect = exc
+                mock_get_client.return_value = mock_client
+
+                with pytest.raises(ProviderUnreachableError) as excinfo:
+                    await adapter.search("hegel")
+
+        assert excinfo.value.reason == "dns_failure"
+
+    @pytest.mark.asyncio
+    async def test_http_error_is_a_response_failure_not_a_reachability_one(
+        self, fast_config
+    ):
+        adapter = AnnasArchiveAdapter(fast_config)
+        request = httpx.Request("GET", "https://annas-archive.gl/search")
+        response = httpx.Response(503, request=request)
+
+        with patch("lib.sources.annas.probe_host", new=AsyncMock(return_value=None)):
+            with patch.object(adapter, "_get_client") as mock_get_client:
+                mock_response = MagicMock()
+                mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                    "boom", request=request, response=response
+                )
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_response
+                mock_get_client.return_value = mock_client
+
+                with pytest.raises(ProviderResponseError) as excinfo:
+                    await adapter.search("hegel")
+
+        assert excinfo.value.reason == "http_error"
+        assert excinfo.value.unreachable is False
+
+
+class TestRouterSourceSelection:
+    """`auto` means fall back; an explicit source means answer for that source."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_annas_failure_does_not_silently_return_libgen(self):
+        """A request tagged source=annas must not end up executing on LibGen.
+
+        This is how an `annas` call came to hang inside LibGen's un-timed
+        search on 2026-08-11 — the failure was attributed to the wrong source
+        and the caller waited on a provider it had not asked for.
+        """
+        router = SourceRouter(SourceConfig(fallback_enabled=True))
+
+        with (
+            patch.object(router, "_get_annas") as mock_annas,
+            patch.object(router, "_get_libgen") as mock_libgen,
+        ):
+            annas = AsyncMock()
+            annas.search.side_effect = ProviderUnreachableError(
+                "annas", "annas-archive.gl", reason="dns_failure"
+            )
+            mock_annas.return_value = annas
+            mock_libgen.return_value = AsyncMock()
+
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await router.search("hegel", source="annas")
+
+            mock_libgen.return_value.search.assert_not_called()
+
+        assert excinfo.value.failures[0].provider == "annas"
+        assert excinfo.value.failures[0].reason == "dns_failure"
+
+    @pytest.mark.asyncio
+    async def test_explicit_libgen_failure_does_not_fall_back_to_annas(self):
+        router = SourceRouter(SourceConfig(fallback_enabled=True))
+
+        with (
+            patch.object(router, "_get_annas") as mock_annas,
+            patch.object(router, "_get_libgen") as mock_libgen,
+        ):
+            libgen = AsyncMock()
+            libgen.search.side_effect = ProviderUnreachableError(
+                "libgen", "libgen.li", reason="connect_timeout"
+            )
+            mock_libgen.return_value = libgen
+            mock_annas.return_value = AsyncMock()
+
+            with pytest.raises(AllSourcesFailedError):
+                await router.search("hegel", source="libgen")
+
+            mock_annas.return_value.search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_falls_back_to_the_other_provider(self):
+        """source=auto is where fallback belongs, and it works both ways."""
+        router = SourceRouter(SourceConfig(fallback_enabled=True))
+
+        with (
+            patch.object(router, "_get_annas") as mock_annas,
+            patch.object(router, "_get_libgen") as mock_libgen,
+        ):
+            libgen = AsyncMock()
+            libgen.search.side_effect = ProviderUnreachableError(
+                "libgen", "libgen.li", reason="connect_timeout"
+            )
+            mock_libgen.return_value = libgen
+
+            annas = AsyncMock()
+            annas.search.return_value = [
+                UnifiedBookResult(md5="x", title="T", source=SourceType.ANNAS_ARCHIVE)
+            ]
+            mock_annas.return_value = annas
+
+            results = await router.search("hegel", source="auto")
+
+        assert len(results) == 1
+        assert results[0].source == SourceType.ANNAS_ARCHIVE
+
+    @pytest.mark.asyncio
+    async def test_every_provider_failure_is_reported_with_its_own_reason(self):
+        """Two providers down for two different reasons must not be flattened."""
+        router = SourceRouter(SourceConfig(annas_secret_key="k", fallback_enabled=True))
+
+        with (
+            patch.object(router, "_get_annas") as mock_annas,
+            patch.object(router, "_get_libgen") as mock_libgen,
+        ):
+            annas = AsyncMock()
+            annas.search.side_effect = ProviderUnreachableError(
+                "annas", "annas-archive.gl", reason="dns_failure"
+            )
+            mock_annas.return_value = annas
+
+            libgen = AsyncMock()
+            libgen.search.side_effect = ProviderUnreachableError(
+                "libgen", "libgen.li", reason="connect_timeout"
+            )
+            mock_libgen.return_value = libgen
+
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await router.search("hegel", source="auto")
+
+        payload = excinfo.value.to_dict()
+        by_provider = {f["provider"]: f["reason"] for f in payload["failures"]}
+        assert by_provider == {"annas": "dns_failure", "libgen": "connect_timeout"}
+
+    @pytest.mark.asyncio
+    async def test_a_reachable_provider_with_no_matches_returns_empty(self):
+        """No match is not an outage; it must not raise."""
+        router = SourceRouter(SourceConfig(fallback_enabled=True))
+
+        with (
+            patch.object(router, "_get_annas") as mock_annas,
+            patch.object(router, "_get_libgen") as mock_libgen,
+        ):
+            for mock in (mock_annas, mock_libgen):
+                adapter = AsyncMock()
+                adapter.search.return_value = []
+                mock.return_value = adapter
+
+            assert await router.search("zzzz no such book", source="auto") == []

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from lib.sources import net
+from lib.sources import annas, net
 from lib.sources.annas import AnnasArchiveAdapter
 from lib.sources.config import SourceConfig, get_source_config
 from lib.sources.errors import (
@@ -376,3 +376,91 @@ class TestRouterSourceSelection:
                 mock.return_value = adapter
 
             assert await router.search("zzzz no such book", source="auto") == []
+
+
+class TestPreflightTargetsTheRealEndpoint:
+    """The probe must address the port and scheme the request will use.
+
+    The autouse `_no_preflight_probes` stub in conftest replaces `probe_host`
+    wholesale, which is why the wrong-port bug survived the first round of
+    tests. These record the arguments instead of suppressing the call.
+    """
+
+    @staticmethod
+    def _recording_probe(calls):
+        async def _probe(
+            provider, host, port=443, timeout=5.0, use_cache=True, scheme="https"
+        ):
+            calls.append(
+                {"host": host, "port": port, "scheme": scheme, "provider": provider}
+            )
+
+        return _probe
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "base_url, expected_host, expected_port, expected_scheme",
+        [
+            ("https://annas-archive.gl", "annas-archive.gl", 443, "https"),
+            ("http://localhost:8080", "localhost", 8080, "http"),
+            ("https://mirror.example:8443", "mirror.example", 8443, "https"),
+            ("http://example.com", "example.com", 80, "http"),
+        ],
+    )
+    async def test_annas_probes_the_configured_port(
+        self, monkeypatch, base_url, expected_host, expected_port, expected_scheme
+    ):
+        calls = []
+        monkeypatch.setattr(annas, "probe_host", self._recording_probe(calls))
+
+        config = SourceConfig(annas_base_url=base_url, preflight_enabled=True)
+        adapter = annas.AnnasArchiveAdapter(config)
+        await adapter._preflight()
+
+        assert calls == [
+            {
+                "host": expected_host,
+                "port": expected_port,
+                "scheme": expected_scheme,
+                "provider": "annas",
+            }
+        ]
+
+
+@pytest.mark.asyncio
+class TestPartialFailureIsNotAnEmptyResult:
+    """An unreachable provider must never be reported as 'no matches'."""
+
+    async def test_empty_plus_failure_raises_rather_than_returning_empty(self):
+        config = SourceConfig(fallback_enabled=True)
+        router = SourceRouter(config)
+
+        healthy = AsyncMock()
+        healthy.search = AsyncMock(return_value=[])
+        broken = AsyncMock()
+        broken.search = AsyncMock(
+            side_effect=ProviderUnreachableError(
+                "annas", "annas-archive.gl", reason="dns_failure"
+            )
+        )
+        router._libgen = healthy
+        router._annas = broken
+
+        with pytest.raises(AllSourcesFailedError) as excinfo:
+            await router.search("obscure title", source="auto")
+
+        # The caller must be able to see WHICH provider went unsearched.
+        reasons = {f.reason for f in excinfo.value.failures}
+        assert reasons == {"dns_failure"}
+        assert any(f.provider == "annas" for f in excinfo.value.failures)
+
+    async def test_all_providers_answering_empty_is_still_an_empty_result(self):
+        config = SourceConfig(fallback_enabled=True)
+        router = SourceRouter(config)
+
+        for name in ("_libgen", "_annas"):
+            adapter = AsyncMock()
+            adapter.search = AsyncMock(return_value=[])
+            setattr(router, name, adapter)
+
+        assert await router.search("nothing matches", source="auto") == []

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -18,6 +18,7 @@ sys.path.insert(
 )
 
 import python_bridge  # Import the module itself
+from lib.sources.errors import ProviderTimeoutError
 
 # Import functions from the module under test
 from python_bridge import (
@@ -468,6 +469,111 @@ class TestBridgeFunctions:
 
 class TestDownloadBook:
     @pytest.mark.asyncio
+    async def test_valid_slow_transfer_can_exceed_provider_resolution_budget(
+        self, tmp_path, mocker
+    ):
+        """A large transfer must not inherit the short resolution deadline."""
+
+        class SlowResponse:
+            url = httpx.URL("https://cdn.example/file")
+            headers = {"content-type": "application/pdf"}
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self, _chunk_size):
+                await asyncio.sleep(0.06)
+                yield b"%PDF slow but valid"
+
+        class SlowStream:
+            async def __aenter__(self):
+                return SlowResponse()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class SlowClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def stream(self, *_args, **_kwargs):
+                return SlowStream()
+
+        config = python_bridge.get_source_config()
+        config.total_timeout = 0.02
+        config.download_timeout = 0.15
+        mocker.patch("python_bridge.get_source_config", return_value=config)
+        mocker.patch("httpx.AsyncClient", SlowClient)
+
+        result = await python_bridge._download_url_to_file(
+            "https://mirror.example/get", str(tmp_path), "slow-valid", "libgen"
+        )
+
+        assert Path(result).read_bytes() == b"%PDF slow but valid"
+
+    @pytest.mark.asyncio
+    async def test_transfer_exceeding_download_budget_is_typed_and_cleans_partial(
+        self, tmp_path, mocker
+    ):
+        """The larger transfer budget remains finite and cleanup-safe."""
+
+        class OverBudgetResponse:
+            url = httpx.URL("https://cdn.example/file")
+            headers = {"content-type": "application/pdf"}
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self, _chunk_size):
+                yield b"partial"
+                await asyncio.sleep(0.15)
+                yield b"late"
+
+        class OverBudgetStream:
+            async def __aenter__(self):
+                return OverBudgetResponse()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class OverBudgetClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def stream(self, *_args, **_kwargs):
+                return OverBudgetStream()
+
+        config = python_bridge.get_source_config()
+        config.total_timeout = 1.0
+        config.download_timeout = 0.03
+        mocker.patch("python_bridge.get_source_config", return_value=config)
+        mocker.patch("httpx.AsyncClient", OverBudgetClient)
+
+        with pytest.raises(ProviderTimeoutError) as excinfo:
+            await python_bridge._download_url_to_file(
+                "https://mirror.example/get",
+                str(tmp_path),
+                "over-budget",
+                "libgen",
+            )
+
+        assert excinfo.value.reason == "read_timeout"
+        assert excinfo.value.host == "cdn.example"
+        assert not (tmp_path / "over-budget.download").exists()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("failure", "expected_reason"),
         [
@@ -537,6 +643,7 @@ class TestDownloadBook:
         )
         config = python_bridge.get_source_config()
         config.total_timeout = 0.03
+        config.download_timeout = 0.03
         config.preflight_timeout = 0.03
         mocker.patch(
             "python_bridge.get_source_router", new=AsyncMock(return_value=router)

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -84,8 +84,22 @@ def mock_eapi_client():
     mock_client.get_downloaded = AsyncMock(
         return_value={"books": MOCK_EAPI_SEARCH_RESPONSE["books"]}
     )
+    # Field names copied from a live /eapi/user/profile response (2026-08-11).
+    # The previous fixture invented `downloads_today_limit` /
+    # `downloads_today_left` to match the code, so the test passed while the
+    # real tool returned {"daily_limit": "unknown", "daily_remaining":
+    # "unknown"} against the actual API. A fixture must mirror the service, not
+    # the caller's assumption about it.
     mock_client.get_profile = AsyncMock(
-        return_value={"user": {"downloads_today_limit": 10, "downloads_today_left": 7}}
+        return_value={
+            "success": 1,
+            "user": {
+                "id": 1,
+                "downloads_today": 3,
+                "downloads_limit": 10,
+                "isPremium": 0,
+            },
+        }
     )
     mock_client.get_recently = AsyncMock(return_value=MOCK_EAPI_SEARCH_RESPONSE)
     mock_client.close = AsyncMock()
@@ -340,9 +354,33 @@ class TestProfileEndpoints:
 
     @pytest.mark.asyncio
     async def test_get_download_limits(self, patch_eapi_client):
+        """Real numbers, from the field names the EAPI actually sends."""
         result = await get_download_limits()
         assert result["daily_limit"] == 10
         assert result["daily_remaining"] == 7
+        assert result["downloads_today"] == 3
+        assert result["is_premium"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_download_limits_clamps_at_zero(self, patch_eapi_client):
+        """The server counts a download when issued and can exceed the cap."""
+        patch_eapi_client.get_profile = AsyncMock(
+            return_value={"user": {"downloads_today": 12, "downloads_limit": 10}}
+        )
+        result = await get_download_limits()
+        assert result["daily_remaining"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_download_limits_reports_unknown_if_the_shape_changes(
+        self, patch_eapi_client
+    ):
+        """A renamed field must degrade to 'unknown', not to a wrong number."""
+        patch_eapi_client.get_profile = AsyncMock(
+            return_value={"user": {"something_else": 5}}
+        )
+        result = await get_download_limits()
+        assert result["daily_limit"] == "unknown"
+        assert result["daily_remaining"] == "unknown"
 
 
 # --- Tests for get_book_metadata_complete (EAPI-based) ---

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -1,9 +1,14 @@
 # Tests for lib/python_bridge.py (EAPI-based)
 
+import json
 import pytest
 import os
 import sys
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
+
+import httpx
 
 from pathlib import Path
 
@@ -16,6 +21,7 @@ import python_bridge  # Import the module itself
 
 # Import functions from the module under test
 from python_bridge import (
+    main,
     process_document,
     download_book,
     normalize_book_details,
@@ -461,6 +467,251 @@ class TestBridgeFunctions:
 
 
 class TestDownloadBook:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("failure", "expected_reason"),
+        [
+            (httpx.ConnectTimeout("connect stalled"), "connect_timeout"),
+            (httpx.ReadTimeout("body stalled"), "read_timeout"),
+            (
+                httpx.HTTPStatusError(
+                    "bad status",
+                    request=httpx.Request("GET", "https://cdn.example/book"),
+                    response=httpx.Response(503),
+                ),
+                "http_error",
+            ),
+            ("trickle", "read_timeout"),
+        ],
+    )
+    async def test_source_transfer_failures_reach_main_as_typed_envelopes(
+        self, failure, expected_reason, tmp_path, mocker, monkeypatch, capsys
+    ):
+        """The actual source transfer boundary must classify every failure."""
+
+        class FakeResponse:
+            headers = {"content-type": "application/pdf"}
+
+            def raise_for_status(self):
+                if isinstance(failure, httpx.HTTPStatusError):
+                    raise failure
+
+            async def aiter_bytes(self, _chunk_size):
+                if failure == "trickle":
+                    await asyncio.sleep(1)
+                    yield b"late"
+                    return
+                if isinstance(failure, httpx.ReadTimeout):
+                    raise failure
+                yield b"%PDF"
+
+        class FakeStream:
+            async def __aenter__(self):
+                if isinstance(failure, httpx.ConnectTimeout):
+                    raise failure
+                return FakeResponse()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class FakeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def stream(self, *_args, **_kwargs):
+                return FakeStream()
+
+        router = SimpleNamespace(
+            get_download_url=AsyncMock(
+                return_value=SimpleNamespace(
+                    url="https://cdn.example/book", source="libgen"
+                )
+            ),
+            close=AsyncMock(),
+        )
+        config = python_bridge.get_source_config()
+        config.total_timeout = 0.03
+        config.preflight_timeout = 0.03
+        mocker.patch(
+            "python_bridge.get_source_router", new=AsyncMock(return_value=router)
+        )
+        mocker.patch("python_bridge.get_source_config", return_value=config)
+        mocker.patch("httpx.AsyncClient", FakeClient)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "python_bridge.py",
+                "download_book",
+                json.dumps(
+                    {
+                        "book_details": {
+                            "md5": "0123456789abcdef0123456789abcdef",
+                            "source": "libgen",
+                        },
+                        "output_dir": str(tmp_path),
+                    }
+                ),
+            ],
+        )
+
+        with pytest.raises(SystemExit):
+            await main()
+
+        envelope = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+        assert envelope["details"]["provider"] == "libgen"
+        assert envelope["details"]["host"] == "cdn.example"
+        assert envelope["details"]["reason"] == expected_reason
+        assert envelope["details"]["operation"] == "download"
+        assert not (tmp_path / "0123456789abcdef0123456789abcdef.download").exists()
+
+    @pytest.mark.asyncio
+    async def test_redirected_partial_read_timeout_attributes_the_cdn_host(
+        self, tmp_path, mocker, monkeypatch, capsys
+    ):
+        """After a redirect, the failing request host owns the failure."""
+        cdn_request = httpx.Request("GET", "https://cdn.example/file")
+
+        class FakeResponse:
+            url = cdn_request.url
+            headers = {"content-type": "application/pdf"}
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self, _chunk_size):
+                yield b"partial"
+                raise httpx.ReadTimeout("CDN body stalled", request=cdn_request)
+
+        class FakeStream:
+            async def __aenter__(self):
+                return FakeResponse()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class FakeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def stream(self, *_args, **_kwargs):
+                return FakeStream()
+
+        router = SimpleNamespace(
+            get_download_url=AsyncMock(
+                return_value=SimpleNamespace(
+                    url="https://mirror.example/get", source="libgen"
+                )
+            ),
+            close=AsyncMock(),
+        )
+        mocker.patch(
+            "python_bridge.get_source_router", new=AsyncMock(return_value=router)
+        )
+        mocker.patch("httpx.AsyncClient", FakeClient)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "python_bridge.py",
+                "download_book",
+                json.dumps(
+                    {
+                        "book_details": {
+                            "md5": "0123456789abcdef0123456789abcdef",
+                            "source": "libgen",
+                        },
+                        "output_dir": str(tmp_path),
+                    }
+                ),
+            ],
+        )
+
+        with pytest.raises(SystemExit):
+            await main()
+
+        envelope = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+        assert envelope["details"]["host"] == "cdn.example"
+        assert envelope["details"]["reason"] == "read_timeout"
+        assert envelope["details"]["operation"] == "download"
+        assert not (tmp_path / "0123456789abcdef0123456789abcdef.download").exists()
+
+    @pytest.mark.asyncio
+    async def test_main_routes_libgen_before_eapi_initialization(
+        self, tmp_path, mocker, monkeypatch, capsys
+    ):
+        """The CLI dispatch must inspect source before deciding authentication."""
+        args = {
+            "book_details": {
+                "md5": "0123456789abcdef0123456789abcdef",
+                "source": "libgen",
+                "title": "LibGen Book",
+            },
+            "output_dir": str(tmp_path),
+        }
+        monkeypatch.setattr(
+            sys, "argv", ["python_bridge.py", "download_book", json.dumps(args)]
+        )
+        initialize = mocker.patch(
+            "python_bridge.initialize_eapi_client",
+            new=AsyncMock(side_effect=AssertionError("EAPI initialization attempted")),
+        )
+        mocker.patch(
+            "python_bridge.download_book",
+            new=AsyncMock(return_value={"file_path": str(tmp_path / "book.pdf")}),
+        )
+
+        await main()
+
+        initialize.assert_not_awaited()
+        response = json.loads(capsys.readouterr().out)
+        assert json.loads(response["content"][0]["text"])["file_path"].endswith(
+            "book.pdf"
+        )
+
+    @pytest.mark.asyncio
+    async def test_libgen_download_does_not_initialize_zlibrary(self, tmp_path, mocker):
+        """A LibGen search result must route without unrelated EAPI credentials."""
+        raw_path = tmp_path / "raw.pdf"
+        raw_path.write_bytes(b"%PDF test")
+        initialize = mocker.patch(
+            "python_bridge.initialize_eapi_client",
+            new=AsyncMock(side_effect=AssertionError("EAPI initialization attempted")),
+        )
+        fetch = mocker.patch(
+            "python_bridge._fetch_from_source",
+            new=AsyncMock(return_value=str(raw_path)),
+        )
+        mocker.patch(
+            "python_bridge.create_unified_filename", return_value="libgen-book.pdf"
+        )
+
+        result = await download_book(
+            book_details={
+                "md5": "0123456789abcdef0123456789abcdef",
+                "source": "libgen",
+                "title": "LibGen Book",
+                "extension": "pdf",
+            },
+            output_dir=str(tmp_path),
+        )
+
+        initialize.assert_not_awaited()
+        fetch.assert_awaited_once()
+        assert result["file_path"].endswith("libgen-book.pdf")
+
     @pytest.mark.asyncio
     async def test_download_book_success(
         self, mock_eapi_download, tmp_path, mocker, patch_eapi_client

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -3,7 +3,10 @@
 import json
 import pytest
 import os
+import signal
+import subprocess
 import sys
+import time
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -468,6 +471,80 @@ class TestBridgeFunctions:
 
 
 class TestDownloadBook:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX signal semantics")
+    def test_sigterm_cancels_dispatch_and_removes_partial_download(self, tmp_path):
+        """The real bridge process must unwind its transfer cleanup on SIGTERM."""
+        partial = tmp_path / "cooperative.download"
+        ready = tmp_path / "ready"
+        code = f"""
+import asyncio
+import pathlib
+import sys
+from types import SimpleNamespace
+sys.path.insert(0, {str(Path(python_bridge.__file__).parent)!r})
+import python_bridge
+partial = pathlib.Path({str(partial)!r})
+ready = pathlib.Path({str(ready)!r})
+async def fake_dispatch(*_args):
+    try:
+        partial.write_bytes(b'partial')
+        ready.write_text('ready')
+        await asyncio.sleep(600)
+    finally:
+        partial.unlink(missing_ok=True)
+python_bridge._dispatch_bridge_function = fake_dispatch
+python_bridge.get_source_config = lambda: SimpleNamespace(preflight_timeout=1)
+sys.argv = ['python_bridge.py', 'process_document', '{{}}']
+asyncio.run(python_bridge.main())
+"""
+        process = subprocess.Popen(
+            [sys.executable, "-c", code],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not ready.exists():
+                time.sleep(0.02)
+            assert ready.exists()
+            assert partial.exists()
+
+            process.send_signal(signal.SIGTERM)
+            process.wait(timeout=5)
+
+            assert not partial.exists()
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_annas_transfer_uses_canonical_provider_name(self, tmp_path, mocker):
+        """Transfer failures use `annas`, while success models retain their enum."""
+        router = SimpleNamespace(
+            get_download_url=AsyncMock(
+                return_value=SimpleNamespace(
+                    url="https://cdn.example/book",
+                    source=SimpleNamespace(value="annas_archive"),
+                )
+            )
+        )
+        transfer = mocker.patch(
+            "python_bridge._download_url_to_file",
+            new=AsyncMock(return_value="book.pdf"),
+        )
+        mocker.patch(
+            "python_bridge.get_source_router", new=AsyncMock(return_value=router)
+        )
+
+        await python_bridge._fetch_from_source(
+            {"md5": "0123456789abcdef0123456789abcdef", "source": "annas"},
+            str(tmp_path),
+        )
+
+        assert transfer.await_args.args[3] == "annas"
+
     @pytest.mark.asyncio
     async def test_valid_slow_transfer_can_exceed_provider_resolution_budget(
         self, tmp_path, mocker

--- a/__tests__/python/test_source_net.py
+++ b/__tests__/python/test_source_net.py
@@ -1,0 +1,269 @@
+"""Tests for the bounded-network helpers in lib/sources/net.py.
+
+These cover the machinery that was missing when three python_bridge.py search
+processes were found alive for hours on 2026-08-11: a wall-clock bound on a
+blocking third-party call, a thread that cannot keep the interpreter alive,
+and a probe that says WHICH failure happened rather than just "it failed".
+"""
+
+import asyncio
+import socket
+import ssl
+import threading
+import time
+
+import httpx
+import pytest
+
+from lib.sources import net
+from lib.sources.config import SourceConfig
+from lib.sources.errors import ProviderTimeoutError, ProviderUnreachableError
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_cache():
+    net.reset_probe_cache()
+    yield
+    net.reset_probe_cache()
+
+
+class TestBuildTimeout:
+    """Every phase of an httpx request must carry a budget."""
+
+    def test_all_phases_bounded(self):
+        config = SourceConfig(connect_timeout=7.0, read_timeout=11.0)
+        timeout = net.build_timeout(config)
+
+        assert timeout.connect == 7.0
+        assert timeout.read == 11.0
+        assert timeout.write == 11.0
+        assert timeout.pool == 7.0
+
+    def test_no_phase_is_unbounded(self):
+        """A None anywhere here is the bug this module exists to prevent."""
+        timeout = net.build_timeout(SourceConfig())
+
+        assert None not in (timeout.connect, timeout.read, timeout.write, timeout.pool)
+
+
+class TestClassifyHttpxError:
+    """DNS failure and connect timeout must not collapse into one reason."""
+
+    def test_connect_timeout(self):
+        reason, _ = net.classify_httpx_error(httpx.ConnectTimeout("too slow"))
+        assert reason == "connect_timeout"
+
+    def test_read_timeout(self):
+        reason, _ = net.classify_httpx_error(httpx.ReadTimeout("no body"))
+        assert reason == "read_timeout"
+
+    def test_dns_failure_read_from_the_cause_chain(self):
+        """httpx raises ConnectError for DNS too; only __cause__ tells them apart."""
+        exc = httpx.ConnectError("boom")
+        exc.__cause__ = socket.gaierror(-2, "Name or service not known")
+
+        reason, detail = net.classify_httpx_error(exc)
+
+        assert reason == "dns_failure"
+        assert "Name or service not known" in detail
+
+    def test_dns_failure_from_message_when_cause_is_missing(self):
+        reason, _ = net.classify_httpx_error(
+            httpx.ConnectError("[Errno -2] Name or service not known")
+        )
+        assert reason == "dns_failure"
+
+    def test_connection_refused(self):
+        exc = httpx.ConnectError("nope")
+        exc.__cause__ = ConnectionRefusedError()
+        reason, _ = net.classify_httpx_error(exc)
+        assert reason == "connect_refused"
+
+    def test_tls_error(self):
+        exc = httpx.ConnectError("handshake")
+        exc.__cause__ = ssl.SSLError("bad cert")
+        reason, _ = net.classify_httpx_error(exc)
+        assert reason == "tls_error"
+
+    def test_http_status_error_names_the_status(self):
+        request = httpx.Request("GET", "https://example.invalid/")
+        response = httpx.Response(503, request=request)
+        reason, detail = net.classify_httpx_error(
+            httpx.HTTPStatusError("boom", request=request, response=response)
+        )
+        assert reason == "http_error"
+        assert "503" in detail
+
+    def test_plain_connect_error_is_not_reported_as_dns(self):
+        reason, _ = net.classify_httpx_error(httpx.ConnectError("network unreachable"))
+        assert reason == "connect_error"
+
+
+class TestClassifyRequestsError:
+    """The LibGen library flattens everything into RequestException prose."""
+
+    def test_timeout_sentence(self):
+        reason, _ = net.classify_requests_error(
+            Exception("Request to https://libgen.li timed out")
+        )
+        assert reason == "read_timeout"
+
+    def test_connect_sentence(self):
+        reason, _ = net.classify_requests_error(
+            Exception("Failed to connect to https://libgen.is")
+        )
+        assert reason == "connect_error"
+
+    def test_cause_chain_beats_the_sentence(self):
+        exc = Exception("Failed to connect to https://libgen.is")
+        exc.__cause__ = socket.gaierror(-2, "Name or service not known")
+        reason, _ = net.classify_requests_error(exc)
+        assert reason == "dns_failure"
+
+
+@pytest.mark.real_preflight
+class TestProbeHost:
+    """The pre-flight probe distinguishes the two observed outage shapes.
+
+    Marked real_preflight so the conftest stub that keeps other unit tests off
+    the network does not stub out the very function under test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dns_failure_is_named_as_such(self, monkeypatch):
+        """The annas-archive.org shape: the name has no address at all."""
+
+        def _fail(*_args, **_kwargs):
+            raise socket.gaierror(-2, "Name or service not known")
+
+        monkeypatch.setattr(socket, "getaddrinfo", _fail)
+
+        with pytest.raises(ProviderUnreachableError) as excinfo:
+            await net.probe_host("annas", "annas-archive.invalid", timeout=1.0)
+
+        assert excinfo.value.reason == "dns_failure"
+        assert excinfo.value.host == "annas-archive.invalid"
+        assert excinfo.value.unreachable is True
+
+    @pytest.mark.asyncio
+    async def test_connect_timeout_when_syn_is_dropped(self, monkeypatch):
+        """The libgen.is shape: resolves fine, never completes a handshake."""
+
+        def _resolves(*_args, **_kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.1", 443))]
+
+        async def _never_connects(*_args, **_kwargs):
+            await asyncio.sleep(30)
+
+        monkeypatch.setattr(socket, "getaddrinfo", _resolves)
+        monkeypatch.setattr(asyncio, "open_connection", _never_connects)
+
+        with pytest.raises(ProviderUnreachableError) as excinfo:
+            await net.probe_host("libgen", "libgen.is", timeout=0.05)
+
+        assert excinfo.value.reason == "connect_timeout"
+        assert excinfo.value.reason != "dns_failure", "must not blur into DNS failure"
+
+    @pytest.mark.asyncio
+    async def test_reachable_host_returns_quietly(self):
+        """Probe a real listening socket on localhost."""
+        server = await asyncio.start_server(lambda r, w: w.close(), "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        try:
+            await net.probe_host("test", "127.0.0.1", port=port, timeout=2.0)
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_verdict_is_cached_within_a_process(self, monkeypatch):
+        """LibGen walks three mirrors; a repeated host must not re-probe."""
+        calls = []
+
+        async def _fail(provider, host, port, timeout):
+            calls.append(host)
+            return ProviderUnreachableError(provider, host, reason="dns_failure")
+
+        monkeypatch.setattr(net, "_probe_host_uncached", _fail)
+
+        for _ in range(3):
+            with pytest.raises(ProviderUnreachableError):
+                await net.probe_host("libgen", "libgen.is", timeout=1.0)
+
+        assert calls == ["libgen.is"]
+
+
+class TestRunBounded:
+    """The mechanism that replaces asyncio.to_thread for uncancellable calls."""
+
+    @pytest.mark.asyncio
+    async def test_returns_the_value(self):
+        result = await net.run_bounded(lambda: 42, 5.0, provider="libgen")
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_propagates_the_exception(self):
+        def _boom():
+            raise ValueError("bad mirror")
+
+        with pytest.raises(ValueError, match="bad mirror"):
+            await net.run_bounded(_boom, 5.0, provider="libgen")
+
+    @pytest.mark.asyncio
+    async def test_returns_at_the_deadline_not_when_the_call_finishes(self):
+        started = threading.Event()
+
+        def _hang():
+            started.set()
+            time.sleep(30)
+
+        began = time.monotonic()
+        with pytest.raises(ProviderTimeoutError) as excinfo:
+            await net.run_bounded(
+                _hang, 0.1, provider="libgen", host="libgen.is", operation="search"
+            )
+        elapsed = time.monotonic() - began
+
+        assert started.is_set()
+        assert elapsed < 5, f"waited {elapsed:.1f}s on a 0.1s budget"
+        assert excinfo.value.reason == "search_timeout"
+        assert excinfo.value.provider == "libgen"
+        assert excinfo.value.host == "libgen.is"
+
+    @pytest.mark.asyncio
+    async def test_worker_thread_is_a_daemon(self):
+        """Non-daemon workers are joined at interpreter exit.
+
+        That is the property that kept whole bridge processes alive after their
+        request was gone, so it is asserted directly rather than inferred.
+        """
+        seen = {}
+        ready = threading.Event()
+
+        def _record():
+            seen["daemon"] = threading.current_thread().daemon
+            ready.set()
+            return "done"
+
+        await net.run_bounded(_record, 5.0, provider="libgen")
+
+        assert ready.wait(2)
+        assert seen["daemon"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_straggler_reporting_late_does_not_explode(self):
+        """The abandoned thread finishes after the awaiter has given up."""
+        release = threading.Event()
+
+        def _slow():
+            release.wait(5)
+            return "late"
+
+        with pytest.raises(ProviderTimeoutError):
+            await net.run_bounded(_slow, 0.05, provider="libgen")
+
+        release.set()
+        # Give the straggler a turn to deliver into a cancelled future.
+        await asyncio.sleep(0.2)

--- a/__tests__/python/test_source_net.py
+++ b/__tests__/python/test_source_net.py
@@ -99,6 +99,18 @@ class TestClassifyHttpxError:
         assert reason == "dns_failure"
         assert "Name or service not known" in detail
 
+    def test_dns_timeout_marker_beats_generic_gaierror_in_cause_chain(self):
+        """A bounded resolver deadline is temporary, not a missing domain."""
+        exc = httpx.ConnectError("boom")
+        exc.__cause__ = socket.gaierror(
+            socket.EAI_AGAIN, f"{net.DNS_TIMEOUT_MARKER}:5s"
+        )
+
+        reason, detail = net.classify_httpx_error(exc)
+
+        assert reason == "dns_timeout"
+        assert "deadline exceeded" in detail
+
     def test_dns_failure_from_message_when_cause_is_missing(self):
         reason, _ = net.classify_httpx_error(
             httpx.ConnectError("[Errno -2] Name or service not known")

--- a/__tests__/python/test_source_net.py
+++ b/__tests__/python/test_source_net.py
@@ -267,3 +267,103 @@ class TestRunBounded:
         release.set()
         # Give the straggler a turn to deliver into a cancelled future.
         await asyncio.sleep(0.2)
+
+
+class TestPortDerivation:
+    """`port_of` — the probe must target what the request targets."""
+
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            ("https://annas-archive.gl", 443),
+            ("http://localhost:8080", 8080),
+            ("http://example.com", 80),
+            ("https://example.com:8443/path", 8443),
+            ("ftp://example.com", 443),
+        ],
+    )
+    def test_derives_port_from_url(self, url, expected):
+        assert net.port_of(url) == expected
+
+
+class TestProxyDetection:
+    """A direct probe must not veto a request the proxy could have carried."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_proxy_env(self, monkeypatch):
+        for var in (
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "NO_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_no_proxy_configured(self):
+        assert net.proxy_in_use("https://annas-archive.gl") is False
+
+    def test_https_proxy_applies_to_https(self, monkeypatch):
+        monkeypatch.setenv("https_proxy", "http://proxy.example:3128")
+        assert net.proxy_in_use("https://annas-archive.gl") is True
+
+    def test_http_proxy_does_not_apply_to_https(self, monkeypatch):
+        monkeypatch.setenv("http_proxy", "http://proxy.example:3128")
+        assert net.proxy_in_use("https://annas-archive.gl") is False
+
+    def test_no_proxy_exclusion_is_respected(self, monkeypatch):
+        # An excluded host really is reached directly, so it SHOULD be probed.
+        monkeypatch.setenv("https_proxy", "http://proxy.example:3128")
+        monkeypatch.setenv("no_proxy", "annas-archive.gl")
+        assert net.proxy_in_use("https://annas-archive.gl") is False
+
+    @pytest.mark.real_preflight
+    @pytest.mark.asyncio
+    async def test_probe_is_skipped_entirely_behind_a_proxy(self, monkeypatch):
+        """The whole point: no socket is opened, so nothing can be vetoed."""
+        monkeypatch.setenv("https_proxy", "http://proxy.example:3128")
+        net.reset_probe_cache()
+
+        def _explode(*args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("preflight opened a socket behind a proxy")
+
+        monkeypatch.setattr(socket, "getaddrinfo", _explode)
+        monkeypatch.setattr(asyncio, "open_connection", _explode)
+
+        await net.probe_host("annas", "annas-archive.gl", port=443)
+
+
+@pytest.mark.asyncio
+class TestBoundedAwait:
+    """`bounded_await` — one deadline over a whole async operation."""
+
+    async def test_returns_the_value_when_it_finishes_in_time(self):
+        async def quick():
+            return "done"
+
+        assert await net.bounded_await(quick(), 5.0, provider="annas") == "done"
+
+    async def test_raises_at_the_deadline(self):
+        async def trickle():
+            # Stands in for a host that keeps the read deadline alive by
+            # sending a byte at a time: never idle, never finished.
+            await asyncio.sleep(30)
+
+        start = time.monotonic()
+        with pytest.raises(ProviderTimeoutError) as excinfo:
+            await net.bounded_await(
+                trickle(), 0.2, provider="annas", host="annas-archive.gl"
+            )
+        assert time.monotonic() - start < 5
+        assert excinfo.value.reason == "search_timeout"
+        assert excinfo.value.provider == "annas"
+
+    async def test_propagates_the_original_exception(self):
+        async def boom():
+            raise ValueError("upstream")
+
+        with pytest.raises(ValueError, match="upstream"):
+            await net.bounded_await(boom(), 5.0, provider="annas")

--- a/__tests__/python/test_source_net.py
+++ b/__tests__/python/test_source_net.py
@@ -148,6 +148,35 @@ class TestProbeHost:
         assert excinfo.value.unreachable is True
 
     @pytest.mark.asyncio
+    async def test_timed_out_dns_resolver_cannot_keep_the_bridge_alive(
+        self, monkeypatch
+    ):
+        """The resolver worker must be daemonised because it cannot be cancelled."""
+        release = threading.Event()
+        seen = {}
+
+        def _hang(*_args, **_kwargs):
+            seen["daemon"] = threading.current_thread().daemon
+            release.wait(30)
+            return []
+
+        monkeypatch.setattr(socket, "getaddrinfo", _hang)
+
+        try:
+            with pytest.raises(ProviderUnreachableError) as excinfo:
+                await net.probe_host(
+                    "annas",
+                    "stalled-resolver.invalid",
+                    timeout=0.05,
+                    use_cache=False,
+                )
+        finally:
+            release.set()
+
+        assert excinfo.value.reason == "dns_timeout"
+        assert seen["daemon"] is True
+
+    @pytest.mark.asyncio
     async def test_connect_timeout_when_syn_is_dropped(self, monkeypatch):
         """The libgen.is shape: resolves fine, never completes a handshake."""
 

--- a/__tests__/python/test_source_net.py
+++ b/__tests__/python/test_source_net.py
@@ -41,6 +41,36 @@ class TestBuildTimeout:
         assert timeout.write == 11.0
         assert timeout.pool == 7.0
 
+
+class TestBoundedResolver:
+    """Actual httpx resolution must not enter asyncio's joined executor."""
+
+    @pytest.mark.asyncio
+    async def test_httpx_hostname_resolution_uses_a_daemon_bounded_worker(
+        self, monkeypatch
+    ):
+        release = threading.Event()
+        worker_daemon = []
+
+        def stalled_getaddrinfo(*_args, **_kwargs):
+            worker_daemon.append(threading.current_thread().daemon)
+            release.wait(5)
+            return []
+
+        monkeypatch.setattr(socket, "getaddrinfo", stalled_getaddrinfo)
+        started = time.monotonic()
+        try:
+            async with net.bounded_resolver(0.05):
+                async with httpx.AsyncClient(trust_env=False) as client:
+                    with pytest.raises(httpx.ConnectError) as excinfo:
+                        await client.get("http://resolver-stall.invalid/")
+        finally:
+            release.set()
+
+        assert time.monotonic() - started < 1
+        assert worker_daemon == [True]
+        assert net.classify_httpx_error(excinfo.value)[0] == "dns_timeout"
+
     def test_no_phase_is_unbounded(self):
         """A None anywhere here is the bug this module exists to prevent."""
         timeout = net.build_timeout(SourceConfig())
@@ -187,13 +217,46 @@ class TestProbeHost:
             await asyncio.sleep(30)
 
         monkeypatch.setattr(socket, "getaddrinfo", _resolves)
-        monkeypatch.setattr(asyncio, "open_connection", _never_connects)
+        monkeypatch.setattr(net, "_open_resolved_connection", _never_connects)
 
         with pytest.raises(ProviderUnreachableError) as excinfo:
             await net.probe_host("libgen", "libgen.is", timeout=0.05)
 
         assert excinfo.value.reason == "connect_timeout"
         assert excinfo.value.reason != "dns_failure", "must not blur into DNS failure"
+
+    @pytest.mark.asyncio
+    async def test_tcp_probe_reuses_the_daemon_resolved_address(self, monkeypatch):
+        """The TCP phase must not ask open_connection to resolve the host again."""
+        address = ("192.0.2.25", 443)
+        connected = []
+
+        def _resolves(*_args, **_kwargs):
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", address)
+            ]
+
+        async def _open_resolved(_loop, sock, target):
+            connected.append((sock, target))
+            return object(), _Writer(sock)
+
+        class _Writer:
+            def __init__(self, sock):
+                self.sock = sock
+
+            def close(self):
+                self.sock.close()
+
+            async def wait_closed(self):
+                return None
+
+        monkeypatch.setattr(socket, "getaddrinfo", _resolves)
+        monkeypatch.setattr(net, "_open_resolved_connection", _open_resolved)
+
+        await net.probe_host("libgen", "libgen.example", timeout=0.2, use_cache=False)
+
+        assert len(connected) == 1
+        assert connected[0][1] == address
 
     @pytest.mark.asyncio
     async def test_reachable_host_returns_quietly(self):

--- a/__tests__/python/test_source_router.py
+++ b/__tests__/python/test_source_router.py
@@ -10,7 +10,7 @@ from lib.sources.router import SourceRouter
 from lib.sources.config import SourceConfig
 from lib.sources.models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
 from lib.sources.annas import QuotaExhaustedError
-from lib.sources.errors import AllSourcesFailedError, ProviderUnreachableError
+from lib.sources.errors import AllSourcesFailedError
 
 pytestmark = pytest.mark.unit
 
@@ -195,6 +195,22 @@ class TestRouterSearch:
 
 class TestRouterDownload:
     """Tests for download URL routing and quota fallback."""
+
+    @pytest.mark.asyncio
+    async def test_missing_annas_key_is_a_structured_configuration_failure(
+        self, config_without_annas
+    ):
+        """An explicit Anna download without a key is caller config, not outage."""
+        router = SourceRouter(config_without_annas)
+
+        with pytest.raises(AllSourcesFailedError) as excinfo:
+            await router.get_download_url("abc123", source="annas")
+
+        assert len(excinfo.value.failures) == 1
+        failure = excinfo.value.failures[0]
+        assert failure.provider == "annas"
+        assert failure.reason == "configuration_error"
+        assert "ANNAS_SECRET_KEY" in failure.detail
 
     @pytest.mark.asyncio
     async def test_download_returns_url_with_source(self, config_with_annas):

--- a/__tests__/python/test_source_router.py
+++ b/__tests__/python/test_source_router.py
@@ -10,6 +10,7 @@ from lib.sources.router import SourceRouter
 from lib.sources.config import SourceConfig
 from lib.sources.models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
 from lib.sources.annas import QuotaExhaustedError
+from lib.sources.errors import AllSourcesFailedError, ProviderUnreachableError
 
 pytestmark = pytest.mark.unit
 
@@ -151,7 +152,12 @@ class TestRouterSearch:
 
     @pytest.mark.asyncio
     async def test_no_fallback_when_disabled(self, config_no_fallback):
-        """Should return empty results when fallback is disabled and Anna's fails."""
+        """Should raise, not return [], when fallback is disabled and Anna's fails.
+
+        Returning [] made an unreachable provider indistinguishable from a
+        query with no matches — the caller cannot tell it should retry, switch
+        source, or fix its config.
+        """
         router = SourceRouter(config_no_fallback)
 
         with patch.object(router, "_get_annas") as mock_get_annas:
@@ -159,9 +165,10 @@ class TestRouterSearch:
             annas_adapter.search.side_effect = Exception("Network error")
             mock_get_annas.return_value = annas_adapter
 
-            results = await router.search("test")
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await router.search("test")
 
-            assert results == []
+            assert "annas" in str(excinfo.value)
 
     @pytest.mark.asyncio
     async def test_direct_libgen_search(self, config_without_annas):

--- a/__tests__/python/test_source_router.py
+++ b/__tests__/python/test_source_router.py
@@ -10,7 +10,7 @@ from lib.sources.router import SourceRouter
 from lib.sources.config import SourceConfig
 from lib.sources.models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
 from lib.sources.annas import QuotaExhaustedError
-from lib.sources.errors import AllSourcesFailedError
+from lib.sources.errors import AllSourcesFailedError, SourceError
 
 pytestmark = pytest.mark.unit
 
@@ -296,7 +296,7 @@ class TestRouterDownload:
 
     @pytest.mark.asyncio
     async def test_quota_exhausted_no_fallback(self, config_no_fallback):
-        """Should raise QuotaExhaustedError when fallback is disabled."""
+        """Explicit Anna quota exhaustion retains the canonical provider envelope."""
         router = SourceRouter(config_no_fallback)
 
         with patch.object(router, "_get_annas") as mock_get_annas:
@@ -306,8 +306,11 @@ class TestRouterDownload:
             )
             mock_get_annas.return_value = annas_adapter
 
-            with pytest.raises(QuotaExhaustedError):
+            with pytest.raises(SourceError) as excinfo:
                 await router.get_download_url("abc123")
+
+        assert excinfo.value.provider == "annas"
+        assert excinfo.value.reason == "quota_exhausted"
 
     @pytest.mark.asyncio
     async def test_fallback_on_download_error(self, config_with_annas):

--- a/__tests__/retry-manager.test.js
+++ b/__tests__/retry-manager.test.js
@@ -173,6 +173,34 @@ describe('Retry Manager', () => {
       expect(retryManager.isRetryableError(error)).toBe(true);
     });
 
+    test('should honor an explicit retryable=true before Python message heuristics', () => {
+      const error = {
+        code: 'PYTHON_ERROR',
+        message: 'Provider returned HTTP 503',
+        retryable: true,
+        context: {
+          details: {
+            operation: 'download',
+            provider: 'libgen',
+            host: 'cdn.example',
+            reason: 'http_error',
+          },
+        },
+      };
+
+      expect(retryManager.isRetryableError(error)).toBe(true);
+    });
+
+    test('should honor an explicit retryable=false before retryable code heuristics', () => {
+      const error = {
+        code: 'NETWORK_ERROR',
+        message: 'Connection failed',
+        retryable: false,
+      };
+
+      expect(retryManager.isRetryableError(error)).toBe(false);
+    });
+
     test('should return false for non-transient Python errors', () => {
       const error = {
         code: 'PYTHON_ERROR',

--- a/__tests__/venv-manager.test.js
+++ b/__tests__/venv-manager.test.js
@@ -6,7 +6,7 @@
  * New tests only validate path detection and error messages.
  */
 
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, jest } from '@jest/globals';
 import { getManagedPythonPath } from '../dist/lib/venv-manager.js';
 import { existsSync } from 'fs';
 import * as path from 'path';
@@ -82,6 +82,20 @@ describe('venv-manager (UV-based)', () => {
 
       // This ensures if project moves, venv moves with it
     });
+  });
+});
+
+describe('venv-manager path validation', () => {
+  test('does not launch an unbounded Python version subprocess before the owned runner', async () => {
+    jest.resetModules();
+    const execSync = jest.fn(() => {
+      throw new Error('unbounded validation subprocess launched');
+    });
+    jest.unstable_mockModule('child_process', () => ({ execSync }));
+
+    const { getManagedPythonPath: getPath } = await import('../dist/lib/venv-manager.js');
+    await expect(getPath()).resolves.toContain('.venv');
+    expect(execSync).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/zlibrary-api-extended.test.js
+++ b/__tests__/zlibrary-api-extended.test.js
@@ -12,7 +12,7 @@ jest.setTimeout(30000);
 
 // Mock dependencies
 const mockGetManagedPythonPath = jest.fn();
-const mockPythonShellRun = jest.fn();
+const mockRunPythonBridge = jest.fn();
 
 // Use dynamic path resolution for portability
 const EXPECTED_SCRIPT_PATH = path.resolve(process.cwd(), 'lib');
@@ -35,10 +35,19 @@ describe('Z-Library API - Extended Coverage', () => {
       getManagedPythonPath: mockGetManagedPythonPath,
     }));
 
-    jest.unstable_mockModule('python-shell', () => ({
-      PythonShell: {
-        run: mockPythonShellRun,
-      },
+    // The bridge subprocess is spawned through python-runner, not
+    // PythonShell.run: the runner is what enforces the wall-clock budget and
+    // kills the child. Mocking it here keeps these tests focused on
+    // callPythonFunction's parsing and error handling.
+    // A factory mock replaces the module wholesale, so every export the module
+    // under test imports has to appear here or the import fails at link time.
+    jest.unstable_mockModule('../lib/python-runner.js', () => ({
+      runPythonBridge: mockRunPythonBridge,
+      killAllPythonChildren: jest.fn(),
+      installExitHooks: jest.fn(),
+      liveChildCount: jest.fn(() => 0),
+      DEFAULT_BRIDGE_TIMEOUT_MS: 240000,
+      LONG_BRIDGE_TIMEOUT_MS: 1800000,
     }));
 
     // Minimal fs mock (required by module imports)
@@ -84,18 +93,18 @@ describe('Z-Library API - Extended Coverage', () => {
       };
 
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
 
       const result = await zlibApi.getBookMetadata('12345', 'abcdef', ['terms', 'description']);
 
       // Verify Python bridge call
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         scriptPath: EXPECTED_SCRIPT_PATH,
         args: ['get_book_metadata_complete', JSON.stringify({
           book_id: '12345',
           book_hash: 'abcdef',
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
 
       // Core fields should be present
       expect(result.title).toBe('Being and Time');
@@ -129,7 +138,7 @@ describe('Z-Library API - Extended Coverage', () => {
       };
 
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
 
       const result = await zlibApi.getBookMetadata('1', 'hash1');
 
@@ -147,7 +156,7 @@ describe('Z-Library API - Extended Coverage', () => {
       const fullMetadata = { id: '2', title: 'Book', terms: ['t1'] };
 
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
 
       const result = await zlibApi.getBookMetadata('2', 'hash2', []);
 
@@ -166,7 +175,7 @@ describe('Z-Library API - Extended Coverage', () => {
       };
 
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
 
       const result = await zlibApi.getBookMetadata('3', 'hash3', ['booklists', 'ipfs', 'ratings']);
 
@@ -177,7 +186,7 @@ describe('Z-Library API - Extended Coverage', () => {
 
     test('should handle non-object metadata (null/undefined) gracefully', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(null));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(null));
 
       const result = await zlibApi.getBookMetadata('4', 'hash4');
       expect(result).toBeNull();
@@ -187,7 +196,7 @@ describe('Z-Library API - Extended Coverage', () => {
       const fullMetadata = { id: '5', title: 'Book' };
 
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
 
       // Request 'terms' group but metadata has no 'terms' field
       const result = await zlibApi.getBookMetadata('5', 'hash5', ['terms']);
@@ -201,7 +210,7 @@ describe('Z-Library API - Extended Coverage', () => {
       const fullMetadata = { id: '6', title: 'Book', terms: ['t1'] };
 
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(fullMetadata));
 
       const result = await zlibApi.getBookMetadata('6', 'hash6', ['nonexistent_group']);
 
@@ -216,7 +225,7 @@ describe('Z-Library API - Extended Coverage', () => {
     test('should call Python bridge with correct args', async () => {
       const mockResult = [{ id: '1', title: 'Dialectic Book' }];
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(mockResult));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(mockResult));
 
       const result = await zlibApi.searchByTerm({
         term: 'dialectic',
@@ -227,7 +236,7 @@ describe('Z-Library API - Extended Coverage', () => {
         limit: 30,
       });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         scriptPath: EXPECTED_SCRIPT_PATH,
         args: ['search_by_term_bridge', JSON.stringify({
           term: 'dialectic',
@@ -237,17 +246,17 @@ describe('Z-Library API - Extended Coverage', () => {
           extensions: ['pdf'],
           limit: 30,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
       expect(result).toEqual(mockResult);
     });
 
     test('should use default limit of 25 when not specified', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse([]));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse([]));
 
       await zlibApi.searchByTerm({ term: 'epistemology' });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         args: ['search_by_term_bridge', JSON.stringify({
           term: 'epistemology',
           year_from: undefined,
@@ -256,12 +265,12 @@ describe('Z-Library API - Extended Coverage', () => {
           extensions: undefined,
           limit: 25,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
     });
 
     test('should propagate errors from Python bridge', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(new Error('Term search failed'));
+      mockRunPythonBridge.mockRejectedValue(new Error('Term search failed'));
 
       await expect(zlibApi.searchByTerm({ term: 'test' }))
         .rejects.toThrow(/Python bridge execution failed for search_by_term_bridge/);
@@ -272,7 +281,7 @@ describe('Z-Library API - Extended Coverage', () => {
     test('should call Python bridge with correct args', async () => {
       const mockResult = [{ id: '1', title: 'Critique of Pure Reason' }];
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(mockResult));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(mockResult));
 
       const result = await zlibApi.searchByAuthor({
         author: 'Kant, Immanuel',
@@ -284,7 +293,7 @@ describe('Z-Library API - Extended Coverage', () => {
         limit: 10,
       });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         scriptPath: EXPECTED_SCRIPT_PATH,
         args: ['search_by_author_bridge', JSON.stringify({
           author: 'Kant, Immanuel',
@@ -295,17 +304,17 @@ describe('Z-Library API - Extended Coverage', () => {
           extensions: ['epub'],
           limit: 10,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
       expect(result).toEqual(mockResult);
     });
 
     test('should use defaults for exact (false) and limit (25)', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse([]));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse([]));
 
       await zlibApi.searchByAuthor({ author: 'Hegel' });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         args: ['search_by_author_bridge', JSON.stringify({
           author: 'Hegel',
           exact: false,
@@ -315,12 +324,12 @@ describe('Z-Library API - Extended Coverage', () => {
           extensions: undefined,
           limit: 25,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
     });
 
     test('should propagate errors from Python bridge', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(new Error('Author search failed'));
+      mockRunPythonBridge.mockRejectedValue(new Error('Author search failed'));
 
       await expect(zlibApi.searchByAuthor({ author: 'test' }))
         .rejects.toThrow(/Python bridge execution failed for search_by_author_bridge/);
@@ -331,7 +340,7 @@ describe('Z-Library API - Extended Coverage', () => {
     test('should call Python bridge with correct args', async () => {
       const mockResult = { books: [{ title: 'Listed Book' }], total: 50, page: 2 };
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(mockResult));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(mockResult));
 
       const result = await zlibApi.fetchBooklist({
         booklistId: 'bl123',
@@ -340,7 +349,7 @@ describe('Z-Library API - Extended Coverage', () => {
         page: 2,
       });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         scriptPath: EXPECTED_SCRIPT_PATH,
         args: ['fetch_booklist_bridge', JSON.stringify({
           booklist_id: 'bl123',
@@ -348,13 +357,13 @@ describe('Z-Library API - Extended Coverage', () => {
           topic: 'Continental Philosophy',
           page: 2,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
       expect(result).toEqual(mockResult);
     });
 
     test('should use default page of 1 when not specified', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse({ books: [] }));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse({ books: [] }));
 
       await zlibApi.fetchBooklist({
         booklistId: 'bl1',
@@ -362,19 +371,19 @@ describe('Z-Library API - Extended Coverage', () => {
         topic: 'test',
       });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         args: ['fetch_booklist_bridge', JSON.stringify({
           booklist_id: 'bl1',
           booklist_hash: 'hash1',
           topic: 'test',
           page: 1,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
     });
 
     test('should propagate errors from Python bridge', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(new Error('Booklist failed'));
+      mockRunPythonBridge.mockRejectedValue(new Error('Booklist failed'));
 
       await expect(zlibApi.fetchBooklist({
         booklistId: 'bl1', booklistHash: 'h1', topic: 't1',
@@ -389,7 +398,7 @@ describe('Z-Library API - Extended Coverage', () => {
         fuzzy_matches: [{ title: 'Fuzzy Match' }],
       };
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(mockResult));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(mockResult));
 
       const result = await zlibApi.searchAdvanced({
         query: 'phenomenology of spirit',
@@ -399,7 +408,7 @@ describe('Z-Library API - Extended Coverage', () => {
         count: 5,
       });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         scriptPath: EXPECTED_SCRIPT_PATH,
         args: ['search_advanced', JSON.stringify({
           query: 'phenomenology of spirit',
@@ -408,17 +417,17 @@ describe('Z-Library API - Extended Coverage', () => {
           to_year: 1807,
           count: 5,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
       expect(result).toEqual(mockResult);
     });
 
     test('should use defaults for exact (false) and count (10)', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse({}));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse({}));
 
       await zlibApi.searchAdvanced({ query: 'test' });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         args: ['search_advanced', JSON.stringify({
           query: 'test',
           exact: false,
@@ -426,12 +435,12 @@ describe('Z-Library API - Extended Coverage', () => {
           to_year: undefined,
           count: 10,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
     });
 
     test('should propagate errors from Python bridge', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(new Error('Advanced search failed'));
+      mockRunPythonBridge.mockRejectedValue(new Error('Advanced search failed'));
 
       await expect(zlibApi.searchAdvanced({ query: 'test' }))
         .rejects.toThrow(/Python bridge execution failed for search_advanced/);
@@ -442,7 +451,7 @@ describe('Z-Library API - Extended Coverage', () => {
     test('should call Python bridge with correct args', async () => {
       const mockResult = [{ md5: 'abc123', title: 'Multi Book', source: 'annas' }];
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse(mockResult));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse(mockResult));
 
       const result = await zlibApi.searchMultiSource({
         query: 'philosophy',
@@ -450,38 +459,170 @@ describe('Z-Library API - Extended Coverage', () => {
         count: 20,
       });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         scriptPath: EXPECTED_SCRIPT_PATH,
         args: ['search_multi_source', JSON.stringify({
           query: 'philosophy',
           source: 'annas',
           count: 20,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
       expect(result).toEqual(mockResult);
     });
 
     test('should use defaults for source (auto) and count (10)', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValueOnce(mockMcpResponse([]));
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse([]));
 
       await zlibApi.searchMultiSource({ query: 'test' });
 
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
         args: ['search_multi_source', JSON.stringify({
           query: 'test',
           source: 'auto',
           count: 10,
         })],
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
     });
 
     test('should propagate errors from Python bridge', async () => {
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(new Error('Multi-source failed'));
+      mockRunPythonBridge.mockRejectedValue(new Error('Multi-source failed'));
 
       await expect(zlibApi.searchMultiSource({ query: 'test' }))
         .rejects.toThrow(/Python bridge execution failed for search_multi_source/);
+    });
+
+    test('should pass an abort signal through to the runner', async () => {
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockResolvedValueOnce(mockMcpResponse([]));
+      const controller = new AbortController();
+
+      await zlibApi.searchMultiSource({ query: 'test' }, { signal: controller.signal });
+
+      expect(mockRunPythonBridge).toHaveBeenCalledWith(
+        'python_bridge.py',
+        expect.any(Object),
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+  });
+
+  /**
+   * The bridge writes a JSON envelope to stderr when a provider fails. These
+   * assert it survives the trip to the caller: a caller that cannot tell
+   * "annas-archive.gl does not resolve" from "libgen.li dropped the
+   * connection" cannot pick a useful next step.
+   */
+  describe('provider failure surfacing', () => {
+    /** Build a python-shell style rejection carrying a bridge stderr envelope. */
+    function bridgeFailure(envelope, extraStderr = '') {
+      const err = new Error('Python process exited with code 1');
+      err.stderr = `${extraStderr}${JSON.stringify(envelope)}`;
+      return err;
+    }
+
+    test('surfaces the provider, host and reason from the stderr envelope', async () => {
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockRejectedValue(
+        bridgeFailure({
+          error: 'annas (annas-archive.gl) could not be resolved',
+          type: 'ProviderUnreachableError',
+          details: {
+            provider: 'annas',
+            host: 'annas-archive.gl',
+            reason: 'dns_failure',
+            detail: 'Name or service not known',
+          },
+        }),
+      );
+
+      const error = await zlibApi
+        .searchMultiSource({ query: 'test', source: 'annas' })
+        .catch((e) => e);
+
+      expect(error.message).toContain('annas-archive.gl');
+      expect(error.message).toContain('search_multi_source failed');
+      expect(error.context.details.provider).toBe('annas');
+      expect(error.context.details.reason).toBe('dns_failure');
+      expect(error.context.pythonErrorType).toBe('ProviderUnreachableError');
+    });
+
+    test('finds the envelope even when log lines precede it on stderr', async () => {
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockRejectedValue(
+        bridgeFailure(
+          {
+            error: 'libgen mirrors all failed',
+            details: {
+              operation: 'search',
+              failures: [
+                { provider: 'libgen', host: 'libgen.li', reason: 'connect_timeout' },
+                { provider: 'libgen', host: 'libgen.vg', reason: 'connect_timeout' },
+              ],
+            },
+          },
+          'WARNING - LibGen mirror li unreachable\nnot json at all\n',
+        ),
+      );
+
+      const error = await zlibApi
+        .searchMultiSource({ query: 'test', source: 'libgen' })
+        .catch((e) => e);
+
+      expect(error.context.details.failures).toHaveLength(2);
+      expect(error.context.details.failures[0].host).toBe('libgen.li');
+    });
+
+    test('an unreachable provider is not retried', async () => {
+      const { isRetryableError } = await import('../lib/retry-manager.js');
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockRejectedValue(
+        bridgeFailure({
+          error: 'libgen (libgen.li) resolved but did not accept a connection',
+          details: { provider: 'libgen', host: 'libgen.li', reason: 'connect_timeout' },
+        }),
+      );
+
+      const error = await zlibApi
+        .searchMultiSource({ query: 'test', source: 'libgen' })
+        .catch((e) => e);
+
+      // The word "connection" in the message would otherwise make the
+      // heuristic classifier retry a host already known to be dead.
+      expect(isRetryableError(error)).toBe(false);
+      expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
+    });
+
+    test('a response-level failure is not marked non-retryable', async () => {
+      // Only reachability failures get the explicit veto. An HTTP error means
+      // the host answered, so whether to retry is left to the general
+      // classifier rather than being decided here.
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockRejectedValue(
+        bridgeFailure({
+          error: 'annas (annas-archive.gl) returned an HTTP error',
+          details: { provider: 'annas', host: 'annas-archive.gl', reason: 'http_error' },
+        }),
+      );
+
+      const error = await zlibApi
+        .searchMultiSource({ query: 'test', source: 'annas' })
+        .catch((e) => e);
+
+      expect(error.retryable).toBe(true);
+    });
+
+    test('falls back to the raw message when stderr holds no envelope', async () => {
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      const err = new Error('boom');
+      err.stderr = 'Traceback (most recent call last):\n  ValueError: nope';
+      mockRunPythonBridge.mockRejectedValue(err);
+
+      const error = await zlibApi.searchMultiSource({ query: 'test' }).catch((e) => e);
+
+      expect(error.message).toContain('Python bridge execution failed');
+      expect(error.message).toContain('Traceback');
     });
   });
 });

--- a/__tests__/zlibrary-api-extended.test.js
+++ b/__tests__/zlibrary-api-extended.test.js
@@ -508,6 +508,39 @@ describe('Z-Library API - Extended Coverage', () => {
     });
   });
 
+  describe('downloadBookToFile error envelope', () => {
+    test('keeps provider details directly on its public-facing wrapper', async () => {
+      const details = {
+        operation: 'download',
+        failures: [
+          { provider: 'libgen', host: 'libgen.li', reason: 'connect_timeout' },
+        ],
+      };
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockRejectedValue(
+        Object.assign(new Error('bridge failed'), {
+          stderr: JSON.stringify({
+            error: 'download failed on every source',
+            type: 'AllSourcesFailedError',
+            details,
+          }),
+        }),
+      );
+
+      const error = await zlibApi
+        .downloadBookToFile({
+          bookDetails: {
+            md5: '0123456789abcdef0123456789abcdef',
+            source: 'libgen',
+          },
+        })
+        .catch((err) => err);
+
+      expect(error.context.details).toEqual(details);
+      expect(error.cause).toBeUndefined();
+    });
+  });
+
   /**
    * The bridge writes a JSON envelope to stderr when a provider fails. These
    * assert it survives the trip to the caller: a caller that cannot tell
@@ -592,6 +625,38 @@ describe('Z-Library API - Extended Coverage', () => {
       // heuristic classifier retry a host already known to be dead.
       expect(isRetryableError(error)).toBe(false);
       expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
+    });
+
+    test('configuration failures do not open the shared bridge circuit', async () => {
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockRejectedValue(
+        bridgeFailure({
+          error: 'download failed on every source',
+          type: 'AllSourcesFailedError',
+          details: {
+            operation: 'download',
+            failures: [
+              {
+                provider: 'annas',
+                host: 'annas-archive.gl',
+                reason: 'configuration_error',
+                detail: 'ANNAS_SECRET_KEY not configured',
+              },
+            ],
+          },
+        }),
+      );
+
+      const messages = [];
+      for (let attempt = 0; attempt < 6; attempt += 1) {
+        const error = await zlibApi
+          .searchMultiSource({ query: 'test', source: 'annas' })
+          .catch((e) => e);
+        messages.push(error.message);
+      }
+
+      expect(messages).not.toContain('Circuit breaker is OPEN');
+      expect(mockRunPythonBridge).toHaveBeenCalledTimes(6);
     });
 
     test('a response-level failure is not marked non-retryable', async () => {

--- a/__tests__/zlibrary-api-extended.test.js
+++ b/__tests__/zlibrary-api-extended.test.js
@@ -47,7 +47,7 @@ describe('Z-Library API - Extended Coverage', () => {
       installExitHooks: jest.fn(),
       liveChildCount: jest.fn(() => 0),
       DEFAULT_BRIDGE_TIMEOUT_MS: 240000,
-      LONG_BRIDGE_TIMEOUT_MS: 1800000,
+      LONG_BRIDGE_TIMEOUT_MS: 2400000,
     }));
 
     // Minimal fs mock (required by module imports)

--- a/__tests__/zlibrary-api-extended.test.js
+++ b/__tests__/zlibrary-api-extended.test.js
@@ -659,6 +659,34 @@ describe('Z-Library API - Extended Coverage', () => {
       expect(mockRunPythonBridge).toHaveBeenCalledTimes(6);
     });
 
+    test('quota exhaustion does not retry or open the shared bridge circuit', async () => {
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockRejectedValue(
+        bridgeFailure({
+          error: 'annas quota exhausted',
+          type: 'SourceError',
+          details: {
+            operation: 'download',
+            provider: 'annas',
+            reason: 'quota_exhausted',
+          },
+        }),
+      );
+
+      const messages = [];
+      for (let attempt = 0; attempt < 6; attempt += 1) {
+        const error = await zlibApi
+          .downloadBookToFile({
+            bookDetails: { md5: '0123456789abcdef0123456789abcdef', source: 'annas' },
+          })
+          .catch((e) => e);
+        messages.push(error.message);
+      }
+
+      expect(messages).not.toContain('Circuit breaker is OPEN');
+      expect(mockRunPythonBridge).toHaveBeenCalledTimes(6);
+    });
+
     test('a response-level failure is not marked non-retryable', async () => {
       // Only reachability failures get the explicit veto. An HTTP error means
       // the host answered, so whether to retry is left to the general

--- a/__tests__/zlibrary-api.test.js
+++ b/__tests__/zlibrary-api.test.js
@@ -11,8 +11,8 @@ jest.setTimeout(30000);
 const mockGetManagedPythonPath = jest.fn();
 const mockRunPythonBridge = jest.fn();
 
-/** Mirrors the runner's PYTHON_BRIDGE_LONG_TIMEOUT default (30 minutes). */
-const LONG_BRIDGE_TIMEOUT_MS = 1800000;
+/** Mirrors the runner's PYTHON_BRIDGE_LONG_TIMEOUT default (40 minutes). */
+const LONG_BRIDGE_TIMEOUT_MS = 2400000;
 const mockFsExistsSync = jest.fn();
 const mockFsMkdirSync = jest.fn();
 const mockFsCreateWriteStream = jest.fn();

--- a/__tests__/zlibrary-api.test.js
+++ b/__tests__/zlibrary-api.test.js
@@ -9,7 +9,10 @@ jest.setTimeout(30000);
 
 // Mock dependencies
 const mockGetManagedPythonPath = jest.fn();
-const mockPythonShellRun = jest.fn();
+const mockRunPythonBridge = jest.fn();
+
+/** Mirrors the runner's PYTHON_BRIDGE_LONG_TIMEOUT default (30 minutes). */
+const LONG_BRIDGE_TIMEOUT_MS = 1800000;
 const mockFsExistsSync = jest.fn();
 const mockFsMkdirSync = jest.fn();
 const mockFsCreateWriteStream = jest.fn();
@@ -38,10 +41,17 @@ describe('Z-Library API', () => {
       // ensureVenvReady is not used here
     }));
 
-    jest.unstable_mockModule('python-shell', () => ({
-      PythonShell: {
-        run: mockPythonShellRun,
-      },
+    // The bridge subprocess is spawned through python-runner, not
+    // PythonShell.run: the runner is what enforces the wall-clock budget and
+    // kills the child. Mocking it here keeps these tests focused on
+    // callPythonFunction's parsing and error handling.
+    jest.unstable_mockModule('../lib/python-runner.js', () => ({
+      runPythonBridge: mockRunPythonBridge,
+      killAllPythonChildren: jest.fn(),
+      installExitHooks: jest.fn(),
+      liveChildCount: jest.fn(() => 0),
+      DEFAULT_BRIDGE_TIMEOUT_MS: 240000,
+      LONG_BRIDGE_TIMEOUT_MS: LONG_BRIDGE_TIMEOUT_MS,
     }));
 
     // Mock fs, http, https selectively
@@ -90,7 +100,7 @@ describe('Z-Library API', () => {
       // Corrected Mock: Simulate python printing the JSON string of the MCP response structure within an array
       const mockPythonResultString_search1 = JSON.stringify(mockApiResult_search1);
       const mockMcpResponseString_search1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_search1 }] });
-      mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_search1]);
+      mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_search1]);
 
       const searchArgs = {
         query: 'test query', exact: true, fromYear: 2000, toYear: 2023,
@@ -100,7 +110,7 @@ describe('Z-Library API', () => {
       result = await zlibApi.searchBooks(searchArgs);
 
       // Verify PythonShell call
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
           mode: 'text', // Ensure mode is text for double parsing
           pythonPath: '/fake/python',
           scriptPath: EXPECTED_SCRIPT_PATH,
@@ -108,7 +118,7 @@ describe('Z-Library API', () => {
               query: searchArgs.query, exact: searchArgs.exact, from_year: searchArgs.fromYear, to_year: searchArgs.toYear,
               languages: searchArgs.languages, extensions: searchArgs.extensions, content_types: [], count: searchArgs.count
           })]
-      }));
+      }), expect.objectContaining({ label: expect.any(String) }));
       // Verify the final result
       expect(result).toEqual(mockApiResult_search1); // Use unique result var
     });
@@ -117,11 +127,11 @@ describe('Z-Library API', () => {
       const apiError = new Error('Python Search Failed');
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
       // Simulate PythonShell.run rejecting
-      mockPythonShellRun.mockRejectedValue(apiError);
+      mockRunPythonBridge.mockRejectedValue(apiError);
 
       await expect(zlibApi.searchBooks({ query: 'test' })).rejects.toThrow(`Python bridge execution failed for search: ${apiError.message}`);
   // Test suite for the internal callPythonFunction logic
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['search', JSON.stringify({ query: 'test', exact: false, from_year: null, to_year: null, languages: [], extensions: [], content_types: [], count: 10 })] })); // Corrected script name and path
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['search', JSON.stringify({ query: 'test', exact: false, from_year: null, to_year: null, languages: [], extensions: [], content_types: [], count: 10 })] }), expect.objectContaining({ label: expect.any(String) })); // Corrected script name and path
     });
 
     describe('callPythonFunction (Internal Logic)', () => {
@@ -142,14 +152,14 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).not.toHaveBeenCalled(); // PythonShell should not be called
+      expect(mockRunPythonBridge).not.toHaveBeenCalled(); // PythonShell should not be called
     }); // <-- This closes the test for getManagedPythonPath failure
 
     test('should throw error if PythonShell.run throws', async () => {
       // Arrange: Mock getManagedPythonPath to succeed, PythonShell.run to throw
       const shellError = new Error('PythonShell failed');
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(shellError);
+      mockRunPythonBridge.mockRejectedValue(shellError);
 
       // Act & Assert
       await expect(zlibApi.searchBooks({ query: 'test' }))
@@ -158,7 +168,7 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).toHaveBeenCalled();
+      expect(mockRunPythonBridge).toHaveBeenCalled();
     });
 
     test('should throw error if Python script returns an error object', async () => {
@@ -168,7 +178,7 @@ describe('Z-Library API', () => {
       // Corrected Mock: Simulate python printing the JSON string of the MCP response structure containing an error object
       const mockPythonErrorString_err1 = JSON.stringify({ error: pythonErrorMsg });
       const mockMcpErrorResponseString_err1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonErrorString_err1 }] });
-      mockPythonShellRun.mockResolvedValueOnce([mockMcpErrorResponseString_err1]);
+      mockRunPythonBridge.mockResolvedValueOnce([mockMcpErrorResponseString_err1]);
 
       // Act & Assert
       await expect(zlibApi.searchBooks({ query: 'test' }))
@@ -177,7 +187,7 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).toHaveBeenCalled();
+      expect(mockRunPythonBridge).toHaveBeenCalled();
     });
 
     test('should throw error if Python script returns non-JSON string', async () => {
@@ -185,7 +195,7 @@ describe('Z-Library API', () => {
       const nonJsonOutput = 'This is not JSON';
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
       // In text mode, the first parse in callPythonFunction would fail
-      mockPythonShellRun.mockResolvedValueOnce([nonJsonOutput]); // Provide the non-JSON string
+      mockRunPythonBridge.mockResolvedValueOnce([nonJsonOutput]); // Provide the non-JSON string
 
       // Act & Assert
       await expect(zlibApi.searchBooks({ query: 'test' }))
@@ -195,13 +205,13 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).toHaveBeenCalled();
+      expect(mockRunPythonBridge).toHaveBeenCalled();
     });
 
     test('should throw error if Python script returns no output', async () => {
       // Arrange: Mock PythonShell.run to return empty array or undefined
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockResolvedValue([]); // Simulate empty results array
+      mockRunPythonBridge.mockResolvedValue([]); // Simulate empty results array
 
       // Act & Assert
       await expect(zlibApi.searchBooks({ query: 'test' }))
@@ -210,7 +220,7 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).toHaveBeenCalled();
+      expect(mockRunPythonBridge).toHaveBeenCalled();
     });
 
      test('should throw error if Python script returns unexpected object format', async () => {
@@ -220,7 +230,7 @@ describe('Z-Library API', () => {
       // Corrected Mock: Simulate python printing the JSON string of the MCP response structure containing the unexpected object
       const mockPythonUnexpectedString_unexp1 = JSON.stringify(unexpectedObject);
       const mockMcpUnexpectedResponseString_unexp1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonUnexpectedString_unexp1 }] });
-      mockPythonShellRun.mockResolvedValueOnce([mockMcpUnexpectedResponseString_unexp1]);
+      mockRunPythonBridge.mockResolvedValueOnce([mockMcpUnexpectedResponseString_unexp1]);
 
       // Act & Assert: The double parse should succeed, returning the unexpected object
       const result = await zlibApi.searchBooks({ query: 'test' });
@@ -228,7 +238,7 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).toHaveBeenCalled();
+      expect(mockRunPythonBridge).toHaveBeenCalled();
     });
 
     test('should include stderr in error message when PythonShell provides it', async () => {
@@ -236,7 +246,7 @@ describe('Z-Library API', () => {
       const shellError = new Error('Python script failed');
       shellError.stderr = 'ImportError: No module named foo\nTraceback...';
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(shellError);
+      mockRunPythonBridge.mockRejectedValue(shellError);
 
       // Act & Assert
       await expect(zlibApi.searchBooks({ query: 'test' }))
@@ -245,7 +255,7 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).toHaveBeenCalled();
+      expect(mockRunPythonBridge).toHaveBeenCalled();
     });
 
     test('should handle PythonShell non-zero exit code error', async () => {
@@ -254,7 +264,7 @@ describe('Z-Library API', () => {
       exitError.exitCode = 1;
       exitError.stderr = 'SyntaxError: invalid syntax';
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(exitError);
+      mockRunPythonBridge.mockRejectedValue(exitError);
 
       // Act & Assert
       await expect(zlibApi.searchBooks({ query: 'test' }))
@@ -263,14 +273,14 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).toHaveBeenCalled();
+      expect(mockRunPythonBridge).toHaveBeenCalled();
     });
 
     test('should handle PythonShell timeout error', async () => {
       // Arrange: Mock PythonShell.run to throw timeout error
       const timeoutError = new Error('Timeout: Python script exceeded execution time');
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(timeoutError);
+      mockRunPythonBridge.mockRejectedValue(timeoutError);
 
       // Act & Assert
       await expect(zlibApi.searchBooks({ query: 'test' }))
@@ -279,7 +289,7 @@ describe('Z-Library API', () => {
 
       // Verify mocks
       expect(mockGetManagedPythonPath).toHaveBeenCalled();
-      expect(mockPythonShellRun).toHaveBeenCalled();
+      expect(mockRunPythonBridge).toHaveBeenCalled();
     });
 
     }); // <-- This closes describe('callPythonFunction (Internal Logic)')
@@ -302,14 +312,14 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure containing an empty list
         const mockPythonEmptyResultString_empty1 = JSON.stringify(mockApiResultEmpty_empty1);
         const mockMcpEmptyResponseString_empty1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonEmptyResultString_empty1 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpEmptyResponseString_empty1]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpEmptyResponseString_empty1]);
 
         result = await zlibApi.searchBooks({ query: 'empty test' });
 
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
             scriptPath: EXPECTED_SCRIPT_PATH,
             args: ['search', JSON.stringify({ query: 'empty test', exact: false, from_year: null, to_year: null, languages: [], extensions: [], content_types: [], count: 10 })] // Default args
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         expect(result).toEqual(mockApiResultEmpty_empty1); // Use unique result var
     });
 
@@ -320,7 +330,7 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_ft1 = JSON.stringify(mockApiResult_ft1);
         const mockMcpResponseString_ft1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_ft1 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_ft1]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_ft1]);
 
         const searchArgs = {
             query: 'javascript', exact: false, phrase: true, words: false,
@@ -328,24 +338,24 @@ describe('Z-Library API', () => {
         };
         result = await zlibApi.fullTextSearch(searchArgs);
 
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
             scriptPath: EXPECTED_SCRIPT_PATH,
             args: ['full_text_search', JSON.stringify({
                 query: searchArgs.query, exact: searchArgs.exact, phrase: searchArgs.phrase, words: searchArgs.words,
                 languages: searchArgs.languages, extensions: searchArgs.extensions, content_types: [], count: searchArgs.count
             })]
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         expect(result).toEqual(mockApiResult_ft1); // Use unique result var
     });
 
      test('should handle errors from Python bridge during fullTextSearch', async () => {
       const apiError = new Error('Python Full Text Failed');
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(apiError);
+      mockRunPythonBridge.mockRejectedValue(apiError);
 
       await expect(zlibApi.fullTextSearch({ query: 'fail text' })).rejects.toThrow(`Python bridge execution failed for full_text_search: ${apiError.message}`);
       // Check default args passed to python
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['full_text_search', JSON.stringify({ query: 'fail text', exact: false, phrase: true, words: false, languages: [], extensions: [], content_types: [], count: 10 })] })); // Corrected script name and path
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['full_text_search', JSON.stringify({ query: 'fail text', exact: false, phrase: true, words: false, languages: [], extensions: [], content_types: [], count: 10 })] }), expect.objectContaining({ label: expect.any(String) })); // Corrected script name and path
     });
   });
 
@@ -359,15 +369,15 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_dl1 = JSON.stringify(pythonResult_dl1);
         const mockMcpResponseString_dl1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_dl1 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_dl1]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_dl1]);
 
         const mockBookDetails = { id: 'success123', url: 'http://example.com/book/success123/slug', title: 'Success Book' };
         const downloadArgs = { bookDetails: mockBookDetails, outputDir: './downloads', process_for_rag: false };
 
         result = await zlibApi.downloadBookToFile(downloadArgs);
 
-        expect(mockPythonShellRun).toHaveBeenCalledTimes(1);
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+        expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
             scriptPath: EXPECTED_SCRIPT_PATH,
             args: ['download_book', JSON.stringify({
                 book_details: mockBookDetails, // Pass bookDetails object
@@ -375,7 +385,7 @@ describe('Z-Library API', () => {
                 process_for_rag: false,
                 processed_output_format: 'txt' // Default format
             })]
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         expect(result).toEqual({
             file_path: '/abs/path/to/downloads/Success Book.epub'
             // No processed_file_path expected
@@ -400,15 +410,15 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_dl2 = JSON.stringify(pythonResult_dl2);
         const mockMcpResponseString_dl2 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_dl2 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_dl2]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_dl2]);
 
         const mockBookDetails = { id: 'rag123', url: 'http://example.com/book/rag123/slug', title: 'RAG Book' };
         const downloadArgs = { bookDetails: mockBookDetails, outputDir: './rag_out', process_for_rag: true, processed_output_format: 'md' };
 
         result = await zlibApi.downloadBookToFile(downloadArgs);
 
-        expect(mockPythonShellRun).toHaveBeenCalledTimes(1);
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+        expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
             scriptPath: EXPECTED_SCRIPT_PATH,
             args: ['download_book', JSON.stringify({
                 book_details: mockBookDetails, // Pass bookDetails object
@@ -416,7 +426,7 @@ describe('Z-Library API', () => {
                 process_for_rag: true,
                 processed_output_format: 'md'
             })]
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         expect(result).toEqual({
             file_path: '/abs/path/to/rag_out/RAG Book.pdf',
             processed_file_path: '/abs/path/to/processed_rag_output/RAG Book.pdf.processed.md',
@@ -445,22 +455,22 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_dl3 = JSON.stringify(pythonResult_dl3);
         const mockMcpResponseString_dl3 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_dl3 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_dl3]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_dl3]);
 
         const mockBookDetails = { id: 'image456', url: 'http://example.com/book/image456/slug', title: 'Image Book' };
         const downloadArgs = { bookDetails: mockBookDetails, process_for_rag: true };
 
         result = await zlibApi.downloadBookToFile(downloadArgs);
 
-        expect(mockPythonShellRun).toHaveBeenCalledTimes(1);
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+        expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
             args: ['download_book', JSON.stringify({
                 book_details: mockBookDetails, // Pass bookDetails object
                 output_dir: './downloads', // Default dir
                 process_for_rag: true,
                 processed_output_format: 'txt' // Default format
             })]
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         expect(result).toEqual({
             file_path: '/abs/path/to/image.pdf',
             processed_file_path: null,
@@ -478,7 +488,7 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_dl4 = JSON.stringify(invalidPythonResult_dl4);
         const mockMcpResponseString_dl4 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_dl4 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_dl4]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_dl4]);
 
         const mockBookDetails = { id: 'invalidResp1', url: 'http://example.com/book/invalidResp1/slug' };
         const downloadArgs = { bookDetails: mockBookDetails };
@@ -488,7 +498,7 @@ describe('Z-Library API', () => {
             // Match the actual wrapped error message
             .toThrow("Failed to download book: Invalid response from Python bridge: Missing original file_path.");
 
-        expect(mockPythonShellRun).toHaveBeenCalledTimes(1);
+        expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
     });
 
     // Updated for Spec v2.1: Uses bookDetails
@@ -498,7 +508,7 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_dl5 = JSON.stringify(invalidPythonResult_dl5);
         const mockMcpResponseString_dl5 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_dl5 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_dl5]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_dl5]);
 
         const mockBookDetails = { id: 'invalidResp2', url: 'http://example.com/book/invalidResp2/slug' };
         const downloadArgs = { bookDetails: mockBookDetails, process_for_rag: true };
@@ -507,18 +517,18 @@ describe('Z-Library API', () => {
             .rejects
             .toThrow("Invalid response from Python bridge: Processing requested but processed_file_path key is missing.");
 
-        expect(mockPythonShellRun).toHaveBeenCalledTimes(1);
+        expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
     });
 
     // Updated for Spec v2.1: Uses bookDetails
     test('should handle errors from Python bridge during download_book', async () => {
       const apiError = new Error('Python Download Book Failed');
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(apiError);
+      mockRunPythonBridge.mockRejectedValue(apiError);
 
       const mockBookDetails = { id: 'failDownload', url: 'http://example.com/book/failDownload/slug' };
       await expect(zlibApi.downloadBookToFile({ bookDetails: mockBookDetails })).rejects.toThrow(`Python bridge execution failed for download_book: ${apiError.message}`);
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['download_book', JSON.stringify({ book_details: mockBookDetails, output_dir: './downloads', process_for_rag: false, processed_output_format: 'txt' })] }));
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['download_book', JSON.stringify({ book_details: mockBookDetails, output_dir: './downloads', process_for_rag: false, processed_output_format: 'txt' })] }), expect.objectContaining({ label: expect.any(String) }));
     });
 
   });
@@ -530,25 +540,25 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_hist1 = JSON.stringify(mockApiResult_hist1);
         const mockMcpResponseString_hist1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_hist1 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_hist1]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_hist1]);
 
         const historyArgs = { count: 10 };
         result = await zlibApi.getDownloadHistory(historyArgs);
 
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
             scriptPath: EXPECTED_SCRIPT_PATH,
             args: ['get_download_history', JSON.stringify({ count: historyArgs.count })]
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         expect(result).toEqual(mockApiResult_hist1); // Use unique result var
     });
 
      test('should handle errors from Python bridge during getDownloadHistory', async () => {
       const apiError = new Error('Python History Failed');
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(apiError);
+      mockRunPythonBridge.mockRejectedValue(apiError);
 
       await expect(zlibApi.getDownloadHistory({ count: 5 })).rejects.toThrow(`Python bridge execution failed for get_download_history: ${apiError.message}`);
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['get_download_history', JSON.stringify({ count: 5 })] })); // Corrected script name and path
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['get_download_history', JSON.stringify({ count: 5 })] }), expect.objectContaining({ label: expect.any(String) })); // Corrected script name and path
     });
   });
 
@@ -559,24 +569,24 @@ describe('Z-Library API', () => {
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_lim1 = JSON.stringify(mockApiResult_lim1);
         const mockMcpResponseString_lim1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_lim1 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_lim1]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_lim1]);
 
         result = await zlibApi.getDownloadLimits();
 
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ // Corrected script name
             scriptPath: EXPECTED_SCRIPT_PATH,
             args: ['get_download_limits', JSON.stringify({})] // Empty args object
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         expect(result).toEqual(mockApiResult_lim1); // Use unique result var
     });
 
      test('should handle errors from Python bridge during getDownloadLimits', async () => {
       const apiError = new Error('Python Limits Failed');
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(apiError);
+      mockRunPythonBridge.mockRejectedValue(apiError);
 
       await expect(zlibApi.getDownloadLimits()).rejects.toThrow(`Python bridge execution failed for get_download_limits: ${apiError.message}`);
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['get_download_limits', JSON.stringify({})] })); // Corrected script name and path
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['get_download_limits', JSON.stringify({})] }), expect.objectContaining({ label: expect.any(String) })); // Corrected script name and path
     });
   });
 
@@ -597,7 +607,7 @@ describe('Z-Library API', () => {
         // Corrected: Ensure mock provides the stringified MCP response in an array (Unique Vars)
         const mockPythonResultString_rag1 = JSON.stringify(pythonResult_rag1);
         const mockMcpResponseString_rag1 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_rag1 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_rag1]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_rag1]);
 
         const processArgs = { filePath: './local/doc.txt', outputFormat: 'txt' };
         const expectedPythonFilePath = path.resolve('./local/doc.txt'); // Node resolves path
@@ -606,14 +616,14 @@ describe('Z-Library API', () => {
         result = await zlibApi.processDocumentForRag(processArgs);
 
         // Assert Python call
-        expect(mockPythonShellRun).toHaveBeenCalledTimes(1);
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+        expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
             scriptPath: EXPECTED_SCRIPT_PATH,
             args: ['process_document', JSON.stringify({
                 file_path_str: expectedPythonFilePath, // Correct arg name
                 output_format: 'txt'
             })]
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         // Assert final result structure (based on spec v2.1)
         expect(result).toEqual({
             processed_file_path: '/abs/path/to/processed_rag_output/doc.txt.processed.txt',
@@ -639,7 +649,7 @@ describe('Z-Library API', () => {
         // Corrected: Ensure mock provides the stringified MCP response in an array (Unique Vars)
         const mockPythonResultString_rag2 = JSON.stringify(pythonResult_rag2);
         const mockMcpResponseString_rag2 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_rag2 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_rag2]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_rag2]);
 
         const processArgs = { filePath: './local/image.pdf' };
         const expectedPythonFilePath = path.resolve('./local/image.pdf');
@@ -648,13 +658,13 @@ describe('Z-Library API', () => {
         result = await zlibApi.processDocumentForRag(processArgs);
 
         // Assert Python call
-        expect(mockPythonShellRun).toHaveBeenCalledTimes(1);
-        expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+        expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
             args: ['process_document', JSON.stringify({
                 file_path_str: expectedPythonFilePath, // Correct arg name expected by Python
                 output_format: 'txt' // Default
             })]
-        }));
+        }), expect.objectContaining({ label: expect.any(String) }));
         // Assert final result structure (based on spec v2.1)
         expect(result).toEqual({
             processed_file_path: null,
@@ -673,7 +683,7 @@ describe('Z-Library API', () => {
         // Corrected: Ensure mock provides the stringified MCP response in an array (Unique Vars)
         const mockPythonResultString_rag3 = JSON.stringify(invalidPythonResult_rag3);
         const mockMcpResponseString_rag3 = JSON.stringify({ content: [{ type: 'text', text: mockPythonResultString_rag3 }] });
-        mockPythonShellRun.mockResolvedValueOnce([mockMcpResponseString_rag3]);
+        mockRunPythonBridge.mockResolvedValueOnce([mockMcpResponseString_rag3]);
 
         const processArgs = { filePath: './local/doc.txt' };
 
@@ -682,17 +692,63 @@ describe('Z-Library API', () => {
             .rejects
             .toThrow("Invalid response from Python bridge during processing. Missing processed_file_path key."); // Updated error message
 
-        expect(mockPythonShellRun).toHaveBeenCalledTimes(1);
+        expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
     });
 
     test('should handle errors from Python bridge during processDocumentForRag', async () => {
       const apiError = new Error('Python Process Failed');
       mockGetManagedPythonPath.mockResolvedValue('/fake/python');
-      mockPythonShellRun.mockRejectedValue(apiError);
+      mockRunPythonBridge.mockRejectedValue(apiError);
 
       await expect(zlibApi.processDocumentForRag({ filePath: './local/doc.txt' })).rejects.toThrow(`Python bridge execution failed for process_document: ${apiError.message}`);
       const expectedPythonFilePath = path.resolve('./local/doc.txt');
-      expect(mockPythonShellRun).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['process_document', JSON.stringify({ file_path_str: expectedPythonFilePath, output_format: 'txt' })] }));
+      expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['process_document', JSON.stringify({ file_path_str: expectedPythonFilePath, output_format: 'txt' })] }), expect.objectContaining({ label: expect.any(String) }));
+    });
+  });
+
+  /**
+   * A budget sized for a provider walk would kill a large download or an OCR
+   * pass mid-flight — turning a slow success into a hard failure, which is a
+   * worse outcome than the orphaned process the budget exists to prevent.
+   */
+  describe('long-running bridge calls', () => {
+    /** The runOptions the bridge was called with on the given invocation. */
+    const runOptionsOf = (call = 0) => mockRunPythonBridge.mock.calls[call][2];
+
+    /** Resolve the bridge with a payload the caller will accept. */
+    const resolveWith = (payload) => {
+      mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+      mockRunPythonBridge.mockResolvedValueOnce([
+        JSON.stringify({ content: [{ type: 'text', text: JSON.stringify(payload) }] }),
+      ]);
+    };
+
+    test('a search inherits the runner default rather than pinning one', async () => {
+      resolveWith([]);
+      await zlibApi.searchBooks({ query: 'test' });
+      expect(runOptionsOf().timeoutMs).toBeUndefined();
+    });
+
+    test('a download gets the long budget', async () => {
+      resolveWith({ file_path: '/abs/downloads/Book.epub' });
+      await zlibApi.downloadBookToFile({
+        bookDetails: { id: 'x', url: 'http://example.com/book/x/s', title: 'Book' },
+        outputDir: './downloads',
+      });
+      expect(runOptionsOf().timeoutMs).toBe(LONG_BRIDGE_TIMEOUT_MS);
+      expect(LONG_BRIDGE_TIMEOUT_MS).toBeGreaterThan(240000);
+    });
+
+    test('document processing gets the long budget', async () => {
+      resolveWith({ processed_file_path: '/abs/processed/doc.txt' });
+      await zlibApi.processDocumentForRag({ filePath: './local/doc.txt' });
+      expect(runOptionsOf().timeoutMs).toBe(LONG_BRIDGE_TIMEOUT_MS);
+    });
+
+    test('an explicit per-call budget still wins', async () => {
+      resolveWith([]);
+      await zlibApi.searchMultiSource({ query: 'test' }, { timeoutMs: 1234 });
+      expect(runOptionsOf().timeoutMs).toBe(1234);
     });
   });
 });

--- a/docs/RETRY_CONFIGURATION.md
+++ b/docs/RETRY_CONFIGURATION.md
@@ -29,6 +29,36 @@ The Z-Library MCP server implements comprehensive retry logic with exponential b
 | `CIRCUIT_BREAKER_THRESHOLD` | `5` | Number of failures before opening circuit |
 | `CIRCUIT_BREAKER_TIMEOUT` | `60000` | Time in ms before attempting to close circuit (1 minute) |
 
+### Multi-Source Timeout Configuration
+
+Nothing in the multi-source path may run unbounded. Two layers cooperate, and
+the outer Node budget must remain larger than the worst-case inner provider walk.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BOOK_SOURCE_CONNECT_TIMEOUT` | `10` | TCP/TLS connect budget per phase, in seconds |
+| `BOOK_SOURCE_READ_TIMEOUT` | `30` | Response-read budget per phase, in seconds |
+| `BOOK_SOURCE_TOTAL_TIMEOUT` | `45` | Wall-clock budget for one provider operation, in seconds |
+| `BOOK_SOURCE_PREFLIGHT` | `true` | Probe DNS and TCP before a provider request |
+| `BOOK_SOURCE_PREFLIGHT_TIMEOUT` | `5` | Budget per DNS or TCP probe phase, in seconds |
+| `PYTHON_BRIDGE_TIMEOUT` | `240000` | Ordinary Python bridge wall-clock budget, in milliseconds |
+| `PYTHON_BRIDGE_LONG_TIMEOUT` | `1800000` | Download and document-processing bridge budget, in milliseconds |
+| `PYTHON_BRIDGE_KILL_GRACE` | `3000` | Grace between process-tree termination and forced kill, in milliseconds |
+
+Malformed, non-positive, and non-finite values fall back to their defaults rather
+than disabling a deadline.
+
+Preflight is skipped when `HTTP_PROXY` or `HTTPS_PROXY` covers the target, with
+`NO_PROXY` honored. A direct DNS/TCP socket cannot represent a proxied request;
+letting that probe veto the real client would create a false outage.
+
+The preflight budget applies to two phases (DNS, then TCP). At the defaults, one
+provider attempt can cost at most `2 × 5s + 45s = 55s`. LibGen can walk three
+mirrors and `auto` can add Anna's Archive, so the worst-case search budget is
+`4 × 55s = 220s`, below the 240-second ordinary bridge budget. Raise
+`PYTHON_BRIDGE_TIMEOUT` whenever provider budgets make that composition larger;
+otherwise the outer process-tree kill can preempt legitimate fallback work.
+
 ## How It Works
 
 ### Exponential Backoff

--- a/docs/RETRY_CONFIGURATION.md
+++ b/docs/RETRY_CONFIGURATION.md
@@ -68,6 +68,18 @@ long bridge default composes worst-case LibGen resolution
 keep `PYTHON_BRIDGE_LONG_TIMEOUT` at least as large as their sum after converting
 milliseconds to seconds.
 
+LibGen download resolution inspects at most the first 2 KiB of a candidate
+response. Some CDNs ignore `Range` and answer `200`; the probe streams and closes
+that response after the inspection window instead of buffering the complete book
+inside the 45-second resolution budget.
+
+On POSIX, bridge timeout, MCP abort, and server shutdown first send `SIGTERM` so
+Python can cancel the active coroutine and remove partial `.download` artifacts.
+After `PYTHON_BRIDGE_KILL_GRACE`, any live process group receives `SIGKILL`; the
+server rejects new bridge work during shutdown and does not re-raise its shutdown
+signal until owned groups are observed gone. A second shutdown signal skips the
+remaining grace period. Native Windows hard ownership remains tracked by #116.
+
 ## How It Works
 
 ### Exponential Backoff
@@ -111,6 +123,12 @@ These errors fail immediately without retry:
 - Validation errors (`INVALID_INPUT`, `VALIDATION_ERROR`)
 - Fatal errors (marked with `fatal: true`)
 - Parse errors (malformed responses)
+- Permanent provider state (`configuration_error`, `quota_exhausted`), including
+  rejected Anna fast-download credentials and exhausted Anna quota
+
+Only aggregates whose every child is permanent caller state bypass retry and
+circuit-breaker accounting. Mixed permanent/transient aggregates remain health
+evidence and retain normal retry classification.
 
 ## Usage Examples
 

--- a/docs/RETRY_CONFIGURATION.md
+++ b/docs/RETRY_CONFIGURATION.md
@@ -39,10 +39,11 @@ the outer Node budget must remain larger than the worst-case inner provider walk
 | `BOOK_SOURCE_CONNECT_TIMEOUT` | `10` | TCP/TLS connect budget per phase, in seconds |
 | `BOOK_SOURCE_READ_TIMEOUT` | `30` | Response-read budget per phase, in seconds |
 | `BOOK_SOURCE_TOTAL_TIMEOUT` | `45` | Wall-clock budget for one provider operation, in seconds |
+| `BOOK_SOURCE_DOWNLOAD_TIMEOUT` | `1500` | Wall-clock budget for a complete source-file transfer, in seconds |
 | `BOOK_SOURCE_PREFLIGHT` | `true` | Probe DNS and TCP before a provider request |
 | `BOOK_SOURCE_PREFLIGHT_TIMEOUT` | `5` | Budget per DNS or TCP probe phase, in seconds |
 | `PYTHON_BRIDGE_TIMEOUT` | `240000` | Ordinary Python bridge wall-clock budget, in milliseconds |
-| `PYTHON_BRIDGE_LONG_TIMEOUT` | `1800000` | Download and document-processing bridge budget, in milliseconds |
+| `PYTHON_BRIDGE_LONG_TIMEOUT` | `2400000` | Download and document-processing bridge budget, in milliseconds |
 | `PYTHON_BRIDGE_KILL_GRACE` | `3000` | Grace between process-tree termination and forced kill, in milliseconds |
 
 Malformed, non-positive, and non-finite values fall back to their defaults rather
@@ -58,6 +59,14 @@ mirrors and `auto` can add Anna's Archive, so the worst-case search budget is
 `4 × 55s = 220s`, below the 240-second ordinary bridge budget. Raise
 `PYTHON_BRIDGE_TIMEOUT` whenever provider budgets make that composition larger;
 otherwise the outer process-tree kill can preempt legitimate fallback work.
+
+Source-file transfer has a separate 1,500-second default because a valid large
+book can exceed the 45-second search and URL-resolution budget. The 2,400-second
+long bridge default composes worst-case LibGen resolution
+(`3 × (2 × 5s + 45s) = 165s`), transfer (`1,500s`), the OCR subprocess default
+(`600s`), and finalization headroom (`135s`). If any component is overridden,
+keep `PYTHON_BRIDGE_LONG_TIMEOUT` at least as large as their sum after converting
+milliseconds to seconds.
 
 ## How It Works
 

--- a/docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md
+++ b/docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md
@@ -71,7 +71,11 @@ Replace direct-`PythonShell` lifecycle state with a process-tree record whose id
 - Direct-parent exit cleans stream/listener state but does not cancel escalation or deregister a live group.
 - After the grace period, a live group receives SIGKILL.
 - A lightweight unref'd liveness check removes the record only after the group is gone.
-- Shutdown retries termination for every still-live record.
+- POSIX Python turns SIGTERM into task cancellation so coroutine `finally`
+  blocks close clients and remove partial download artifacts before exit.
+- Shutdown uses the same TERM/grace/KILL path, rejects new bridge work, and
+  re-raises the initiating signal only after every owned group is observed gone.
+  A second signal skips the remaining grace period but retains the observed-gone gate.
 - Windows retains the best-effort `taskkill /T /F` strategy with direct-child
   fallback. It does not provide hard descendant ownership after direct-parent exit,
   remains Linux-host-uncorroborated, and must not be described as host-tested. Native
@@ -136,21 +140,25 @@ This preserves the repository contract that LibGen needs no account and Z-Librar
 }
 ```
 
-Single-source failures may use the top-level provider/host/reason fields. Aggregate failures carry ordered child failures. Configuration errors use `configuration_error` and are permanent caller errors.
+Single-source failures may use the top-level provider/host/reason fields. Aggregate failures carry ordered child failures. Configuration errors use `configuration_error`; exhausted provider quota uses `quota_exhausted`. Both are permanent caller state. An aggregate is permanent only when every child carries one of those reasons.
 
 ### Adapter and aggregate rules
 
 - LibGen resolution accumulates `SourceError` objects, never display strings.
-- `_serves_bytes` returns semantic success/non-byte results but lets transport exceptions propagate for normal classification.
+- `_serves_bytes` streams only its 2 KiB inspection window, returns semantic
+  success/non-byte results, and lets transport exceptions propagate for normal classification.
 - `SourceRouter` preserves child failures from nested aggregates.
-- Anna configuration failures are typed before the router catches them.
+- Anna missing/rejected-key failures and explicit quota exhaustion remain typed
+  before the router or bridge can flatten them.
+- Anna transfer errors normalize the provider to canonical `annas`; success
+  models retain the `annas_archive` source enum.
 
 ### Node normalization
 
 Extract one bridge-envelope parser/normalizer used by both exported Node wrappers. A wrapper may add a human-facing message, but it must preserve the normalized error object directly rather than requiring consumers to traverse arbitrary `cause` chains.
 
 - retry classification reads normalized `reason`/`failures`;
-- the circuit breaker excludes aborts and permanent configuration-only failures;
+- the circuit breaker excludes aborts and all-permanent caller-state failures;
 - search and download handlers use the same normalized details helper;
 - `wrapResult` emits the unchanged envelope as `structuredContent`;
 - no error or diagnostic writes to stdout.
@@ -185,6 +193,14 @@ Required mutations/scenarios:
 10. a valid source transfer may exceed the provider-resolution deadline but not the finite download deadline;
 11. normalized retry verdicts override legacy message heuristics without changing generic legacy bridge-error behavior;
 12. both exported Node wrappers use the long bridge budget for downloads and document processing while preserving explicit overrides.
+13. a real POSIX SIGTERM cancels bridge dispatch and removes a partial download;
+14. server shutdown rejects new work, applies shared TERM/grace/KILL ownership,
+    waits for observed exit, and accelerates safely on a second signal;
+15. a Range-ignoring LibGen CDN cannot make the probe consume the complete body;
+16. Anna rejected-key and quota envelopes bypass retry/breaker accounting only
+    when every aggregate child is permanent;
+17. DNS timeout markers outrank generic `gaierror`, and Anna transfer failures
+    use canonical provider `annas`.
 
 After focused RED-GREEN cycles, run on the exact committed and rebased tree:
 

--- a/docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md
+++ b/docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md
@@ -1,7 +1,7 @@
 # ISSUE-106 Lifecycle and Error-Envelope Design Correction
 
 Date: 2026-08-12
-Status: Proposed for owner review
+Status: Approved for PR #106; native Windows hard ownership deferred to #116
 Scope: PR #106, `fix/ISSUE-NET-001-multi-source-timeouts`
 
 ## Decision
@@ -39,11 +39,26 @@ A per-operation subprocess would make DNS and third-party library hangs killable
 
 Rejected for now: it adds serialization, startup, cleanup, and platform complexity to every provider operation. Use it only if the bounded event-loop resolver cannot close actual HTTP resolution without private-library hooks.
 
-### C. Split or defer the remaining findings
+### C. Split or defer contract-critical lifecycle and envelope findings
 
 Move lifecycle and envelope work into follow-up PRs while leaving #106 open or merging a smaller subset.
 
-Rejected: splitting does not reduce the cross-layer dependencies, and merging would publish guarantees the code does not meet. #101 and #107 would then build on an unstable vocabulary and failure model.
+Rejected: splitting the POSIX lifecycle, cooperative cleanup, DNS classification,
+or envelope work does not reduce the cross-layer dependencies, and merging would
+publish guarantees the code does not meet. #101 and #107 would then build on an
+unstable vocabulary and failure model. Native Windows hard ownership is a separate
+platform boundary and is deferred below.
+
+### D. Defer native Windows hard ownership — selected platform boundary
+
+Keep the existing best-effort `taskkill /T /F` path in #106, but do not claim that
+it retains ownership after the direct Python parent exits. Native Windows Job Object
+ownership, packaging, and real Windows-host lifecycle tests move to #116.
+
+Selected because v1.5 does not promise equal cross-platform process-lifecycle
+containment, while the POSIX lifecycle and provider error contracts remain on the
+critical path for #101 and #107. Issue #116 stays unslotted until a later release map
+explicitly takes ownership of the Windows guarantee.
 
 ## Lifecycle Architecture
 
@@ -57,7 +72,10 @@ Replace direct-`PythonShell` lifecycle state with a process-tree record whose id
 - After the grace period, a live group receives SIGKILL.
 - A lightweight unref'd liveness check removes the record only after the group is gone.
 - Shutdown retries termination for every still-live record.
-- Windows retains the `taskkill /T /F` strategy with direct-child fallback. It remains a Linux-host-unverified boundary and must not be described as host-tested.
+- Windows retains the best-effort `taskkill /T /F` strategy with direct-child
+  fallback. It does not provide hard descendant ownership after direct-parent exit,
+  remains Linux-host-uncorroborated, and must not be described as host-tested. Native
+  Job Object ownership is tracked by #116.
 
 ### Managed-Python validation
 
@@ -194,11 +212,12 @@ The correction is complete only when:
 Stop and return to design if:
 
 - installed httpx/AnyIO bypasses the bounded loop resolver;
-- Windows requires a native job-object dependency to meet the contract;
 - the next Codex pass reports another instance of either structural class.
 
 ## Residual Boundaries
 
-- Windows process-tree behavior requires Windows-host corroboration.
+- Windows hard process-tree ownership is outside #106 and tracked by #116. The
+  retained `taskkill /T /F` fallback is best-effort and lacks Windows-host
+  corroboration.
 - Unit tests mock third-party provider responses by repository policy; live drift remains covered by `npm run doctor` and the upstream workflow.
 - No history rewrite, merge, or auto-merge is part of this design correction.

--- a/docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md
+++ b/docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md
@@ -80,6 +80,14 @@ Install a bounded resolver on the one-shot Python bridge event loop before dispa
 
 The numeric-address TCP preflight remains useful but is no longer the only DNS safety mechanism.
 
+Search and URL resolution use the short provider-operation budget. A complete
+source-file transfer uses a separate finite download budget so a valid large
+book is not cancelled at the search deadline. The finite 2,400-second Node
+long-operation default composes 165 seconds of worst-case LibGen resolution,
+1,500 seconds of transfer, the 600-second OCR subprocess default, and 135
+seconds of finalization headroom. Per-phase HTTP limits and partial-file cleanup
+continue to apply inside that wall clock.
+
 If an integration test demonstrates that httpx bypasses the bounded loop resolver in the installed dependency versions, stop and reconsider alternative B rather than adding another site patch.
 
 ## Source Routing and Initialization
@@ -156,6 +164,9 @@ Required mutations/scenarios:
 7. LibGen preflight, key resolution, and CDN byte-probe DNS/TLS/timeout failures retain mirror host and reason;
 8. search and download aggregates survive Python serialization, both Node wrappers, handlers, and MCP `structuredContent` unchanged;
 9. stdio purity remains intact.
+10. a valid source transfer may exceed the provider-resolution deadline but not the finite download deadline;
+11. normalized retry verdicts override legacy message heuristics without changing generic legacy bridge-error behavior;
+12. both exported Node wrappers use the long bridge budget for downloads and document processing while preserving explicit overrides.
 
 After focused RED-GREEN cycles, run on the exact committed and rebased tree:
 

--- a/docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md
+++ b/docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md
@@ -1,0 +1,193 @@
+# ISSUE-106 Lifecycle and Error-Envelope Design Correction
+
+Date: 2026-08-12
+Status: Proposed for owner review
+Scope: PR #106, `fix/ISSUE-NET-001-multi-source-timeouts`
+
+## Decision
+
+Correct #106 as one cross-layer design rather than continuing site-by-site review fixes.
+
+The implementation will enforce two invariants:
+
+1. One lifecycle owner bounds every Python process, process group, DNS lookup, and provider operation until the owned resource is observed gone.
+2. One normalized provider-error envelope retains provider, host, reason, operation, and child failures from the Python adapter through MCP `structuredContent`.
+
+Source selection must happen before Z-Library authentication so credential-free LibGen acquisition remains supported.
+
+## Why This Correction Is Required
+
+Three substantive review rounds found the same classes at different boundaries:
+
+- timeouts existed at individual awaits while process groups, resolver workers, or validation subprocesses could outlive them;
+- source failures were reclassified or flattened at adapters, aggregates, stderr parsing, Node wrappers, retry/circuit logic, and handlers;
+- `download_book` initialized Z-Library before determining that a LibGen result required no Z-Library account.
+
+The third-round audit reproduced remaining descendant survival, joined resolver shutdown, pre-routing credential failure, CDN-error misclassification, unbounded Python validation, and a secondary exported wrapper with different error semantics. Passing unit suites therefore does not establish the stated #106 contract.
+
+## Alternatives Considered
+
+### A. Centralize lifecycle and error semantics in #106 — selected
+
+Build one lifecycle boundary and one error-envelope boundary, then make every consumer use them. This is the smallest approach that closes the contract #101 and #107 depend on.
+
+Trade-off: it is a cross-layer correction and requires another full review pass.
+
+### B. Isolate every provider operation in its own subprocess
+
+A per-operation subprocess would make DNS and third-party library hangs killable at the OS boundary.
+
+Rejected for now: it adds serialization, startup, cleanup, and platform complexity to every provider operation. Use it only if the bounded event-loop resolver cannot close actual HTTP resolution without private-library hooks.
+
+### C. Split or defer the remaining findings
+
+Move lifecycle and envelope work into follow-up PRs while leaving #106 open or merging a smaller subset.
+
+Rejected: splitting does not reduce the cross-layer dependencies, and merging would publish guarantees the code does not meet. #101 and #107 would then build on an unstable vocabulary and failure model.
+
+## Lifecycle Architecture
+
+### Process-tree ownership
+
+Replace direct-`PythonShell` lifecycle state with a process-tree record whose identity survives direct-parent exit. The record contains the root PID/process-group identity, platform strategy, termination state, and liveness check.
+
+- POSIX launches each bridge in its own process group.
+- Timeout, abort, and shutdown signal the group, not only the direct child.
+- Direct-parent exit cleans stream/listener state but does not cancel escalation or deregister a live group.
+- After the grace period, a live group receives SIGKILL.
+- A lightweight unref'd liveness check removes the record only after the group is gone.
+- Shutdown retries termination for every still-live record.
+- Windows retains the `taskkill /T /F` strategy with direct-child fallback. It remains a Linux-host-unverified boundary and must not be described as host-tested.
+
+### Managed-Python validation
+
+`getManagedPythonPath` will perform filesystem resolution and executable-permission checks only. It will not run `python --version` synchronously.
+
+The first real bridge invocation is the execution check and already runs through the lifecycle owner. Spawn failures retain the existing actionable environment guidance without creating a second unbounded process path.
+
+### DNS and provider-operation bounds
+
+Preflight-only DNS protection is insufficient because AnyIO/httpx resolves hostnames again.
+
+Install a bounded resolver on the one-shot Python bridge event loop before dispatch:
+
+- preserve the event loop `getaddrinfo` signature;
+- execute `socket.getaddrinfo` through the existing daemon-thread boundary;
+- apply the configured DNS/preflight deadline;
+- return normal address tuples to AnyIO/httpx so actual HTTP clients cannot fall back to the joined default executor;
+- restore the loop method during shutdown/tests;
+- translate timeout and resolver failures at the adapter boundary into the stable source vocabulary.
+
+The numeric-address TCP preflight remains useful but is no longer the only DNS safety mechanism.
+
+If an integration test demonstrates that httpx bypasses the bounded loop resolver in the installed dependency versions, stop and reconsider alternative B rather than adding another site patch.
+
+## Source Routing and Initialization
+
+`python_bridge.py::main` must parse the requested operation and `book_details.source` before constructing EAPI state.
+
+- LibGen and Anna source downloads route through `SourceRouter` without Z-Library credentials.
+- Z-Library downloads initialize EAPI only after routing selects Z-Library.
+- Operations that inherently require Z-Library keep the current credential requirement.
+- Missing Anna download credentials become `configuration_error`, not dependency-health evidence.
+
+This preserves the repository contract that LibGen needs no account and Z-Library credentials are not required for server startup or LibGen operations.
+
+## Error-Envelope Architecture
+
+### Canonical Python envelope
+
+`SourceError` and `AllSourcesFailedError` remain the canonical Python vocabulary. Every failure exported from a source operation normalizes to:
+
+```json
+{
+  "operation": "download",
+  "provider": "libgen",
+  "host": "libgen.li",
+  "reason": "connect_timeout",
+  "detail": "...",
+  "failures": []
+}
+```
+
+Single-source failures may use the top-level provider/host/reason fields. Aggregate failures carry ordered child failures. Configuration errors use `configuration_error` and are permanent caller errors.
+
+### Adapter and aggregate rules
+
+- LibGen resolution accumulates `SourceError` objects, never display strings.
+- `_serves_bytes` returns semantic success/non-byte results but lets transport exceptions propagate for normal classification.
+- `SourceRouter` preserves child failures from nested aggregates.
+- Anna configuration failures are typed before the router catches them.
+
+### Node normalization
+
+Extract one bridge-envelope parser/normalizer used by both exported Node wrappers. A wrapper may add a human-facing message, but it must preserve the normalized error object directly rather than requiring consumers to traverse arbitrary `cause` chains.
+
+- retry classification reads normalized `reason`/`failures`;
+- the circuit breaker excludes aborts and permanent configuration-only failures;
+- search and download handlers use the same normalized details helper;
+- `wrapResult` emits the unchanged envelope as `structuredContent`;
+- no error or diagnostic writes to stdout.
+
+## Handling the Existing Local Draft
+
+The current uncommitted 14-file batch is evidence, not an implementation baseline to accept wholesale.
+
+- retain the RED tests and correct adapter/envelope changes where they fit this design;
+- replace the process-tree registry fix because it still loses descendant-only survivors;
+- extend the DNS test through a real local httpx resolution path and interpreter exit;
+- extend the LibGen test so `_serves_bytes` transport failures retain their true reason;
+- add route-before-auth and secondary-wrapper envelope tests.
+
+No existing draft change is published until it satisfies the design and the full verification matrix.
+
+## Test Contract
+
+Each behavior must be observed RED before implementation and GREEN afterward.
+
+Required mutations/scenarios:
+
+1. direct Python parent exits after SIGTERM while a redirected descendant survives;
+2. shutdown still owns and kills that descendant group;
+3. malformed/wrapper Python executable cannot block pre-run validation indefinitely;
+4. actual local httpx hostname resolution stalls, returns within the provider deadline, and the one-shot interpreter exits without joining a resolver worker;
+5. credential-free LibGen download reaches `SourceRouter` without EAPI initialization;
+6. missing Anna key is `configuration_error` and does not consume retry or breaker budget;
+7. LibGen preflight, key resolution, and CDN byte-probe DNS/TLS/timeout failures retain mirror host and reason;
+8. search and download aggregates survive Python serialization, both Node wrappers, handlers, and MCP `structuredContent` unchanged;
+9. stdio purity remains intact.
+
+After focused RED-GREEN cycles, run on the exact committed and rebased tree:
+
+```bash
+npm run build
+node --experimental-vm-modules node_modules/jest/bin/jest.js
+uv run pytest -m "not slow and not integration and not performance" --benchmark-disable -rs
+npx eslint src/
+npx prettier --check src/
+```
+
+Then push normally, reply to each open finding with a fenced review verdict and commit, resolve the matching thread, audit thread-to-verdict pairing, and request one final `@codex review` pass.
+
+## Completion and Stop Conditions
+
+The correction is complete only when:
+
+- every production Python execution path uses the lifecycle owner;
+- no provider HTTP resolution uses the event loop's joined default executor;
+- source selection precedes unrelated authentication;
+- all exported source failures use the canonical envelope through MCP output;
+- the required focused mutations and full matrix pass;
+- all current review threads have technically supported dispositions.
+
+Stop and return to design if:
+
+- installed httpx/AnyIO bypasses the bounded loop resolver;
+- Windows requires a native job-object dependency to meet the contract;
+- the next Codex pass reports another instance of either structural class.
+
+## Residual Boundaries
+
+- Windows process-tree behavior requires Windows-host corroboration.
+- Unit tests mock third-party provider responses by repository policy; live drift remains covered by `npm run doctor` and the upstream workflow.
+- No history rewrite, merge, or auto-merge is part of this design correction.

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,16 +43,22 @@ export default {
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'json-summary'],
   collectCoverageFrom: ['dist/**/*.js', '!dist/**/*.test.js', '!dist/**/*.d.ts'],
-  // Ratcheted to just under the actual measurement (85.08 / 79.59 / 77.89 / 87.37
-  // at 165 tests) so the gate catches a real regression. The previous floors were
-  // set against a 93-test suite and had drifted ~20 points below reality, which
-  // meant coverage could halve without CI noticing. Raise these when coverage
-  // rises; never lower them to make a change pass.
+  // Ratcheted to just under the actual measurement so the gate catches a real
+  // regression. The floors were once set against a 93-test suite and had
+  // drifted ~20 points below reality, which meant coverage could halve without
+  // CI noticing. Raise these when coverage rises; never lower them to make a
+  // change pass.
+  //
+  // Measured 85.89 / 79.68 / 79.67 / 87.61 at 206 tests. Branches and functions
+  // are ratcheted to that; statements and lines are deliberately left lower,
+  // because six venv-manager tests pass only where a .venv exists and their
+  // absence costs ~0.5 points on those two metrics — a floor that assumes them
+  // would fail on a checkout that has not run `uv sync` yet.
   coverageThreshold: {
     global: {
       statements: 84,
-      branches: 78,
-      functions: 76,
+      branches: 79,
+      functions: 79,
       lines: 86,
     },
   },

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -3,6 +3,7 @@ import sys
 import os
 import json
 import traceback
+from urllib.parse import urlsplit
 
 # Add project root to sys.path to allow importing 'lib'
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -23,7 +24,19 @@ from lib import enhanced_metadata
 # Import multi-source router
 from lib.sources.router import SourceRouter
 from lib.sources.config import get_source_config
-from lib.sources.errors import AllSourcesFailedError, SourceError
+from lib.sources.errors import (
+    AllSourcesFailedError,
+    ProviderResponseError,
+    ProviderTimeoutError,
+    ProviderUnreachableError,
+    SourceError,
+)
+from lib.sources.net import (
+    bounded_await,
+    bounded_resolver,
+    build_timeout,
+    classify_httpx_error,
+)
 
 # Add zlibrary source directory to path for EAPI imports
 zlibrary_src_path = os.path.join(os.path.dirname(__file__), "..", "zlibrary", "src")
@@ -694,7 +707,9 @@ async def process_document(
 SOURCE_ALIASES = {"libgen", "annas", "annas_archive"}
 
 
-async def _download_url_to_file(url: str, output_dir: str, md5: str) -> str:
+async def _download_url_to_file(
+    url: str, output_dir: str, md5: str, provider: str
+) -> str:
     """Stream a resolved source URL to disk and return the raw path.
 
     The source-agnostic half of acquisition: everything downstream of this
@@ -710,26 +725,97 @@ async def _download_url_to_file(url: str, output_dir: str, md5: str) -> str:
     Path(output_dir).mkdir(parents=True, exist_ok=True)
     raw_path = Path(output_dir) / f"{md5}.download"
 
-    async with httpx.AsyncClient(timeout=180, follow_redirects=True) as client:
-        async with client.stream("GET", url) as response:
-            response.raise_for_status()
+    original_host = (urlsplit(url).hostname or "").lower()
+    active_host = original_host
+    config = get_source_config()
 
-            content_type = response.headers.get("content-type", "")
-            if "text/html" in content_type:
-                raise ValueError(
-                    f"Source served HTML rather than a file for {md5} — the "
-                    f"download key has most likely expired. Re-resolve and retry."
-                )
+    async def stream_to_disk() -> int:
+        nonlocal active_host
+        try:
+            async with httpx.AsyncClient(
+                timeout=build_timeout(config), follow_redirects=True
+            ) as client:
+                async with client.stream("GET", url) as response:
+                    response_url = getattr(response, "url", None)
+                    if response_url is not None:
+                        active_host = (
+                            urlsplit(str(response_url)).hostname or active_host
+                        ).lower()
+                    response.raise_for_status()
 
-            written = 0
-            with open(raw_path, "wb") as handle:
-                async for chunk in response.aiter_bytes(65536):
-                    handle.write(chunk)
-                    written += len(chunk)
+                    content_type = response.headers.get("content-type", "")
+                    if "text/html" in content_type:
+                        raise ProviderResponseError(
+                            provider,
+                            active_host,
+                            f"HTML response for {md5}; download key may have expired",
+                            reason="protocol_error",
+                        )
+
+                    written = 0
+                    with open(raw_path, "wb") as handle:
+                        async for chunk in response.aiter_bytes(65536):
+                            handle.write(chunk)
+                            written += len(chunk)
+                    return written
+        except BaseException:
+            # Cancellation and every classified failure must leave no partial
+            # artifact for a later retry to mistake for a completed download.
+            raw_path.unlink(missing_ok=True)
+            raise
+
+    try:
+        written = await bounded_await(
+            stream_to_disk(),
+            config.total_timeout,
+            provider=provider,
+            host=original_host,
+            operation="download",
+        )
+    except SourceError as exc:
+        if isinstance(exc, ProviderTimeoutError) and exc.reason == "search_timeout":
+            raise ProviderTimeoutError(
+                provider,
+                active_host,
+                exc.detail,
+                reason="read_timeout",
+            ) from exc
+        raise
+    except httpx.HTTPError as exc:
+        reason, detail = classify_httpx_error(exc)
+        try:
+            request = exc.request
+        except RuntimeError:
+            # Manually raised or transport-created exceptions may expose the
+            # property while leaving it unset. The active response/original
+            # host remains the correct fallback in that case.
+            request = None
+        request_url = getattr(request, "url", None)
+        failure_host = active_host
+        if request_url is not None:
+            failure_host = (urlsplit(str(request_url)).hostname or failure_host).lower()
+        error_type = (
+            ProviderUnreachableError
+            if reason
+            in {
+                "dns_failure",
+                "dns_timeout",
+                "connect_timeout",
+                "connect_refused",
+                "connect_error",
+                "tls_error",
+            }
+            else ProviderTimeoutError
+            if reason == "read_timeout"
+            else ProviderResponseError
+        )
+        raise error_type(provider, failure_host, detail, reason=reason) from exc
 
     if written == 0:
         raw_path.unlink(missing_ok=True)
-        raise ValueError(f"Source returned an empty body for {md5}")
+        raise ProviderResponseError(
+            provider, active_host, f"empty body for {md5}", reason="protocol_error"
+        )
 
     logger.info(f"Downloaded {written} bytes from source to {raw_path}")
     return str(raw_path)
@@ -752,7 +838,8 @@ async def _fetch_from_source(book_details: dict, output_dir: str) -> str:
     result = await router.get_download_url(md5, source=selection)
     logger.info(f"Resolved {source} download for {md5} via {result.source}")
 
-    return await _download_url_to_file(result.url, output_dir, md5)
+    provider = getattr(result.source, "value", result.source) or selection
+    return await _download_url_to_file(result.url, output_dir, md5, str(provider))
 
 
 async def download_book(
@@ -1141,60 +1228,32 @@ async def main():
         sys.exit(1)
 
     try:
-        # Initialize EAPI client for all functions except local file processing and multi-source search
-        if function_name not in ["process_document", "search_multi_source"]:
-            await initialize_eapi_client()
+        book_source = ""
+        if function_name == "download_book":
+            book_source = (
+                (args_dict.get("book_details") or {}).get("source") or ""
+            ).lower()
+        needs_eapi = function_name not in ["process_document", "search_multi_source"]
+        if function_name == "download_book" and book_source in SOURCE_ALIASES:
+            needs_eapi = False
 
-        # Standardize 'language' key to 'languages' if present for search functions
-        if function_name in ["search", "full_text_search"]:
-            if "language" in args_dict and args_dict["language"]:
-                args_dict["languages"] = args_dict.pop("language")
-            elif "languages" in args_dict and args_dict["languages"]:
-                pass
-            else:
-                args_dict["languages"] = []
+        # Install before authentication and dispatch: httpx/AnyIO resolves
+        # again even after source preflight, and its default executor is joined
+        # during asyncio.run() shutdown.
+        resolver_timeout = get_source_config().preflight_timeout
+        async with bounded_resolver(resolver_timeout):
+            if needs_eapi:
+                await initialize_eapi_client()
 
-            if "content_types" not in args_dict or not args_dict["content_types"]:
-                args_dict["content_types"] = []
-
-        if function_name == "search":
-            logger.info(
-                f"python_bridge.main: About to call search with args_dict: {args_dict}"
-            )
-            result = await search(**args_dict)
-        elif function_name == "full_text_search":
-            logger.info(
-                f"python_bridge.main: About to call full_text_search with args_dict: {args_dict}"
-            )
-            result = await full_text_search(**args_dict)
-        elif function_name == "get_download_history":
-            result = await get_download_history(**args_dict)
-        elif function_name == "get_download_limits":
-            result = await get_download_limits(**args_dict)
-        elif function_name == "download_book":
-            result = await download_book(**args_dict)
-        elif function_name == "process_document":
-            if "file_path" in args_dict:
-                args_dict["file_path_str"] = args_dict.pop("file_path")
-            result = await process_document(**args_dict)
-        elif function_name == "get_book_metadata_complete":
-            result = await get_book_metadata_complete(**args_dict)
-        elif function_name == "search_by_term_bridge":
-            result = await search_by_term_bridge(**args_dict)
-        elif function_name == "search_by_author_bridge":
-            result = await search_by_author_bridge(**args_dict)
-        elif function_name == "search_advanced":
-            result = await search_advanced(**args_dict)
-        elif function_name == "fetch_booklist_bridge":
-            result = await fetch_booklist_bridge(**args_dict)
-        elif function_name == "get_recent_books":
-            result = await get_recent_books(**args_dict)
-        elif function_name == "eapi_health_check":
-            result = await eapi_health_check()
-        elif function_name == "search_multi_source":
-            result = await search_multi_source(**args_dict)
-        else:
-            raise ValueError(f"Unknown function: {function_name}")
+            # Standardize 'language' key to 'languages' for search functions.
+            if function_name in ["search", "full_text_search"]:
+                if "language" in args_dict and args_dict["language"]:
+                    args_dict["languages"] = args_dict.pop("language")
+                elif not args_dict.get("languages"):
+                    args_dict["languages"] = []
+                if not args_dict.get("content_types"):
+                    args_dict["content_types"] = []
+            result = await _dispatch_bridge_function(function_name, args_dict)
 
         # Print only confirmation and path to stdout to avoid large content
         mcp_style_response = {"content": [{"type": "text", "text": json.dumps(result)}]}
@@ -1212,6 +1271,14 @@ async def main():
         # MCP caller can act on it instead of pattern-matching prose.
         if isinstance(e, (SourceError, AllSourcesFailedError)):
             error_info["details"] = e.to_dict()
+            operation = (
+                "download"
+                if function_name == "download_book"
+                else "search"
+                if function_name == "search_multi_source"
+                else function_name
+            )
+            error_info["details"].setdefault("operation", operation)
         print(json.dumps(error_info), file=sys.stderr)
         sys.exit(1)
     finally:
@@ -1221,6 +1288,47 @@ async def main():
         # Clean up source router
         if _source_router:
             await _source_router.close()
+
+
+async def _dispatch_bridge_function(function_name: str, args_dict: dict):
+    """Dispatch one parsed bridge operation after lifecycle setup."""
+    if function_name == "search":
+        logger.info(
+            f"python_bridge.main: About to call search with args_dict: {args_dict}"
+        )
+        return await search(**args_dict)
+    elif function_name == "full_text_search":
+        logger.info(
+            f"python_bridge.main: About to call full_text_search with args_dict: {args_dict}"
+        )
+        return await full_text_search(**args_dict)
+    elif function_name == "get_download_history":
+        return await get_download_history(**args_dict)
+    elif function_name == "get_download_limits":
+        return await get_download_limits(**args_dict)
+    elif function_name == "download_book":
+        return await download_book(**args_dict)
+    elif function_name == "process_document":
+        if "file_path" in args_dict:
+            args_dict["file_path_str"] = args_dict.pop("file_path")
+        return await process_document(**args_dict)
+    elif function_name == "get_book_metadata_complete":
+        return await get_book_metadata_complete(**args_dict)
+    elif function_name == "search_by_term_bridge":
+        return await search_by_term_bridge(**args_dict)
+    elif function_name == "search_by_author_bridge":
+        return await search_by_author_bridge(**args_dict)
+    elif function_name == "search_advanced":
+        return await search_advanced(**args_dict)
+    elif function_name == "fetch_booklist_bridge":
+        return await fetch_booklist_bridge(**args_dict)
+    elif function_name == "get_recent_books":
+        return await get_recent_books(**args_dict)
+    elif function_name == "eapi_health_check":
+        return await eapi_health_check()
+    elif function_name == "search_multi_source":
+        return await search_multi_source(**args_dict)
+    raise ValueError(f"Unknown function: {function_name}")
 
 
 if __name__ == "__main__":

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -10,6 +10,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 import asyncio
+import signal
 
 from pathlib import Path
 from filename_utils import create_unified_filename
@@ -57,6 +58,39 @@ _eapi_client: EAPIClient = None
 
 # Module-level source router (for multi-source search)
 _source_router: SourceRouter = None
+
+
+def _install_cooperative_signal_handlers():
+    """Turn POSIX termination into task cancellation so async cleanup runs."""
+    state = {"signal": None}
+    originals = {}
+    if os.name == "nt":
+        return state, originals
+
+    loop = asyncio.get_running_loop()
+    task = asyncio.current_task()
+    if task is None:
+        return state, originals
+
+    def cancel(signum):
+        if state["signal"] is None:
+            state["signal"] = signum
+            task.cancel()
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        originals[signum] = signal.getsignal(signum)
+        loop.add_signal_handler(signum, cancel, signum)
+    return state, originals
+
+
+def _restore_signal_handlers(originals):
+    if not originals:
+        return
+    loop = asyncio.get_running_loop()
+    for signum, original in originals.items():
+        loop.remove_signal_handler(signum)
+        signal.signal(signum, original)
+
 
 # Debug mode configuration (ISSUE-009)
 # Enable with: ZLIBRARY_DEBUG=1 or DEBUG=1
@@ -839,6 +873,8 @@ async def _fetch_from_source(book_details: dict, output_dir: str) -> str:
     logger.info(f"Resolved {source} download for {md5} via {result.source}")
 
     provider = getattr(result.source, "value", result.source) or selection
+    if provider == "annas_archive":
+        provider = "annas"
     return await _download_url_to_file(result.url, output_dir, md5, str(provider))
 
 
@@ -1208,6 +1244,7 @@ async def main():
     cli_args = parser.parse_args()
 
     function_name = cli_args.function_name
+    termination, original_signal_handlers = _install_cooperative_signal_handlers()
     try:
         logger.info(f"python_bridge.main: Received raw args_json: {cli_args.args_json}")
         args_dict_immediately_after_parse = json.loads(cli_args.args_json)
@@ -1259,6 +1296,10 @@ async def main():
         mcp_style_response = {"content": [{"type": "text", "text": json.dumps(result)}]}
         print(json.dumps(mcp_style_response))
 
+    except asyncio.CancelledError:
+        signum = termination["signal"] or signal.SIGTERM
+        logger.info(f"python_bridge.main: received signal {signum}; cancelling")
+        raise SystemExit(128 + int(signum))
     except Exception as e:
         # Print error as JSON to stderr
         error_info = {
@@ -1282,12 +1323,15 @@ async def main():
         print(json.dumps(error_info), file=sys.stderr)
         sys.exit(1)
     finally:
-        # Clean up EAPI client
-        if _eapi_client:
-            await _eapi_client.close()
-        # Clean up source router
-        if _source_router:
-            await _source_router.close()
+        try:
+            # Clean up EAPI client
+            if _eapi_client:
+                await _eapi_client.close()
+            # Clean up source router
+            if _source_router:
+                await _source_router.close()
+        finally:
+            _restore_signal_handlers(original_signal_handlers)
 
 
 async def _dispatch_bridge_function(function_name: str, args_dict: dict):

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -767,7 +767,7 @@ async def _download_url_to_file(
     try:
         written = await bounded_await(
             stream_to_disk(),
-            config.total_timeout,
+            config.download_timeout,
             provider=provider,
             host=original_host,
             operation="download",

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -23,6 +23,7 @@ from lib import enhanced_metadata
 # Import multi-source router
 from lib.sources.router import SourceRouter
 from lib.sources.config import get_source_config
+from lib.sources.errors import AllSourcesFailedError, SourceError
 
 # Add zlibrary source directory to path for EAPI imports
 zlibrary_src_path = os.path.join(os.path.dirname(__file__), "..", "zlibrary", "src")
@@ -607,13 +608,47 @@ async def get_download_history(count=10):
 
 
 async def get_download_limits():
-    """Get user's download limits via EAPI profile."""
+    """Get user's download limits via EAPI profile.
+
+    /eapi/user/profile reports `downloads_limit` (the daily cap) and
+    `downloads_today` (how many are spent). It has never carried
+    `downloads_today_limit` or `downloads_today_left`, the names this function
+    used to read, so both values fell through to the "unknown" default and the
+    tool could not answer the one question callers ask it — whether there is
+    quota left to spend. Verified against a live profile response 2026-08-11.
+
+    `downloads_remaining` is derived, not reported; it is clamped at zero
+    because the server counts a download the moment it is issued and can report
+    `downloads_today` above the cap.
+
+    Returns:
+        dict with daily_limit, daily_remaining (both int, or "unknown" if the
+        response shape changes again), plus downloads_today and is_premium.
+    """
     eapi = await get_eapi_client()
     profile = await eapi.get_profile()
     user = profile.get("user", profile)
+
+    limit = user.get("downloads_limit")
+    used = user.get("downloads_today")
+
+    remaining = "unknown"
+    if isinstance(limit, int) and isinstance(used, int):
+        remaining = max(0, limit - used)
+    elif isinstance(limit, int):
+        remaining = limit
+
+    if limit is None:
+        logger.warning(
+            "EAPI profile has no 'downloads_limit' field; response keys: %s",
+            sorted(user.keys()),
+        )
+
     return {
-        "daily_limit": user.get("downloads_today_limit", "unknown"),
-        "daily_remaining": user.get("downloads_today_left", "unknown"),
+        "daily_limit": limit if limit is not None else "unknown",
+        "daily_remaining": remaining,
+        "downloads_today": used if used is not None else "unknown",
+        "is_premium": bool(user.get("isPremium", 0)),
     }
 
 
@@ -1172,6 +1207,11 @@ async def main():
             "type": type(e).__name__,
             "traceback": traceback.format_exc(),
         }
+        # Provider failures carry which source failed and why (DNS vs connect
+        # timeout vs HTTP error). Pass that through as structured data so the
+        # MCP caller can act on it instead of pattern-matching prose.
+        if isinstance(e, (SourceError, AllSourcesFailedError)):
+            error_info["details"] = e.to_dict()
         print(json.dumps(error_info), file=sys.stderr)
         sys.exit(1)
     finally:

--- a/lib/sources/__init__.py
+++ b/lib/sources/__init__.py
@@ -18,6 +18,7 @@ from .base import SourceAdapter
 from .config import SourceConfig, get_source_config
 from .errors import (
     AllSourcesFailedError,
+    ProviderConfigurationError,
     ProviderResponseError,
     ProviderTimeoutError,
     ProviderUnreachableError,
@@ -42,6 +43,7 @@ __all__ = [
     "SourceError",
     "ProviderUnreachableError",
     "ProviderTimeoutError",
+    "ProviderConfigurationError",
     "ProviderResponseError",
     "AllSourcesFailedError",
 ]

--- a/lib/sources/__init__.py
+++ b/lib/sources/__init__.py
@@ -16,6 +16,13 @@ Usage:
 from .annas import AnnasArchiveAdapter, QuotaExhaustedError
 from .base import SourceAdapter
 from .config import SourceConfig, get_source_config
+from .errors import (
+    AllSourcesFailedError,
+    ProviderResponseError,
+    ProviderTimeoutError,
+    ProviderUnreachableError,
+    SourceError,
+)
 from .libgen import LibgenAdapter
 from .models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
 from .router import SourceRouter
@@ -32,4 +39,9 @@ __all__ = [
     "QuotaExhaustedError",
     "LibgenAdapter",
     "SourceRouter",
+    "SourceError",
+    "ProviderUnreachableError",
+    "ProviderTimeoutError",
+    "ProviderResponseError",
+    "AllSourcesFailedError",
 ]

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -21,7 +21,13 @@ from .base import SourceAdapter
 from .config import ANNAS_TRUSTED_HOSTS, SourceConfig
 from .errors import ProviderResponseError, ProviderUnreachableError
 from .models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
-from .net import build_timeout, classify_httpx_error, probe_host
+from .net import (
+    bounded_await,
+    build_timeout,
+    classify_httpx_error,
+    port_of,
+    probe_host,
+)
 
 PROVIDER = "annas"
 
@@ -131,6 +137,11 @@ class AnnasArchiveAdapter(SourceAdapter):
         self.base_url = config.annas_base_url.rstrip("/")
         self.secret_key = config.annas_secret_key
         self.host = (urlsplit(self.base_url).hostname or "").lower()
+        # The probe must target what the request targets. A base URL may name
+        # a non-default port (a local mirror, a test double), and probing 443
+        # regardless would report a reachable host as dead.
+        self.port = port_of(self.base_url)
+        self.scheme = urlsplit(self.base_url).scheme or "https"
         self._client: Optional[httpx.AsyncClient] = None
 
     async def _get_client(self) -> httpx.AsyncClient:
@@ -159,7 +170,9 @@ class AnnasArchiveAdapter(SourceAdapter):
         await probe_host(
             PROVIDER,
             self.host,
+            port=self.port,
             timeout=self.config.preflight_timeout,
+            scheme=self.scheme,
         )
 
     def _as_source_error(self, exc: BaseException) -> Exception:
@@ -179,6 +192,18 @@ class AnnasArchiveAdapter(SourceAdapter):
         if reason in ("http_error", "protocol_error"):
             return ProviderResponseError(PROVIDER, self.host, detail, reason=reason)
         return ProviderUnreachableError(PROVIDER, self.host, detail, reason=reason)
+
+    async def _fetch(self, client, url: str, params: Optional[Dict] = None):
+        """GET a URL and raise on an error status, as one awaitable.
+
+        Exists so the status check sits *inside* the wall-clock budget rather
+        than after it.
+        """
+        response = (
+            await client.get(url, params=params) if params else await client.get(url)
+        )
+        response.raise_for_status()
+        return response
 
     async def search(self, query: str, **kwargs) -> List[UnifiedBookResult]:
         """Search Anna's Archive for books.
@@ -202,8 +227,16 @@ class AnnasArchiveAdapter(SourceAdapter):
         client = await self._get_client()
         url = f"{self.base_url}/search?q={quote(query)}"
         try:
-            response = await client.get(url)
-            response.raise_for_status()
+            # httpx bounds each phase separately and restarts its read deadline
+            # on every chunk, so a host that trickles bytes never trips it. The
+            # outer budget is what actually enforces config.total_timeout.
+            response = await bounded_await(
+                self._fetch(client, url),
+                self.config.total_timeout,
+                provider=PROVIDER,
+                host=self.host,
+                operation="search",
+            )
         except Exception as exc:
             raise self._as_source_error(exc) from exc
 
@@ -346,8 +379,13 @@ class AnnasArchiveAdapter(SourceAdapter):
         }
 
         try:
-            response = await client.get(url, params=params)
-            response.raise_for_status()
+            response = await bounded_await(
+                self._fetch(client, url, params=params),
+                self.config.total_timeout,
+                provider=PROVIDER,
+                host=self.host,
+                operation="download resolution",
+            )
             data = response.json()
         except Exception as exc:
             raise self._as_source_error(exc) from exc

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -19,7 +19,7 @@ from bs4.element import Tag
 
 from .base import SourceAdapter
 from .config import ANNAS_TRUSTED_HOSTS, SourceConfig
-from .errors import ProviderResponseError, ProviderUnreachableError
+from .errors import ProviderResponseError, ProviderUnreachableError, SourceError
 from .models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
 from .net import (
     bounded_await,
@@ -186,7 +186,7 @@ class AnnasArchiveAdapter(SourceAdapter):
             ProviderUnreachableError (transport) or ProviderResponseError
             (the host answered but the answer was unusable).
         """
-        if isinstance(exc, (ProviderUnreachableError, ProviderResponseError)):
+        if isinstance(exc, SourceError):
             return exc
         reason, detail = classify_httpx_error(exc)
         if reason in ("http_error", "protocol_error"):

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -19,7 +19,11 @@ from bs4.element import Tag
 
 from .base import SourceAdapter
 from .config import ANNAS_TRUSTED_HOSTS, SourceConfig
+from .errors import ProviderResponseError, ProviderUnreachableError
 from .models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
+from .net import build_timeout, classify_httpx_error, probe_host
+
+PROVIDER = "annas"
 
 # Each Anna's result renders a metadata strip of "·"-separated segments, e.g.
 #   English [en] · PDF · 5.6MB · 2008 · 📕 Book (fiction) · 🚀/lgli/nexusstc/zlib
@@ -126,17 +130,55 @@ class AnnasArchiveAdapter(SourceAdapter):
         self.config = config
         self.base_url = config.annas_base_url.rstrip("/")
         self.secret_key = config.annas_secret_key
+        self.host = (urlsplit(self.base_url).hostname or "").lower()
         self._client: Optional[httpx.AsyncClient] = None
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client.
 
         Returns:
-            Configured httpx.AsyncClient instance
+            Configured httpx.AsyncClient instance, with connect and read
+            budgets taken from config rather than a hard-coded constant.
         """
         if self._client is None:
-            self._client = httpx.AsyncClient(timeout=30, follow_redirects=True)
+            self._client = httpx.AsyncClient(
+                timeout=build_timeout(self.config), follow_redirects=True
+            )
         return self._client
+
+    async def _preflight(self) -> None:
+        """Fail fast if the configured Anna's host is not reachable.
+
+        Anna's domains lapse (annas-archive.org and .se are NXDOMAIN as of
+        2026-08-11), so "this domain no longer exists" is a routine outcome and
+        deserves a one-probe answer naming the host, not a full request budget
+        spent on a name that cannot resolve.
+        """
+        if not self.config.preflight_enabled or not self.host:
+            return
+        await probe_host(
+            PROVIDER,
+            self.host,
+            timeout=self.config.preflight_timeout,
+        )
+
+    def _as_source_error(self, exc: BaseException) -> Exception:
+        """Convert a transport failure into a provider-attributed error.
+
+        Args:
+            exc: Exception raised by an httpx call
+
+        Returns:
+            The original exception if it is already attributed, otherwise a
+            ProviderUnreachableError (transport) or ProviderResponseError
+            (the host answered but the answer was unusable).
+        """
+        if isinstance(exc, (ProviderUnreachableError, ProviderResponseError)):
+            return exc
+        reason, detail = classify_httpx_error(exc)
+        if reason in ("http_error", "protocol_error"):
+            return ProviderResponseError(PROVIDER, self.host, detail, reason=reason)
+        return ProviderUnreachableError(PROVIDER, self.host, detail, reason=reason)
 
     async def search(self, query: str, **kwargs) -> List[UnifiedBookResult]:
         """Search Anna's Archive for books.
@@ -150,11 +192,20 @@ class AnnasArchiveAdapter(SourceAdapter):
 
         Returns:
             List of UnifiedBookResult with source=ANNAS_ARCHIVE
+
+        Raises:
+            ProviderUnreachableError: If the host does not resolve or connect
+            ProviderResponseError: If it answers with an HTTP or protocol error
         """
+        await self._preflight()
+
         client = await self._get_client()
         url = f"{self.base_url}/search?q={quote(query)}"
-        response = await client.get(url)
-        response.raise_for_status()
+        try:
+            response = await client.get(url)
+            response.raise_for_status()
+        except Exception as exc:
+            raise self._as_source_error(exc) from exc
 
         soup = BeautifulSoup(response.text, "html.parser")
         results = []
@@ -284,6 +335,8 @@ class AnnasArchiveAdapter(SourceAdapter):
                 f"has moved to a new domain you have verified yourself."
             )
 
+        await self._preflight()
+
         client = await self._get_client()
         url = f"{self.base_url}/dyn/api/fast_download.json"
         params = {
@@ -292,9 +345,12 @@ class AnnasArchiveAdapter(SourceAdapter):
             "domain_index": 1,  # CRITICAL: Use 1, not 0 (SSL errors on 0)
         }
 
-        response = await client.get(url, params=params)
-        response.raise_for_status()
-        data = response.json()
+        try:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as exc:
+            raise self._as_source_error(exc) from exc
 
         # Check for API error
         if data.get("error"):

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -399,6 +399,15 @@ class AnnasArchiveAdapter(SourceAdapter):
                 operation="download resolution",
             )
             data = response.json()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (401, 403):
+                raise ProviderConfigurationError(
+                    PROVIDER,
+                    self.host,
+                    f"ANNAS_SECRET_KEY rejected by fast-download endpoint "
+                    f"(HTTP {exc.response.status_code})",
+                ) from exc
+            raise self._as_source_error(exc) from exc
         except Exception as exc:
             raise self._as_source_error(exc) from exc
 

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -19,7 +19,12 @@ from bs4.element import Tag
 
 from .base import SourceAdapter
 from .config import ANNAS_TRUSTED_HOSTS, SourceConfig
-from .errors import ProviderResponseError, ProviderUnreachableError, SourceError
+from .errors import (
+    ProviderConfigurationError,
+    ProviderResponseError,
+    ProviderUnreachableError,
+    SourceError,
+)
 from .models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
 from .net import (
     bounded_await,
@@ -347,17 +352,24 @@ class AnnasArchiveAdapter(SourceAdapter):
             DownloadResult with URL and quota info
 
         Raises:
-            ValueError: If ANNAS_SECRET_KEY not configured, or if the configured
+            ProviderConfigurationError: If ANNAS_SECRET_KEY is not configured,
+                or if the configured
                 base URL's host is not a known Anna's Archive domain (the key is
                 never sent to unverified hosts)
             Exception: If API returns error or no download_url
         """
-        if not self.secret_key:
-            raise ValueError("ANNAS_SECRET_KEY not configured")
-
         host = (urlsplit(self.base_url).hostname or "").lower()
+        if not self.secret_key:
+            raise ProviderConfigurationError(
+                PROVIDER,
+                host,
+                "ANNAS_SECRET_KEY not configured",
+            )
+
         if host not in ANNAS_TRUSTED_HOSTS:
-            raise ValueError(
+            raise ProviderConfigurationError(
+                PROVIDER,
+                host,
                 f"Refusing to send ANNAS_SECRET_KEY to unverified host '{host}'. "
                 f"The fast-download API passes the key as a URL parameter, and "
                 f"lapsed Anna's Archive domains get re-registered by squatters "
@@ -365,7 +377,7 @@ class AnnasArchiveAdapter(SourceAdapter):
                 f"to a known Anna's Archive domain "
                 f"({', '.join(sorted(ANNAS_TRUSTED_HOSTS))}) or update "
                 f"ANNAS_TRUSTED_HOSTS in lib/sources/config.py if the project "
-                f"has moved to a new domain you have verified yourself."
+                f"has moved to a new domain you have verified yourself.",
             )
 
         await self._preflight()

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -6,10 +6,33 @@ Environment variables:
     LIBGEN_MIRROR: LibGen mirror to use (default: li)
     BOOK_SOURCE_DEFAULT: Default source selection (auto|annas|libgen)
     BOOK_SOURCE_FALLBACK_ENABLED: Enable fallback to other source (default: true)
+    BOOK_SOURCE_CONNECT_TIMEOUT: TCP/TLS connect budget, seconds (default: 10)
+    BOOK_SOURCE_READ_TIMEOUT: Response-read budget, seconds (default: 30)
+    BOOK_SOURCE_TOTAL_TIMEOUT: Per-provider wall-clock budget, seconds (default: 45)
+    BOOK_SOURCE_PREFLIGHT: Probe host reachability before searching (default: true)
+    BOOK_SOURCE_PREFLIGHT_TIMEOUT: Budget per probe phase, seconds (default: 5)
 """
 
 import os
 from dataclasses import dataclass
+
+# Timeout defaults. Every outbound call in this package is bounded by these;
+# nothing here may fall back to "no timeout". The per-provider TOTAL budget
+# exists because a per-request timeout does not bound a call that walks several
+# mirrors, and because the LibGen library's own request cannot be interrupted
+# once started (see lib/sources/net.run_bounded).
+#
+# These compose. The preflight budget is per PHASE and there are two (DNS, then
+# TCP), so one provider attempt costs at worst 2*preflight + total = 55s. LibGen
+# walks up to three mirrors and an `auto` search adds Anna's on top, giving a
+# worst case of 4 x 55s = 220s. PYTHON_BRIDGE_TIMEOUT on the Node side (240s)
+# has to stay above that — a subprocess kill that fires first would preempt a
+# legitimate slow walk rather than catch a hang. Raising any value here without
+# raising that one narrows a margin that is already only 20s.
+DEFAULT_CONNECT_TIMEOUT = 10.0
+DEFAULT_READ_TIMEOUT = 30.0
+DEFAULT_TOTAL_TIMEOUT = 45.0
+DEFAULT_PREFLIGHT_TIMEOUT = 5.0
 
 # Hosts operated by the Anna's Archive project, per the mirror list the live
 # site itself advertises (verified 2026-07-24: .gl/.pk/.gd serve real search
@@ -58,6 +81,11 @@ class SourceConfig:
         libgen_mirror: LibGen mirror suffix (e.g., 'li', 'rs')
         default_source: Which source to try first ('auto', 'annas', 'libgen')
         fallback_enabled: Whether to try other source if primary fails
+        connect_timeout: Seconds allowed for TCP/TLS connect
+        read_timeout: Seconds allowed to read a response
+        total_timeout: Seconds allowed for a whole provider operation
+        preflight_enabled: Probe host reachability before the real request
+        preflight_timeout: Seconds allowed for each probe phase
     """
 
     annas_secret_key: str = ""
@@ -65,11 +93,33 @@ class SourceConfig:
     libgen_mirror: str = DEFAULT_LIBGEN_MIRROR
     default_source: str = "auto"  # 'auto' | 'annas' | 'libgen'
     fallback_enabled: bool = True
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT
+    read_timeout: float = DEFAULT_READ_TIMEOUT
+    total_timeout: float = DEFAULT_TOTAL_TIMEOUT
+    preflight_enabled: bool = True
+    preflight_timeout: float = DEFAULT_PREFLIGHT_TIMEOUT
 
     @property
     def has_annas_key(self) -> bool:
         """Check if Anna's Archive API key is configured."""
         return bool(self.annas_secret_key)
+
+
+def _positive_float(name: str, default: float) -> float:
+    """Read a positive float from the environment, falling back on nonsense.
+
+    A malformed or non-positive timeout must not disable the timeout — that is
+    the failure this module exists to prevent — so it falls back to the default
+    rather than to None.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
 
 
 def get_source_config() -> SourceConfig:
@@ -85,4 +135,16 @@ def get_source_config() -> SourceConfig:
         default_source=os.environ.get("BOOK_SOURCE_DEFAULT", "auto"),
         fallback_enabled=os.environ.get("BOOK_SOURCE_FALLBACK_ENABLED", "true").lower()
         == "true",
+        connect_timeout=_positive_float(
+            "BOOK_SOURCE_CONNECT_TIMEOUT", DEFAULT_CONNECT_TIMEOUT
+        ),
+        read_timeout=_positive_float("BOOK_SOURCE_READ_TIMEOUT", DEFAULT_READ_TIMEOUT),
+        total_timeout=_positive_float(
+            "BOOK_SOURCE_TOTAL_TIMEOUT", DEFAULT_TOTAL_TIMEOUT
+        ),
+        preflight_enabled=os.environ.get("BOOK_SOURCE_PREFLIGHT", "true").lower()
+        == "true",
+        preflight_timeout=_positive_float(
+            "BOOK_SOURCE_PREFLIGHT_TIMEOUT", DEFAULT_PREFLIGHT_TIMEOUT
+        ),
     )

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -13,6 +13,7 @@ Environment variables:
     BOOK_SOURCE_PREFLIGHT_TIMEOUT: Budget per probe phase, seconds (default: 5)
 """
 
+import math
 import os
 from dataclasses import dataclass
 
@@ -119,7 +120,7 @@ def _positive_float(name: str, default: float) -> float:
         value = float(raw)
     except ValueError:
         return default
-    return value if value > 0 else default
+    return value if math.isfinite(value) and value > 0 else default
 
 
 def get_source_config() -> SourceConfig:

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -9,6 +9,7 @@ Environment variables:
     BOOK_SOURCE_CONNECT_TIMEOUT: TCP/TLS connect budget, seconds (default: 10)
     BOOK_SOURCE_READ_TIMEOUT: Response-read budget, seconds (default: 30)
     BOOK_SOURCE_TOTAL_TIMEOUT: Per-provider wall-clock budget, seconds (default: 45)
+    BOOK_SOURCE_DOWNLOAD_TIMEOUT: Full source-file transfer budget, seconds (default: 1500)
     BOOK_SOURCE_PREFLIGHT: Probe host reachability before searching (default: true)
     BOOK_SOURCE_PREFLIGHT_TIMEOUT: Budget per probe phase, seconds (default: 5)
 """
@@ -33,6 +34,13 @@ from dataclasses import dataclass
 DEFAULT_CONNECT_TIMEOUT = 10.0
 DEFAULT_READ_TIMEOUT = 30.0
 DEFAULT_TOTAL_TIMEOUT = 45.0
+# A source URL can legitimately serve a multi-hundred-megabyte book. Keep its
+# full-transfer wall clock finite but separate from the 45-second search and
+# URL-resolution budget. The independent 40-minute Node budget allows 165
+# seconds for worst-case LibGen resolution, 25 minutes for transfer, 10 minutes
+# for OCR, and 135 seconds for finalization without coupling Python config to a
+# TypeScript constant.
+DEFAULT_DOWNLOAD_TIMEOUT = 1500.0
 DEFAULT_PREFLIGHT_TIMEOUT = 5.0
 
 # Hosts operated by the Anna's Archive project, per the mirror list the live
@@ -85,6 +93,7 @@ class SourceConfig:
         connect_timeout: Seconds allowed for TCP/TLS connect
         read_timeout: Seconds allowed to read a response
         total_timeout: Seconds allowed for a whole provider operation
+        download_timeout: Seconds allowed for a complete source-file transfer
         preflight_enabled: Probe host reachability before the real request
         preflight_timeout: Seconds allowed for each probe phase
     """
@@ -97,6 +106,7 @@ class SourceConfig:
     connect_timeout: float = DEFAULT_CONNECT_TIMEOUT
     read_timeout: float = DEFAULT_READ_TIMEOUT
     total_timeout: float = DEFAULT_TOTAL_TIMEOUT
+    download_timeout: float = DEFAULT_DOWNLOAD_TIMEOUT
     preflight_enabled: bool = True
     preflight_timeout: float = DEFAULT_PREFLIGHT_TIMEOUT
 
@@ -142,6 +152,9 @@ def get_source_config() -> SourceConfig:
         read_timeout=_positive_float("BOOK_SOURCE_READ_TIMEOUT", DEFAULT_READ_TIMEOUT),
         total_timeout=_positive_float(
             "BOOK_SOURCE_TOTAL_TIMEOUT", DEFAULT_TOTAL_TIMEOUT
+        ),
+        download_timeout=_positive_float(
+            "BOOK_SOURCE_DOWNLOAD_TIMEOUT", DEFAULT_DOWNLOAD_TIMEOUT
         ),
         preflight_enabled=os.environ.get("BOOK_SOURCE_PREFLIGHT", "true").lower()
         == "true",

--- a/lib/sources/errors.py
+++ b/lib/sources/errors.py
@@ -28,6 +28,7 @@ REASON_TEXT = {
     "http_error": "returned an HTTP error",
     "quota_exhausted": "has no downloads left on this account today",
     "protocol_error": "returned a malformed response",
+    "configuration_error": "cannot run with the supplied configuration",
     "unknown": "failed for an unclassified reason",
 }
 
@@ -119,6 +120,18 @@ class ProviderResponseError(SourceError):
     """The provider answered, but with an error or an unparseable body."""
 
     reason = "http_error"
+
+
+class ProviderConfigurationError(SourceError, ValueError):
+    """The caller selected a provider without its required configuration.
+
+    This remains a ValueError for adapter callers while carrying a stable
+    source reason through the bridge envelope. It is permanent until the
+    caller changes configuration and therefore must not count as dependency
+    health evidence.
+    """
+
+    reason = "configuration_error"
 
 
 class AllSourcesFailedError(Exception):

--- a/lib/sources/errors.py
+++ b/lib/sources/errors.py
@@ -1,0 +1,144 @@
+"""Provider-attributed errors for the multi-source search path.
+
+Every failure in this path names WHICH provider failed and WHY, because the
+caller's next move differs by reason: a DNS failure means the domain is gone or
+blocked and the mirror list needs updating, whereas a connect timeout means the
+host resolves but its packets are being dropped and a different mirror may
+work. Collapsing both into a bare "search failed" (or, worse, into an empty
+result list) is what made an unreachable provider indistinguishable from a
+query that legitimately matched nothing.
+
+Reason codes are stable strings so callers can branch on them without parsing
+prose. They are surfaced to the MCP caller inside the error envelope.
+"""
+
+from typing import Any, Dict, List, Optional
+
+# Human-readable gloss per reason code. Keep these phrased as a predicate that
+# reads naturally after "<provider> (<host>) ...".
+REASON_TEXT = {
+    "dns_failure": "could not be resolved (DNS returned no address)",
+    "dns_timeout": "did not resolve before the DNS probe deadline",
+    "connect_timeout": "resolved but did not accept a connection before the deadline",
+    "connect_refused": "resolved but actively refused the connection",
+    "connect_error": "resolved but the connection failed",
+    "tls_error": "accepted the connection but the TLS handshake failed",
+    "read_timeout": "accepted the connection but sent no response before the deadline",
+    "search_timeout": "did not finish the search before the deadline",
+    "http_error": "returned an HTTP error",
+    "quota_exhausted": "has no downloads left on this account today",
+    "protocol_error": "returned a malformed response",
+    "unknown": "failed for an unclassified reason",
+}
+
+# Reasons that mean "this host is not talking to us at all", as opposed to a
+# host that answered with something we did not like. Only these justify trying
+# a different mirror or provider without further thought.
+UNREACHABLE_REASONS = frozenset(
+    {
+        "dns_failure",
+        "dns_timeout",
+        "connect_timeout",
+        "connect_refused",
+        "connect_error",
+        "tls_error",
+    }
+)
+
+
+class SourceError(Exception):
+    """Base class for a failure attributed to one source provider.
+
+    Attributes:
+        provider: Provider name ('annas' or 'libgen')
+        host: Hostname that failed, when known
+        reason: Stable reason code, a key of REASON_TEXT
+        detail: Free-text extra context (exception type, HTTP status, ...)
+    """
+
+    reason = "unknown"
+
+    def __init__(
+        self,
+        provider: str,
+        host: str = "",
+        detail: str = "",
+        reason: Optional[str] = None,
+    ):
+        self.provider = provider
+        self.host = host
+        self.detail = detail
+        if reason:
+            self.reason = reason
+        super().__init__(self._build_message())
+
+    def _build_message(self) -> str:
+        where = f" ({self.host})" if self.host else ""
+        gloss = REASON_TEXT.get(self.reason, self.reason)
+        tail = f" [{self.detail}]" if self.detail else ""
+        return f"{self.provider}{where} {gloss}{tail}"
+
+    @property
+    def unreachable(self) -> bool:
+        """Whether this failure means the host never answered."""
+        return self.reason in UNREACHABLE_REASONS
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Machine-readable form for the MCP error envelope."""
+        return {
+            "provider": self.provider,
+            "host": self.host,
+            "reason": self.reason,
+            "detail": self.detail,
+            "message": str(self),
+        }
+
+
+class ProviderUnreachableError(SourceError):
+    """The provider's host never completed a connection.
+
+    Raised by the pre-flight probe and by adapters that classify a transport
+    failure. Distinguishes DNS failure from connect timeout via `reason`.
+    """
+
+    reason = "connect_error"
+
+
+class ProviderTimeoutError(SourceError):
+    """The provider connected but the operation exceeded its wall-clock budget.
+
+    Also raised when a blocking third-party call is abandoned: see
+    `lib/sources/net.run_bounded`, which cannot interrupt the underlying
+    socket and instead abandons a daemon thread.
+    """
+
+    reason = "search_timeout"
+
+
+class ProviderResponseError(SourceError):
+    """The provider answered, but with an error or an unparseable body."""
+
+    reason = "http_error"
+
+
+class AllSourcesFailedError(Exception):
+    """Every candidate provider (or mirror) failed.
+
+    Carries the individual failures so the caller can see that, say, Anna's
+    failed DNS while LibGen timed out connecting — two different problems that
+    a single flattened message would hide.
+    """
+
+    def __init__(self, operation: str, failures: List[SourceError]):
+        self.operation = operation
+        self.failures = failures
+        summary = "; ".join(str(f) for f in failures) or "no providers attempted"
+        super().__init__(f"{operation} failed on every source: {summary}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Machine-readable form for the MCP error envelope."""
+        return {
+            "operation": self.operation,
+            "failures": [f.to_dict() for f in self.failures],
+            "message": str(self),
+        }

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -16,12 +16,27 @@ from bs4 import BeautifulSoup
 
 from .base import SourceAdapter
 from .config import SourceConfig
+from .errors import (
+    AllSourcesFailedError,
+    ProviderResponseError,
+    ProviderUnreachableError,
+    SourceError,
+)
 from .models import DownloadResult, SourceType, UnifiedBookResult
+from .net import (
+    build_timeout,
+    classify_httpx_error,
+    classify_requests_error,
+    probe_host,
+    run_bounded,
+)
 
 # CRITICAL: Import is libgen_api_enhanced, NOT libgen_api
 from libgen_api_enhanced import LibgenSearch
 
 logger = logging.getLogger("zlibrary.sources")
+
+PROVIDER = "libgen"
 
 # Mirrors tried in order when resolving a download. Different mirrors hand off
 # to different CDN nodes (cdn3/cdn4/... .booksdl.lc) and those nodes fail
@@ -29,6 +44,11 @@ logger = logging.getLogger("zlibrary.sources")
 # served real bytes. Failing over between mirrors therefore also routes around
 # a dead CDN node, which is why this list exists rather than a single default.
 FALLBACK_MIRRORS = ("li", "vg", "la")
+
+
+def mirror_host(mirror: str) -> str:
+    """Hostname for a mirror suffix, matching what LibgenSearch builds."""
+    return f"libgen.{mirror}"
 
 
 class LibgenAdapter(SourceAdapter):
@@ -64,10 +84,20 @@ class LibgenAdapter(SourceAdapter):
         self._last_request = time.time()
 
     async def search(self, query: str, **kwargs) -> List[UnifiedBookResult]:
-        """Search for books matching query.
+        """Search for books matching query, failing over between mirrors.
 
-        Uses libgen-api-enhanced LibgenSearch.search_title() wrapped in
-        asyncio.to_thread() to avoid blocking the event loop.
+        Two hazards are handled here that the previous implementation was not
+        bounded against:
+
+        - `libgen_api_enhanced` issues `requests.get(...)` with **no timeout**
+          (search_request.py:177), so a mirror that drops SYNs blocks forever.
+          It runs under `run_bounded` on a daemon thread: the await is capped
+          at `config.total_timeout` and an abandoned call cannot outlive the
+          process. Under `asyncio.to_thread` it did exactly that — three
+          orphaned bridge processes, the oldest 9h10m old, on 2026-08-11.
+        - Search used only the configured mirror while `get_download_url`
+          already walked `_mirror_candidates()`. It now walks the same list, so
+          one dead mirror no longer means no results.
 
         Args:
             query: Search string (title, author, ISBN, etc.)
@@ -75,18 +105,46 @@ class LibgenAdapter(SourceAdapter):
 
         Returns:
             List of UnifiedBookResult with source=LIBGEN
+
+        Raises:
+            AllSourcesFailedError: If no mirror could complete the search
         """
-        await self._rate_limit()
+        failures = []
 
-        def _search_sync():
-            s = LibgenSearch(mirror=self.mirror)
-            return s.search_title(query)
+        for mirror in self._mirror_candidates():
+            host = mirror_host(mirror)
+            try:
+                await self._preflight(mirror)
+            except ProviderUnreachableError as exc:
+                logger.warning("LibGen mirror %s unreachable: %s", mirror, exc)
+                failures.append(exc)
+                continue
 
-        results = await asyncio.to_thread(_search_sync)
+            await self._rate_limit()
 
-        if not results:
-            return []
+            def _search_sync(mirror=mirror):
+                return LibgenSearch(mirror=mirror).search_title(query)
 
+            try:
+                results = await run_bounded(
+                    _search_sync,
+                    self.config.total_timeout,
+                    provider=PROVIDER,
+                    host=host,
+                    operation="search",
+                )
+            except Exception as exc:
+                failure = self._as_source_error(exc, host)
+                logger.warning("LibGen search failed on %s: %s", mirror, failure)
+                failures.append(failure)
+                continue
+
+            return self._to_unified(results or [])
+
+        raise AllSourcesFailedError(f"LibGen search for {query!r}", failures)
+
+    def _to_unified(self, results) -> List[UnifiedBookResult]:
+        """Convert libgen-api-enhanced books into UnifiedBookResult."""
         return [
             UnifiedBookResult(
                 md5=getattr(book, "md5", "") or "",
@@ -114,6 +172,53 @@ class LibgenAdapter(SourceAdapter):
     def _mirror_candidates(self) -> List[str]:
         """Mirrors to try, configured one first, without duplicates."""
         return [self.mirror] + [m for m in FALLBACK_MIRRORS if m != self.mirror]
+
+    async def _preflight(self, mirror: str) -> None:
+        """Fail fast if a mirror is not reachable.
+
+        This matters more for LibGen than for Anna's: once the third-party
+        search call starts it cannot be interrupted, only abandoned. Probing
+        first means an unroutable mirror (libgen.is resolves to
+        193.218.118.42 but drops every SYN, measured 2026-08-11) costs one
+        bounded probe and never enters that call.
+
+        Args:
+            mirror: Mirror suffix, e.g. 'li'
+
+        Raises:
+            ProviderUnreachableError: If the mirror does not resolve or connect
+        """
+        if not self.config.preflight_enabled:
+            return
+        await probe_host(
+            PROVIDER,
+            mirror_host(mirror),
+            timeout=self.config.preflight_timeout,
+        )
+
+    def _as_source_error(self, exc: BaseException, host: str) -> Exception:
+        """Convert a failure into a provider-attributed error.
+
+        Handles both httpx exceptions (our own `get_download_url` requests) and
+        the `requests`-based exceptions that surface from the LibGen library.
+
+        Args:
+            exc: Exception raised while talking to a mirror
+            host: Mirror hostname for attribution
+
+        Returns:
+            An already-attributed error unchanged, otherwise a
+            ProviderResponseError or ProviderUnreachableError.
+        """
+        if isinstance(exc, SourceError):
+            return exc
+        if isinstance(exc, httpx.HTTPError):
+            reason, detail = classify_httpx_error(exc)
+        else:
+            reason, detail = classify_requests_error(exc)
+        if reason in ("http_error", "protocol_error"):
+            return ProviderResponseError(PROVIDER, host, detail, reason=reason)
+        return ProviderUnreachableError(PROVIDER, host, detail, reason=reason)
 
     async def _resolve_key(
         self, client: httpx.AsyncClient, mirror: str, md5: str
@@ -197,14 +302,26 @@ class LibgenAdapter(SourceAdapter):
         """
         attempts = []
 
-        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+        async with httpx.AsyncClient(
+            timeout=build_timeout(self.config), follow_redirects=True
+        ) as client:
             for mirror in self._mirror_candidates():
+                try:
+                    await self._preflight(mirror)
+                except ProviderUnreachableError as exc:
+                    attempts.append(f"{mirror}: {exc.reason}")
+                    logger.warning(f"LibGen mirror {mirror} unreachable: {exc}")
+                    continue
+
                 await self._rate_limit()
                 try:
                     key = await self._resolve_key(client, mirror, md5)
                 except Exception as exc:  # network, TLS, HTTP error
-                    attempts.append(f"{mirror}: {type(exc).__name__}")
-                    logger.warning(f"LibGen mirror {mirror} failed for {md5}: {exc}")
+                    failure = self._as_source_error(exc, mirror_host(mirror))
+                    attempts.append(f"{mirror}: {failure.reason}")
+                    logger.warning(
+                        f"LibGen mirror {mirror} failed for {md5}: {failure}"
+                    )
                     continue
 
                 if not key:

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -264,19 +264,27 @@ class LibgenAdapter(SourceAdapter):
         # Transport exceptions must reach the normal classifier. Returning
         # their class name as a semantic non-byte result reclassified DNS/TLS
         # and timeout failures as protocol_error at the mirror aggregate.
-        response = await client.get(url, headers={"Range": "bytes=0-2047"})
+        inspected = bytearray()
+        async with client.stream(
+            "GET", url, headers={"Range": "bytes=0-2047"}
+        ) as response:
+            if "/ads.php" in str(response.url):
+                return False, "key expired (bounced to ads.php)"
+            if response.status_code not in (200, 206):
+                return False, f"HTTP {response.status_code}"
+            if "text/html" in response.headers.get("content-type", ""):
+                return False, "served HTML, not a file"
 
-        if "/ads.php" in str(response.url):
-            return False, "key expired (bounced to ads.php)"
-        if response.status_code not in (200, 206):
-            return False, f"HTTP {response.status_code}"
-        if "text/html" in response.headers.get("content-type", ""):
-            return False, "served HTML, not a file"
-        if not response.content[:4] == b"%PDF" and len(response.content) < 512:
-            return False, "response too small to be a file"
+            async for chunk in response.aiter_bytes():
+                inspected.extend(chunk[: 2048 - len(inspected)])
+                if len(inspected) >= 2048:
+                    break
 
-        cdn = urlparse(str(response.url)).hostname or "?"
-        return True, cdn
+            if not inspected[:4] == b"%PDF" and len(inspected) < 512:
+                return False, "response too small to be a file"
+
+            cdn = urlparse(str(response.url)).hostname or "?"
+            return True, cdn
 
     async def get_download_url(self, md5: str) -> DownloadResult:
         """Resolve a clearnet download URL for a book by MD5 hash.

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -24,6 +24,7 @@ from .errors import (
 )
 from .models import DownloadResult, SourceType, UnifiedBookResult
 from .net import (
+    bounded_await,
     build_timeout,
     classify_httpx_error,
     classify_requests_error,
@@ -314,8 +315,25 @@ class LibgenAdapter(SourceAdapter):
                     continue
 
                 await self._rate_limit()
-                try:
+
+                async def resolve_attempt() -> tuple[Optional[str], str]:
+                    """Resolve and validate one mirror under one total budget."""
                     key = await self._resolve_key(client, mirror, md5)
+                    if not key:
+                        return None, "no GET link"
+
+                    candidate = f"https://libgen.{mirror}/get.php?md5={md5}&key={key}"
+                    ok, detail = await self._serves_bytes(client, candidate)
+                    return (candidate if ok else None), detail
+
+                try:
+                    url, detail = await bounded_await(
+                        resolve_attempt(),
+                        self.config.total_timeout,
+                        provider=PROVIDER,
+                        host=mirror_host(mirror),
+                        operation="download resolution",
+                    )
                 except Exception as exc:  # network, TLS, HTTP error
                     failure = self._as_source_error(exc, mirror_host(mirror))
                     attempts.append(f"{mirror}: {failure.reason}")
@@ -324,16 +342,10 @@ class LibgenAdapter(SourceAdapter):
                     )
                     continue
 
-                if not key:
-                    attempts.append(f"{mirror}: no GET link")
-                    continue
-
-                url = f"https://libgen.{mirror}/get.php?md5={md5}&key={key}"
-                ok, detail = await self._serves_bytes(client, url)
-                if not ok:
+                if not url:
                     attempts.append(f"{mirror}: {detail}")
                     logger.warning(
-                        f"LibGen mirror {mirror} resolved but cannot serve {md5}: {detail}"
+                        f"LibGen mirror {mirror} could not serve {md5}: {detail}"
                     )
                     continue
 

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -261,10 +261,10 @@ class LibgenAdapter(SourceAdapter):
         an expired key silently redirects back to `/ads.php`, and a dead node
         can answer 200 with an HTML error page.
         """
-        try:
-            response = await client.get(url, headers={"Range": "bytes=0-2047"})
-        except Exception as exc:
-            return False, type(exc).__name__
+        # Transport exceptions must reach the normal classifier. Returning
+        # their class name as a semantic non-byte result reclassified DNS/TLS
+        # and timeout failures as protocol_error at the mirror aggregate.
+        response = await client.get(url, headers={"Range": "bytes=0-2047"})
 
         if "/ads.php" in str(response.url):
             return False, "key expired (bounced to ads.php)"
@@ -299,9 +299,9 @@ class LibgenAdapter(SourceAdapter):
             DownloadResult with URL and no quota_info (LibGen has no quota)
 
         Raises:
-            ValueError: If no mirror yields a download key
+            AllSourcesFailedError: If no mirror yields a working download URL
         """
-        attempts = []
+        failures: List[SourceError] = []
 
         async with httpx.AsyncClient(
             timeout=build_timeout(self.config), follow_redirects=True
@@ -310,7 +310,7 @@ class LibgenAdapter(SourceAdapter):
                 try:
                     await self._preflight(mirror)
                 except ProviderUnreachableError as exc:
-                    attempts.append(f"{mirror}: {exc.reason}")
+                    failures.append(exc)
                     logger.warning(f"LibGen mirror {mirror} unreachable: {exc}")
                     continue
 
@@ -336,14 +336,21 @@ class LibgenAdapter(SourceAdapter):
                     )
                 except Exception as exc:  # network, TLS, HTTP error
                     failure = self._as_source_error(exc, mirror_host(mirror))
-                    attempts.append(f"{mirror}: {failure.reason}")
+                    failures.append(failure)
                     logger.warning(
                         f"LibGen mirror {mirror} failed for {md5}: {failure}"
                     )
                     continue
 
                 if not url:
-                    attempts.append(f"{mirror}: {detail}")
+                    failures.append(
+                        ProviderResponseError(
+                            PROVIDER,
+                            mirror_host(mirror),
+                            detail,
+                            reason="protocol_error",
+                        )
+                    )
                     logger.warning(
                         f"LibGen mirror {mirror} could not serve {md5}: {detail}"
                     )
@@ -358,10 +365,7 @@ class LibgenAdapter(SourceAdapter):
                     quota_info=None,  # LibGen has no quota
                 )
 
-        raise ValueError(
-            f"No LibGen mirror could resolve a download for {md5} "
-            f"(tried {', '.join(attempts)})"
-        )
+        raise AllSourcesFailedError("download", failures)
 
     async def close(self) -> None:
         """Clean up resources.

--- a/lib/sources/net.py
+++ b/lib/sources/net.py
@@ -293,17 +293,22 @@ async def _probe_host_uncached(
     provider: str, host: str, port: int, timeout: float
 ) -> Optional[ProviderUnreachableError]:
     """Run the probe, returning the failure rather than raising it."""
-    loop = asyncio.get_running_loop()
-
-    # DNS. loop.getaddrinfo delegates to the default executor, whose threads
-    # are non-daemon; the resolver's own limits (resolv.conf timeout x
-    # attempts, typically <= 10s) are what actually bound it, so the wait_for
-    # here is a second line of defence rather than the only one.
+    # DNS is a blocking libc/NSS call and cannot be cancelled. The event loop's
+    # default executor uses non-daemon workers and joins them during
+    # asyncio.run() shutdown, so wait_for(loop.getaddrinfo(...)) can return at
+    # five seconds yet still keep the one-shot bridge alive until the resolver
+    # eventually returns. Reuse the daemon-thread boundary that protects the
+    # third-party LibGen client; translate its generic operation timeout into
+    # the DNS-specific stable reason expected from a preflight.
     try:
-        await asyncio.wait_for(
-            loop.getaddrinfo(host, port, type=socket.SOCK_STREAM), timeout
+        await run_bounded(
+            lambda: socket.getaddrinfo(host, port, type=socket.SOCK_STREAM),
+            timeout,
+            provider=provider,
+            host=host,
+            operation="dns probe",
         )
-    except asyncio.TimeoutError:
+    except ProviderTimeoutError:
         return ProviderUnreachableError(
             provider, host, f"no DNS answer within {timeout:g}s", reason="dns_timeout"
         )

--- a/lib/sources/net.py
+++ b/lib/sources/net.py
@@ -42,6 +42,7 @@ import socket
 import ssl
 import threading
 import urllib.request
+from contextlib import asynccontextmanager
 from typing import Any, Callable, Dict, Optional, Tuple
 from urllib.parse import urlsplit
 
@@ -50,6 +51,12 @@ import httpx
 from .errors import ProviderTimeoutError, ProviderUnreachableError
 
 logger = logging.getLogger("zlibrary.sources")
+
+# Machine marker deliberately carried in the gaierror text. httpcore/httpx
+# discard the original exception type and cause on this path but preserve its
+# message. Matching this exact token is stable and avoids guessing from broad
+# human-readable timeout prose.
+DNS_TIMEOUT_MARKER = "zlibrary_mcp_dns_timeout"
 
 # Cached probe verdicts, keyed by (host, port), for the lifetime of the
 # process. The bridge is a one-shot process per MCP call, so this only ever
@@ -177,7 +184,11 @@ def classify_httpx_error(exc: BaseException) -> Tuple[str, str]:
             if isinstance(cause, ConnectionRefusedError):
                 return "connect_refused", detail
             cause = cause.__cause__
-        # httpx does not always preserve the cause; fall back to the text.
+        # httpx strips the gaierror cause produced by its AnyIO transport, but
+        # retains our exact machine marker in the ConnectError message.
+        if DNS_TIMEOUT_MARKER in str(exc):
+            return "dns_timeout", f"{detail}: DNS resolution deadline exceeded"
+        # httpx does not always preserve other causes; fall back to the text.
         text = str(exc).lower()
         if "name or service not known" in text or "nodename nor servname" in text:
             return "dns_failure", str(exc)
@@ -301,7 +312,7 @@ async def _probe_host_uncached(
     # third-party LibGen client; translate its generic operation timeout into
     # the DNS-specific stable reason expected from a preflight.
     try:
-        await run_bounded(
+        addresses = await run_bounded(
             lambda: socket.getaddrinfo(host, port, type=socket.SOCK_STREAM),
             timeout,
             provider=provider,
@@ -321,9 +332,28 @@ async def _probe_host_uncached(
 
     # TCP connect. Deliberately no TLS handshake: this only answers "is anything
     # listening", and a handshake would double the cost of the common case.
+    async def connect_resolved():
+        """Connect using numeric sockaddrs from the daemon-bounded lookup."""
+        loop = asyncio.get_running_loop()
+        last_error: Optional[OSError] = None
+        for family, socktype, proto, _canonname, sockaddr in addresses:
+            sock = socket.socket(family, socktype, proto)
+            sock.setblocking(False)
+            try:
+                return await _open_resolved_connection(loop, sock, sockaddr)
+            except BaseException as exc:
+                sock.close()
+                if isinstance(exc, OSError):
+                    last_error = exc
+                    continue
+                raise
+        if last_error is not None:
+            raise last_error
+        raise OSError("DNS returned no usable stream addresses")
+
     writer = None
     try:
-        _, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout)
+        _, writer = await asyncio.wait_for(connect_resolved(), timeout)
     except asyncio.TimeoutError:
         return ProviderUnreachableError(
             provider,
@@ -346,6 +376,12 @@ async def _probe_host_uncached(
                 pass
 
     return None
+
+
+async def _open_resolved_connection(loop, sock, sockaddr):
+    """Connect a prepared socket to one numeric address tuple."""
+    await loop.sock_connect(sock, sockaddr)
+    return await asyncio.open_connection(sock=sock)
 
 
 def reset_probe_cache() -> None:
@@ -433,6 +469,48 @@ async def run_bounded(
             f"{operation} exceeded {timeout:g}s",
             reason="search_timeout",
         ) from None
+
+
+@asynccontextmanager
+async def bounded_resolver(timeout: float):
+    """Route event-loop hostname resolution through a daemon worker.
+
+    httpx/AnyIO performs its own resolution after provider preflight. The
+    default loop implementation delegates that libc/NSS call to a non-daemon
+    executor which asyncio joins at shutdown, so cancelling the HTTP request
+    cannot bound the one-shot interpreter. Replacing the loop method keeps the
+    public signature AnyIO expects while reusing the daemon lifecycle boundary.
+    """
+    loop = asyncio.get_running_loop()
+    original = loop.getaddrinfo
+
+    async def getaddrinfo(
+        host,
+        port,
+        *,
+        family=0,
+        type=0,
+        proto=0,
+        flags=0,
+    ):
+        try:
+            return await run_bounded(
+                lambda: socket.getaddrinfo(host, port, family, type, proto, flags),
+                timeout,
+                provider="network",
+                host=str(host),
+                operation="dns resolution",
+            )
+        except ProviderTimeoutError as exc:
+            raise socket.gaierror(
+                socket.EAI_AGAIN, f"{DNS_TIMEOUT_MARKER}:{timeout:g}s"
+            ) from exc
+
+    loop.getaddrinfo = getaddrinfo
+    try:
+        yield
+    finally:
+        loop.getaddrinfo = original
 
 
 async def bounded_await(

--- a/lib/sources/net.py
+++ b/lib/sources/net.py
@@ -178,6 +178,11 @@ def classify_httpx_error(exc: BaseException) -> Tuple[str, str]:
         cause = exc.__cause__
         while cause is not None:
             if isinstance(cause, socket.gaierror):
+                if DNS_TIMEOUT_MARKER in str(cause):
+                    return (
+                        "dns_timeout",
+                        f"{detail}: DNS resolution deadline exceeded",
+                    )
                 return "dns_failure", f"{detail}: {cause}"
             if isinstance(cause, ssl.SSLError):
                 return "tls_error", f"{detail}: {type(cause).__name__}"

--- a/lib/sources/net.py
+++ b/lib/sources/net.py
@@ -23,7 +23,16 @@ three different mechanisms:
    separates "DNS has no address for this name" from "the name resolves but
    the host drops our packets". Those need different fixes (update the mirror
    list vs. try another mirror), so they get different reason codes rather
-   than one generic failure.
+   than one generic failure. It probes the port and scheme the real request
+   will use, and skips itself entirely when a proxy is configured — a probe
+   that vetoes a request the real client could have completed is worse than
+   no probe at all.
+
+4. **Operations that outlive their phases** — an `httpx.Timeout` bounds each
+   phase separately, and its read deadline restarts on every chunk received,
+   so a host that trickles bytes never trips it. `bounded_await` puts one
+   wall-clock deadline over a whole async operation, which is what actually
+   enforces `config.total_timeout`. `build_timeout` alone never did.
 """
 
 import asyncio
@@ -32,6 +41,7 @@ import logging
 import socket
 import ssl
 import threading
+import urllib.request
 from typing import Any, Callable, Dict, Optional, Tuple
 from urllib.parse import urlsplit
 
@@ -51,6 +61,60 @@ _probe_cache: Dict[Tuple[str, int], Optional[ProviderUnreachableError]] = {}
 def host_of(url: str) -> str:
     """Extract the hostname from a URL, or '' if it has none."""
     return (urlsplit(url).hostname or "").lower()
+
+
+def port_of(url: str) -> int:
+    """The TCP port a URL addresses, explicit or implied by its scheme.
+
+    The preflight opens a socket to this port, so it has to be the port the
+    real request will use. Defaulting to 443 regardless made a base URL like
+    `http://localhost:8080` probe `localhost:443` and report a reachable host
+    as dead.
+
+    Args:
+        url: Absolute URL
+
+    Returns:
+        The explicit port if the URL carries one, else 80 for http and 443
+        for anything else (https and unknown schemes alike).
+    """
+    parts = urlsplit(url)
+    if parts.port:
+        return parts.port
+    return 80 if parts.scheme == "http" else 443
+
+
+def proxy_in_use(url: str) -> bool:
+    """Whether an outbound proxy would carry a request to this URL.
+
+    httpx and requests both honour HTTP_PROXY / HTTPS_PROXY / ALL_PROXY by
+    default (`trust_env` is True), but a raw socket does not. On a network
+    where direct egress is blocked and a proxy is mandatory — corporate LANs,
+    many container runtimes — the real request succeeds through the proxy
+    while a direct probe cannot connect at all. Preflighting there would
+    report every provider unreachable and stop the working request from ever
+    being made, which is strictly worse than having no preflight.
+
+    Args:
+        url: Absolute URL the request will be sent to
+
+    Returns:
+        True if a proxy applies to this URL and the preflight must be skipped
+    """
+    parts = urlsplit(url)
+    host = parts.hostname or ""
+    try:
+        # getproxies() reads the *_PROXY environment (plus system config on
+        # macOS/Windows); proxy_bypass() applies NO_PROXY, so a host excluded
+        # from the proxy is still probed directly, which is correct.
+        proxies = urllib.request.getproxies()
+        if not proxies:
+            return False
+        if host and urllib.request.proxy_bypass(host):
+            return False
+    except Exception:  # noqa: BLE001 - never let proxy detection break a search
+        return False
+    return parts.scheme in proxies or "all" in proxies
 
 
 def build_timeout(config) -> httpx.Timeout:
@@ -175,6 +239,7 @@ async def probe_host(
     port: int = 443,
     timeout: float = 5.0,
     use_cache: bool = True,
+    scheme: str = "https",
 ) -> None:
     """Check that a host resolves and accepts a TCP connection.
 
@@ -187,16 +252,30 @@ async def probe_host(
     libgen.is resolved to 193.218.118.42 but dropped every SYN) and they call
     for different remedies.
 
+    Skipped entirely when a proxy applies: the probe is an optimisation, and an
+    optimisation that vetoes a request the real client could have completed is
+    worse than no optimisation at all.
+
     Args:
         provider: Provider name for error attribution
         host: Hostname to probe
         port: TCP port (default 443)
         timeout: Budget in seconds for EACH of the DNS and connect phases
         use_cache: Reuse a verdict already reached for this (host, port)
+        scheme: URL scheme the real request will use, for proxy detection
 
     Raises:
         ProviderUnreachableError: If DNS or the TCP connect fails or times out
     """
+    if proxy_in_use(f"{scheme}://{host}:{port}"):
+        logger.debug(
+            "%s: skipping preflight for %s — an outbound proxy is configured "
+            "and the direct probe would not reflect the real request path",
+            provider,
+            host,
+        )
+        return
+
     key = (host, port)
     if use_cache and key in _probe_cache:
         cached = _probe_cache[key]
@@ -342,6 +421,54 @@ async def run_bounded(
             provider,
             operation,
             timeout,
+        )
+        raise ProviderTimeoutError(
+            provider,
+            host,
+            f"{operation} exceeded {timeout:g}s",
+            reason="search_timeout",
+        ) from None
+
+
+async def bounded_await(
+    awaitable,
+    timeout: float,
+    *,
+    provider: str,
+    host: str = "",
+    operation: str = "request",
+):
+    """Await a coroutine under a wall-clock budget.
+
+    The async counterpart to `run_bounded`. `httpx.Timeout` bounds each phase
+    of a request separately, and its read deadline restarts every time another
+    chunk arrives — so a host that trickles bytes indefinitely never trips it
+    and the operation runs past `total_timeout` unbounded. That is what this
+    closes: one deadline over the whole operation, however many phases or
+    redirects it spans.
+
+    Unlike `run_bounded` this needs no thread. The work is already async, so
+    `asyncio.wait_for` cancels it properly and no socket is left held.
+
+    Args:
+        awaitable: Coroutine to run
+        timeout: Wall-clock budget in seconds
+        provider: Provider name for error attribution
+        host: Hostname for error attribution
+        operation: Short label for the error message
+
+    Returns:
+        Whatever the coroutine returns
+
+    Raises:
+        ProviderTimeoutError: If the budget elapses first
+        Exception: Whatever the coroutine raised
+    """
+    try:
+        return await asyncio.wait_for(awaitable, timeout)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "%s %s exceeded its %.0fs total budget", provider, operation, timeout
         )
         raise ProviderTimeoutError(
             provider,

--- a/lib/sources/net.py
+++ b/lib/sources/net.py
@@ -1,0 +1,351 @@
+"""Bounded-network helpers for the multi-source path.
+
+Everything outbound in `lib/sources/` goes through here so that no call can
+block without a deadline. Three distinct hazards are covered, and they need
+three different mechanisms:
+
+1. **httpx calls we own** — bounded by an `httpx.Timeout` built from config.
+   `build_timeout` exists so connect/read budgets are configurable rather than
+   hard-coded, and so every client in the package gets the same ones.
+
+2. **Blocking third-party calls we do not own** — `libgen_api_enhanced` calls
+   `requests.get(...)` with **no `timeout=` argument** (search_request.py), and
+   even catches a `requests.exceptions.Timeout` that therefore can never fire.
+   An unroutable host (SYN dropped, as libgen.is does from some networks) makes
+   that call block forever. `asyncio.to_thread` cannot rescue it: its worker
+   threads are non-daemon and are joined at interpreter shutdown, so the whole
+   Python process survives the MCP call that spawned it — the orphaned
+   `python_bridge.py search...` processes observed 2026-08-11 with 9h of
+   elapsed time. `run_bounded` runs such calls on a **daemon** thread instead:
+   the await is bounded, and an abandoned thread cannot keep the process alive.
+
+3. **Hosts that are simply gone** — `probe_host` is a cheap pre-flight that
+   separates "DNS has no address for this name" from "the name resolves but
+   the host drops our packets". Those need different fixes (update the mirror
+   list vs. try another mirror), so they get different reason codes rather
+   than one generic failure.
+"""
+
+import asyncio
+import json
+import logging
+import socket
+import ssl
+import threading
+from typing import Any, Callable, Dict, Optional, Tuple
+from urllib.parse import urlsplit
+
+import httpx
+
+from .errors import ProviderTimeoutError, ProviderUnreachableError
+
+logger = logging.getLogger("zlibrary.sources")
+
+# Cached probe verdicts, keyed by (host, port), for the lifetime of the
+# process. The bridge is a one-shot process per MCP call, so this only ever
+# collapses the repeated probes of a single call (LibGen walks three mirrors)
+# and cannot go stale across calls.
+_probe_cache: Dict[Tuple[str, int], Optional[ProviderUnreachableError]] = {}
+
+
+def host_of(url: str) -> str:
+    """Extract the hostname from a URL, or '' if it has none."""
+    return (urlsplit(url).hostname or "").lower()
+
+
+def build_timeout(config) -> httpx.Timeout:
+    """Build an httpx timeout from a SourceConfig.
+
+    Args:
+        config: SourceConfig carrying connect_timeout / read_timeout
+
+    Returns:
+        httpx.Timeout with an explicit budget on every phase. httpx defaults
+        pool/write to the same value so a saturated pool cannot hang either.
+    """
+    return httpx.Timeout(
+        connect=config.connect_timeout,
+        read=config.read_timeout,
+        write=config.read_timeout,
+        pool=config.connect_timeout,
+    )
+
+
+def classify_httpx_error(exc: BaseException) -> Tuple[str, str]:
+    """Map an httpx/transport exception to a (reason, detail) pair.
+
+    The cause chain matters more than the httpx class: httpx raises
+    `ConnectError` for a failed DNS lookup, a refused connection, and a broken
+    TLS handshake alike, and only `__cause__` tells those apart.
+
+    Args:
+        exc: Exception raised by an httpx call
+
+    Returns:
+        (reason code from errors.REASON_TEXT, free-text detail)
+    """
+    detail = type(exc).__name__
+
+    if isinstance(exc, httpx.ConnectTimeout):
+        return "connect_timeout", detail
+    if isinstance(exc, httpx.PoolTimeout):
+        return "connect_timeout", detail
+    if isinstance(exc, (httpx.ReadTimeout, httpx.WriteTimeout)):
+        return "read_timeout", detail
+    if isinstance(exc, httpx.TimeoutException):
+        return "read_timeout", detail
+    if isinstance(exc, httpx.HTTPStatusError):
+        return "http_error", f"HTTP {exc.response.status_code}"
+    if isinstance(exc, (httpx.RemoteProtocolError, httpx.DecodingError)):
+        return "protocol_error", detail
+    # response.json() on a non-JSON body. The host answered, so this is a
+    # response problem, not a reachability one.
+    if isinstance(exc, json.JSONDecodeError):
+        return "protocol_error", f"{detail}: {exc}"
+
+    if isinstance(exc, httpx.ConnectError):
+        cause = exc.__cause__
+        while cause is not None:
+            if isinstance(cause, socket.gaierror):
+                return "dns_failure", f"{detail}: {cause}"
+            if isinstance(cause, ssl.SSLError):
+                return "tls_error", f"{detail}: {type(cause).__name__}"
+            if isinstance(cause, ConnectionRefusedError):
+                return "connect_refused", detail
+            cause = cause.__cause__
+        # httpx does not always preserve the cause; fall back to the text.
+        text = str(exc).lower()
+        if "name or service not known" in text or "nodename nor servname" in text:
+            return "dns_failure", str(exc)
+        if "refused" in text:
+            return "connect_refused", detail
+        return "connect_error", f"{detail}: {exc}"
+
+    if isinstance(exc, ssl.SSLError):
+        return "tls_error", detail
+    if isinstance(exc, socket.gaierror):
+        return "dns_failure", f"{detail}: {exc}"
+    if isinstance(exc, ConnectionRefusedError):
+        return "connect_refused", detail
+    if isinstance(exc, asyncio.TimeoutError):
+        return "read_timeout", detail
+
+    return "unknown", f"{detail}: {exc}"
+
+
+def classify_requests_error(exc: BaseException) -> Tuple[str, str]:
+    """Map an exception from the `requests`-based LibGen library.
+
+    `libgen_api_enhanced` re-raises every transport failure as a bare
+    `requests.exceptions.RequestException` carrying only a sentence, so the
+    original class is usually gone by the time we see it. Match on the cause
+    chain first and fall back to that sentence.
+
+    Args:
+        exc: Exception raised by a libgen_api_enhanced call
+
+    Returns:
+        (reason code from errors.REASON_TEXT, free-text detail)
+    """
+    detail = type(exc).__name__
+
+    cause = exc.__cause__ or exc.__context__
+    while cause is not None:
+        if isinstance(cause, socket.gaierror):
+            return "dns_failure", f"{detail}: {cause}"
+        if isinstance(cause, ssl.SSLError):
+            return "tls_error", f"{detail}: {type(cause).__name__}"
+        if isinstance(cause, ConnectionRefusedError):
+            return "connect_refused", detail
+        cause = cause.__cause__ or cause.__context__
+
+    text = str(exc).lower()
+    if "timed out" in text or "timeout" in text:
+        return "read_timeout", str(exc)
+    if "failed to connect" in text or "connection" in text:
+        return "connect_error", str(exc)
+    if "http error" in text:
+        return "http_error", str(exc)
+    return "unknown", f"{detail}: {exc}"
+
+
+async def probe_host(
+    provider: str,
+    host: str,
+    port: int = 443,
+    timeout: float = 5.0,
+    use_cache: bool = True,
+) -> None:
+    """Check that a host resolves and accepts a TCP connection.
+
+    Runs before the real request so an unreachable provider costs one bounded
+    probe instead of the full per-request budget (and, for LibGen, so we never
+    enter the un-interruptible third-party call at all).
+
+    DNS and connect are probed separately on purpose: they are the two failure
+    modes measured on dionysus 2026-08-11 (annas-archive.org had no DNS record;
+    libgen.is resolved to 193.218.118.42 but dropped every SYN) and they call
+    for different remedies.
+
+    Args:
+        provider: Provider name for error attribution
+        host: Hostname to probe
+        port: TCP port (default 443)
+        timeout: Budget in seconds for EACH of the DNS and connect phases
+        use_cache: Reuse a verdict already reached for this (host, port)
+
+    Raises:
+        ProviderUnreachableError: If DNS or the TCP connect fails or times out
+    """
+    key = (host, port)
+    if use_cache and key in _probe_cache:
+        cached = _probe_cache[key]
+        if cached is not None:
+            raise cached
+        return
+
+    error = await _probe_host_uncached(provider, host, port, timeout)
+    _probe_cache[key] = error
+    if error is not None:
+        raise error
+
+
+async def _probe_host_uncached(
+    provider: str, host: str, port: int, timeout: float
+) -> Optional[ProviderUnreachableError]:
+    """Run the probe, returning the failure rather than raising it."""
+    loop = asyncio.get_running_loop()
+
+    # DNS. loop.getaddrinfo delegates to the default executor, whose threads
+    # are non-daemon; the resolver's own limits (resolv.conf timeout x
+    # attempts, typically <= 10s) are what actually bound it, so the wait_for
+    # here is a second line of defence rather than the only one.
+    try:
+        await asyncio.wait_for(
+            loop.getaddrinfo(host, port, type=socket.SOCK_STREAM), timeout
+        )
+    except asyncio.TimeoutError:
+        return ProviderUnreachableError(
+            provider, host, f"no DNS answer within {timeout:g}s", reason="dns_timeout"
+        )
+    except socket.gaierror as exc:
+        return ProviderUnreachableError(provider, host, str(exc), reason="dns_failure")
+    except OSError as exc:
+        return ProviderUnreachableError(
+            provider, host, f"{type(exc).__name__}: {exc}", reason="dns_failure"
+        )
+
+    # TCP connect. Deliberately no TLS handshake: this only answers "is anything
+    # listening", and a handshake would double the cost of the common case.
+    writer = None
+    try:
+        _, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout)
+    except asyncio.TimeoutError:
+        return ProviderUnreachableError(
+            provider,
+            host,
+            f"no TCP handshake within {timeout:g}s",
+            reason="connect_timeout",
+        )
+    except ConnectionRefusedError:
+        return ProviderUnreachableError(provider, host, "", reason="connect_refused")
+    except OSError as exc:
+        return ProviderUnreachableError(
+            provider, host, f"{type(exc).__name__}: {exc}", reason="connect_error"
+        )
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass
+
+    return None
+
+
+def reset_probe_cache() -> None:
+    """Clear cached probe verdicts (used by tests)."""
+    _probe_cache.clear()
+
+
+async def run_bounded(
+    func: Callable[[], Any],
+    timeout: float,
+    *,
+    provider: str,
+    host: str = "",
+    operation: str = "request",
+) -> Any:
+    """Run a blocking callable on a daemon thread under a wall-clock budget.
+
+    Use this instead of `asyncio.to_thread` for any third-party synchronous
+    call whose own timeouts cannot be configured. Two properties matter:
+
+    - The await returns at `timeout` whether or not the call has finished.
+    - The thread is a daemon, so an abandoned call cannot keep the interpreter
+      alive at shutdown. `asyncio.to_thread` gives neither: its worker threads
+      are registered for join-at-exit, which is precisely how a hung LibGen
+      search outlived its MCP request by nine hours.
+
+    The abandoned thread still holds a socket until the process exits. That is
+    acceptable here because the bridge is a one-shot process per MCP call; it
+    would not be in a long-lived server.
+
+    Args:
+        func: Zero-argument blocking callable
+        timeout: Wall-clock budget in seconds
+        provider: Provider name for error attribution
+        host: Hostname for error attribution
+        operation: Short label for the error message
+
+    Returns:
+        Whatever `func` returns
+
+    Raises:
+        ProviderTimeoutError: If the budget elapses first
+        Exception: Whatever `func` raised
+    """
+    loop = asyncio.get_running_loop()
+    future: "asyncio.Future[Any]" = loop.create_future()
+
+    def _deliver(setter: Callable[[Any], None], value: Any) -> None:
+        # The loop may be gone, or the future already cancelled by the timeout,
+        # by the time a straggling thread reports back. Neither is an error.
+        try:
+            loop.call_soon_threadsafe(_apply, setter, value)
+        except RuntimeError:
+            pass
+
+    def _apply(setter: Callable[[Any], None], value: Any) -> None:
+        if not future.done():
+            setter(value)
+
+    def _runner() -> None:
+        try:
+            result = func()
+        except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
+            _deliver(future.set_exception, exc)
+        else:
+            _deliver(future.set_result, result)
+
+    thread = threading.Thread(
+        target=_runner, name=f"{provider}-{operation}", daemon=True
+    )
+    thread.start()
+
+    try:
+        return await asyncio.wait_for(future, timeout)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "%s %s exceeded its %.0fs budget; abandoning the worker thread",
+            provider,
+            operation,
+            timeout,
+        )
+        raise ProviderTimeoutError(
+            provider,
+            host,
+            f"{operation} exceeded {timeout:g}s",
+            reason="search_timeout",
+        ) from None

--- a/lib/sources/router.py
+++ b/lib/sources/router.py
@@ -188,7 +188,7 @@ class SourceRouter:
         if answered and not failures:
             return []
 
-        raise AllSourcesFailedError(f"search for {query!r}", failures)
+        raise AllSourcesFailedError("search", failures)
 
     def _download_candidates(self, source: SourceSelection) -> List[SourceSelection]:
         """Ordered providers to try for a download.
@@ -265,7 +265,7 @@ class SourceRouter:
         if quota_error is not None and len(candidates) == 1:
             raise quota_error
 
-        raise AllSourcesFailedError(f"download for {md5}", failures)
+        raise AllSourcesFailedError("download", failures)
 
     async def close(self) -> None:
         """Clean up all adapter resources."""

--- a/lib/sources/router.py
+++ b/lib/sources/router.py
@@ -225,7 +225,7 @@ class SourceRouter:
             DownloadResult with URL and quota info (if Anna's)
 
         Raises:
-            QuotaExhaustedError: If the only candidate's quota is exhausted
+            SourceError: If the only candidate's quota is exhausted
             AllSourcesFailedError: If every candidate provider failed
         """
         candidates = self._download_candidates(source)
@@ -259,11 +259,11 @@ class SourceRouter:
                 )
                 logger.warning(f"{name} download failed: {exc}")
 
-        # With a single candidate, quota exhaustion is the whole story and the
-        # caller wants to branch on it, so it is re-raised in its own type
-        # rather than flattened into the aggregate.
+        # With a single candidate, quota exhaustion is the whole story. Keep
+        # the recorded SourceError so the canonical bridge envelope retains
+        # provider and reason instead of rethrowing the adapter-only exception.
         if quota_error is not None and len(candidates) == 1:
-            raise quota_error
+            raise failures[0]
 
         raise AllSourcesFailedError("download", failures)
 

--- a/lib/sources/router.py
+++ b/lib/sources/router.py
@@ -141,11 +141,15 @@ class SourceRouter:
         Returns:
             List of UnifiedBookResult with source field indicating origin.
             An empty list means every attempted provider answered and none had
-            a match — never that a provider was unreachable.
+            a match — never that a provider was unreachable, and never that
+            only some of them answered.
 
         Raises:
-            AllSourcesFailedError: If every candidate provider failed. For an
-                explicit source that is a one-element set naming just that
+            AllSourcesFailedError: If any candidate provider failed without a
+                later one producing results. That includes the partial case —
+                one provider answering empty while another is unreachable — so
+                a missing provider is never silently reported as "no matches".
+                For an explicit source the failure set names just that
                 provider, so the caller still learns which one broke and why.
         """
         candidates = self._search_candidates(source)
@@ -176,9 +180,12 @@ class SourceRouter:
                 return results
             logger.info(f"{name} returned no results")
 
-        # At least one provider was reachable and simply had no match. That is
-        # a legitimate empty result, not an outage, so it must not raise.
-        if answered:
+        # An empty list is only honest when EVERY attempted provider answered.
+        # A partial walk — LibGen returns no matches, then Anna's fails DNS —
+        # would otherwise be reported as "no such book", when the truth is that
+        # the provider most likely to have it was never successfully searched.
+        # `answered` alone is not the test; the absence of failures is.
+        if answered and not failures:
             return []
 
         raise AllSourcesFailedError(f"search for {query!r}", failures)

--- a/lib/sources/router.py
+++ b/lib/sources/router.py
@@ -14,6 +14,7 @@ from typing import List, Literal, Optional
 
 from .annas import AnnasArchiveAdapter, QuotaExhaustedError
 from .config import SourceConfig, get_source_config
+from .errors import AllSourcesFailedError, SourceError
 from .libgen import LibgenAdapter
 from .models import DownloadResult, UnifiedBookResult
 
@@ -37,6 +38,11 @@ class SourceRouter:
     search needs no credentials. 'auto' deliberately stays LibGen-first when no
     key is set: LibGen returns a resolvable download link, whereas an Anna's
     result without a key still needs a route the caller may not have.
+
+    Fallback is tied to source='auto'. An explicitly named provider is the
+    whole request, so its failure is raised with the provider, host and reason
+    named rather than papered over with another provider's results — and no
+    caller ends up waiting on a provider it did not ask for.
 
     Usage:
         config = get_source_config()
@@ -94,13 +100,38 @@ class SourceRouter:
             return "annas" if self.config.has_annas_key else "libgen"
         return source
 
+    def _search_candidates(self, source: SourceSelection) -> List[SourceSelection]:
+        """Ordered providers to try for a search.
+
+        `auto` means "give me results from wherever", so it gets the full list
+        and the router walks it. An EXPLICIT source is a single-element list:
+        asking for Anna's and silently receiving LibGen results is the bug #74
+        fixed for the empty-result case, and quietly rerouting on a network
+        failure reintroduces it — worse, it is how a request tagged
+        `source="annas"` ended up hanging inside LibGen's search (2026-08-11).
+
+        Args:
+            source: Requested source
+
+        Returns:
+            Provider names in the order they should be attempted
+        """
+        primary = self._determine_source(source)
+        if source != "auto" or not self.config.fallback_enabled:
+            return [primary]
+        return [primary] + [s for s in ("annas", "libgen") if s != primary]
+
+    def _adapter_for(self, name: SourceSelection):
+        """Get the adapter for a provider name."""
+        return self._get_annas() if name == "annas" else self._get_libgen()
+
     async def search(
         self,
         query: str,
         source: SourceSelection = "auto",
         **kwargs,
     ) -> List[UnifiedBookResult]:
-        """Search for books with automatic fallback.
+        """Search for books, falling back between providers when `source=auto`.
 
         Args:
             query: Search query string
@@ -108,34 +139,76 @@ class SourceRouter:
             **kwargs: Additional arguments passed to adapters
 
         Returns:
-            List of UnifiedBookResult with source field indicating origin
+            List of UnifiedBookResult with source field indicating origin.
+            An empty list means every attempted provider answered and none had
+            a match — never that a provider was unreachable.
+
+        Raises:
+            AllSourcesFailedError: If every candidate provider failed. For an
+                explicit source that is a one-element set naming just that
+                provider, so the caller still learns which one broke and why.
         """
-        actual_source = self._determine_source(source)
+        candidates = self._search_candidates(source)
+        failures: List[SourceError] = []
+        answered = False
 
-        if actual_source == "annas":
+        for name in candidates:
             try:
-                results = await self._get_annas().search(query, **kwargs)
-                if results:
-                    return results
-                logger.info("Anna's Archive returned no results")
-            except Exception as e:
-                logger.warning(f"Anna's Archive search failed: {e}")
+                results = await self._adapter_for(name).search(query, **kwargs)
+            except AllSourcesFailedError as exc:
+                # A provider that walks its own mirrors (LibGen) reports a set.
+                failures.extend(exc.failures)
+                logger.warning(f"{name} search failed: {exc}")
+                continue
+            except SourceError as exc:
+                failures.append(exc)
+                logger.warning(f"{name} search failed: {exc}")
+                continue
+            except Exception as exc:
+                failures.append(
+                    SourceError(name, detail=f"{type(exc).__name__}: {exc}")
+                )
+                logger.warning(f"{name} search failed: {exc}")
+                continue
 
-            # Fallback to LibGen if enabled
-            if self.config.fallback_enabled:
-                logger.info("Falling back to LibGen")
-                return await self._get_libgen().search(query, **kwargs)
+            answered = True
+            if results:
+                return results
+            logger.info(f"{name} returned no results")
+
+        # At least one provider was reachable and simply had no match. That is
+        # a legitimate empty result, not an outage, so it must not raise.
+        if answered:
             return []
 
-        # Direct LibGen search
-        return await self._get_libgen().search(query, **kwargs)
+        raise AllSourcesFailedError(f"search for {query!r}", failures)
+
+    def _download_candidates(self, source: SourceSelection) -> List[SourceSelection]:
+        """Ordered providers to try for a download.
+
+        Narrower than `_search_candidates`: Anna's fast-download API needs
+        ANNAS_SECRET_KEY, so without one it is not a usable download fallback
+        even though its search is.
+
+        Args:
+            source: Requested source
+
+        Returns:
+            Provider names in the order they should be attempted
+        """
+        primary = self._determine_source(source)
+        if source != "auto" or not self.config.fallback_enabled:
+            return [primary]
+        if primary == "annas":
+            return ["annas", "libgen"]
+        return ["libgen"] + (["annas"] if self.config.has_annas_key else [])
 
     async def get_download_url(
         self,
         md5: str,
         source: SourceSelection = "auto",
     ) -> DownloadResult:
-        """Get download URL with automatic fallback on quota exhaustion.
+        """Get download URL, falling back between providers when `source=auto`.
 
         Args:
             md5: Book MD5 hash
@@ -145,36 +218,47 @@ class SourceRouter:
             DownloadResult with URL and quota info (if Anna's)
 
         Raises:
-            QuotaExhaustedError: If Anna's quota exhausted and fallback disabled
-            ValueError: If book not found in any source
+            QuotaExhaustedError: If the only candidate's quota is exhausted
+            AllSourcesFailedError: If every candidate provider failed
         """
-        actual_source = self._determine_source(source)
+        candidates = self._download_candidates(source)
+        failures: List[SourceError] = []
+        quota_error: Optional[QuotaExhaustedError] = None
 
-        if actual_source == "annas":
-            annas = self._get_annas()
-            if annas:
-                try:
-                    result = await annas.get_download_url(md5)
-                    # Check quota - if 0 left, raise for fallback
-                    if result.quota_info and result.quota_info.downloads_left == 0:
-                        raise QuotaExhaustedError("Anna's Archive quota exhausted")
-                    return result
-                except QuotaExhaustedError:
-                    if self.config.fallback_enabled:
-                        logger.warning(
-                            "Anna's Archive quota exhausted, falling back to LibGen"
-                        )
-                        return await self._get_libgen().get_download_url(md5)
-                    raise
-                except Exception as e:
-                    if self.config.fallback_enabled:
-                        logger.warning(
-                            f"Anna's Archive download failed: {e}, falling back to LibGen"
-                        )
-                        return await self._get_libgen().get_download_url(md5)
-                    raise
+        for name in candidates:
+            try:
+                result = await self._adapter_for(name).get_download_url(md5)
+                # A response that reports zero downloads left is a failure to
+                # act on, not a result to return: the URL it carries will not
+                # serve bytes.
+                if result.quota_info and result.quota_info.downloads_left == 0:
+                    raise QuotaExhaustedError(f"{name} quota exhausted")
+                return result
+            except QuotaExhaustedError as exc:
+                quota_error = exc
+                failures.append(
+                    SourceError(name, detail=str(exc), reason="quota_exhausted")
+                )
+                logger.warning(f"{name} quota exhausted for {md5}")
+            except AllSourcesFailedError as exc:
+                failures.extend(exc.failures)
+                logger.warning(f"{name} download failed: {exc}")
+            except SourceError as exc:
+                failures.append(exc)
+                logger.warning(f"{name} download failed: {exc}")
+            except Exception as exc:
+                failures.append(
+                    SourceError(name, detail=f"{type(exc).__name__}: {exc}")
+                )
+                logger.warning(f"{name} download failed: {exc}")
 
-        return await self._get_libgen().get_download_url(md5)
+        # With a single candidate, quota exhaustion is the whole story and the
+        # caller wants to branch on it, so it is re-raised in its own type
+        # rather than flattened into the aggregate.
+        if quota_error is not None and len(candidates) == 1:
+            raise quota_error
+
+        raise AllSourcesFailedError(f"download for {md5}", failures)
 
     async def close(self) -> None:
         """Clean up all adapter resources."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,4 @@ markers =
     real_world: end-to-end validation with real-world documents (deselect with '-m "not real_world"')
     performance: benchmark and timing budget tests (deselect with '-m "not performance"')
     e2e: full MCP pipeline end-to-end tests (deselect with '-m "not e2e"')
+    real_preflight: opts out of the autouse pre-flight stub so the probe itself can be tested

--- a/src/index.ts
+++ b/src/index.ts
@@ -389,7 +389,13 @@ const handlers: HandlerMap = {
     try {
       return await zlibraryApi.downloadBookToFile(args, options);
     } catch (error: any) {
-      return { error: { message: error.message || 'Failed to download book' } };
+      const details = error?.context?.details;
+      return {
+        error: {
+          message: error.message || 'Failed to download book',
+          ...(details === undefined ? {} : { details }),
+        },
+      };
     }
   },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -521,7 +521,13 @@ const handlers: HandlerMap = {
       // puts that on stderr as `details`; surface it rather than flattening
       // everything to one sentence, because "annas could not be resolved" and
       // "libgen did not accept a connection" call for different responses.
-      return { error: { message: error.message || 'Failed to search multi-source' } };
+      const details = error?.context?.details;
+      return {
+        error: {
+          message: error.message || 'Failed to search multi-source',
+          ...(details === undefined ? {} : { details }),
+        },
+      };
     }
   },
 };
@@ -627,6 +633,7 @@ function wrapResult(result: any, toolName: string) {
           text: `Error from tool "${toolName}": ${result.error.message || result.error}`,
         },
       ],
+      structuredContent: result,
       isError: true as const,
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,24 +257,40 @@ const toolAnnotations: Record<string, ToolAnnotations> = {
 // Tool handler implementations
 // ============================================================================
 
+/**
+ * Cancellation context for a tool call.
+ *
+ * Every handler takes it, not just the multi-source ones: the subprocess
+ * budget bounds a hung call, but only the client's own signal ends one the
+ * client has already stopped waiting for. Without it a cancelled download
+ * keeps running for up to PYTHON_BRIDGE_LONG_TIMEOUT with nobody to receive
+ * the result.
+ */
+interface HandlerOptions {
+  signal?: AbortSignal;
+}
+
 interface HandlerMap {
-  [key: string]: (args: any) => Promise<any>;
-  searchBooks: (args: any) => Promise<any>;
-  fullTextSearch: (args: any) => Promise<any>;
-  getDownloadHistory: (args: any) => Promise<any>;
-  getDownloadLimits: (args: any) => Promise<any>;
-  downloadBookToFile: (args: any) => Promise<any>;
-  processDocumentForRag: (args: any) => Promise<any>;
-  getBookMetadata: (args: any) => Promise<any>;
-  searchByTerm: (args: any) => Promise<any>;
-  searchByAuthor: (args: any) => Promise<any>;
-  fetchBooklist: (args: any) => Promise<any>;
-  searchAdvanced: (args: any) => Promise<any>;
-  searchMultiSource: (args: any) => Promise<any>;
+  [key: string]: (args: any, options?: HandlerOptions) => Promise<any>;
+  searchBooks: (args: any, options?: HandlerOptions) => Promise<any>;
+  fullTextSearch: (args: any, options?: HandlerOptions) => Promise<any>;
+  getDownloadHistory: (args: any, options?: HandlerOptions) => Promise<any>;
+  getDownloadLimits: (args: any, options?: HandlerOptions) => Promise<any>;
+  downloadBookToFile: (args: any, options?: HandlerOptions) => Promise<any>;
+  processDocumentForRag: (args: any, options?: HandlerOptions) => Promise<any>;
+  getBookMetadata: (args: any, options?: HandlerOptions) => Promise<any>;
+  searchByTerm: (args: any, options?: HandlerOptions) => Promise<any>;
+  searchByAuthor: (args: any, options?: HandlerOptions) => Promise<any>;
+  fetchBooklist: (args: any, options?: HandlerOptions) => Promise<any>;
+  searchAdvanced: (args: any, options?: HandlerOptions) => Promise<any>;
+  searchMultiSource: (args: any, options?: HandlerOptions) => Promise<any>;
 }
 
 const handlers: HandlerMap = {
-  searchBooks: async (args: z.infer<typeof SearchBooksParamsSchema>) => {
+  searchBooks: async (
+    args: z.infer<typeof SearchBooksParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
       const searchBooksReceivedArgsLog = `[${new Date().toISOString()}] [src/index.ts] searchBooks handler received Zod-parsed args: ${JSON.stringify(args)}\n`;
       logger.debug(searchBooksReceivedArgsLog.trim());
@@ -303,13 +319,16 @@ const handlers: HandlerMap = {
       } catch (e) {
         console.error('Failed to write to logs/nodejs_debug.log', e);
       }
-      return await zlibraryApi.searchBooks(apiArgs);
+      return await zlibraryApi.searchBooks(apiArgs, options);
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to search books' } };
     }
   },
 
-  fullTextSearch: async (args: z.infer<typeof FullTextSearchParamsSchema>) => {
+  fullTextSearch: async (
+    args: z.infer<typeof FullTextSearchParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
       const ftsReceivedArgsLog = `[${new Date().toISOString()}] [src/index.ts] fullTextSearch handler received Zod-parsed args: ${JSON.stringify(args)}\n`;
       logger.debug(ftsReceivedArgsLog.trim());
@@ -338,121 +357,170 @@ const handlers: HandlerMap = {
       } catch (e) {
         console.error('Failed to write to logs/nodejs_debug.log', e);
       }
-      return await zlibraryApi.fullTextSearch(apiArgsFTS);
+      return await zlibraryApi.fullTextSearch(apiArgsFTS, options);
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to perform full text search' } };
     }
   },
 
-  getDownloadHistory: async (args: z.infer<typeof GetDownloadHistoryParamsSchema>) => {
+  getDownloadHistory: async (
+    args: z.infer<typeof GetDownloadHistoryParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.getDownloadHistory(args);
+      return await zlibraryApi.getDownloadHistory(args, options);
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to get download history' } };
     }
   },
 
-  getDownloadLimits: async () => {
+  getDownloadLimits: async (_args: unknown, options: HandlerOptions = {}) => {
     try {
-      return await zlibraryApi.getDownloadLimits();
+      return await zlibraryApi.getDownloadLimits(options);
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to get download limits' } };
     }
   },
 
-  downloadBookToFile: async (args: z.infer<typeof DownloadBookToFileParamsSchema>) => {
+  downloadBookToFile: async (
+    args: z.infer<typeof DownloadBookToFileParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.downloadBookToFile(args);
+      return await zlibraryApi.downloadBookToFile(args, options);
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to download book' } };
     }
   },
 
-  processDocumentForRag: async (args: z.infer<typeof ProcessDocumentForRagParamsSchema>) => {
+  processDocumentForRag: async (
+    args: z.infer<typeof ProcessDocumentForRagParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.processDocumentForRag({
-        filePath: args.file_path,
-        outputFormat: args.output_format,
-      });
+      return await zlibraryApi.processDocumentForRag(
+        {
+          filePath: args.file_path,
+          outputFormat: args.output_format,
+        },
+        options,
+      );
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to process document for RAG' } };
     }
   },
 
-  getBookMetadata: async (args: z.infer<typeof GetBookMetadataParamsSchema>) => {
+  getBookMetadata: async (
+    args: z.infer<typeof GetBookMetadataParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.getBookMetadata(args.bookId, args.bookHash, args.include);
+      return await zlibraryApi.getBookMetadata(args.bookId, args.bookHash, args.include, options);
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to get book metadata' } };
     }
   },
 
-  searchByTerm: async (args: z.infer<typeof SearchByTermParamsSchema>) => {
+  searchByTerm: async (
+    args: z.infer<typeof SearchByTermParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.searchByTerm({
-        term: args.term,
-        yearFrom: args.yearFrom,
-        yearTo: args.yearTo,
-        languages: args.languages,
-        extensions: args.extensions,
-        limit: args.count,
-      });
+      return await zlibraryApi.searchByTerm(
+        {
+          term: args.term,
+          yearFrom: args.yearFrom,
+          yearTo: args.yearTo,
+          languages: args.languages,
+          extensions: args.extensions,
+          limit: args.count,
+        },
+        options,
+      );
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to search by term' } };
     }
   },
 
-  searchByAuthor: async (args: z.infer<typeof SearchByAuthorParamsSchema>) => {
+  searchByAuthor: async (
+    args: z.infer<typeof SearchByAuthorParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.searchByAuthor({
-        author: args.author,
-        exact: args.exact,
-        yearFrom: args.yearFrom,
-        yearTo: args.yearTo,
-        languages: args.languages,
-        extensions: args.extensions,
-        limit: args.count,
-      });
+      return await zlibraryApi.searchByAuthor(
+        {
+          author: args.author,
+          exact: args.exact,
+          yearFrom: args.yearFrom,
+          yearTo: args.yearTo,
+          languages: args.languages,
+          extensions: args.extensions,
+          limit: args.count,
+        },
+        options,
+      );
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to search by author' } };
     }
   },
 
-  fetchBooklist: async (args: z.infer<typeof FetchBooklistParamsSchema>) => {
+  fetchBooklist: async (
+    args: z.infer<typeof FetchBooklistParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.fetchBooklist({
-        booklistId: args.booklistId,
-        booklistHash: args.booklistHash,
-        topic: args.topic,
-        page: args.page,
-      });
+      return await zlibraryApi.fetchBooklist(
+        {
+          booklistId: args.booklistId,
+          booklistHash: args.booklistHash,
+          topic: args.topic,
+          page: args.page,
+        },
+        options,
+      );
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to fetch booklist' } };
     }
   },
 
-  searchAdvanced: async (args: z.infer<typeof SearchAdvancedParamsSchema>) => {
+  searchAdvanced: async (
+    args: z.infer<typeof SearchAdvancedParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.searchAdvanced({
-        query: args.query,
-        exact: args.exact,
-        yearFrom: args.yearFrom,
-        yearTo: args.yearTo,
-        count: args.count,
-      });
+      return await zlibraryApi.searchAdvanced(
+        {
+          query: args.query,
+          exact: args.exact,
+          yearFrom: args.yearFrom,
+          yearTo: args.yearTo,
+          count: args.count,
+        },
+        options,
+      );
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to perform advanced search' } };
     }
   },
 
-  searchMultiSource: async (args: z.infer<typeof SearchMultiSourceParamsSchema>) => {
+  searchMultiSource: async (
+    args: z.infer<typeof SearchMultiSourceParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.searchMultiSource({
-        query: args.query,
-        source: args.source,
-        count: args.count,
-      });
+      return await zlibraryApi.searchMultiSource(
+        {
+          query: args.query,
+          source: args.source,
+          count: args.count,
+        },
+        { signal: options.signal },
+      );
     } catch (error: any) {
+      // Provider failures name which source failed and why. The Python bridge
+      // puts that on stderr as `details`; surface it rather than flattening
+      // everything to one sentence, because "annas could not be resolved" and
+      // "libgen did not accept a connection" call for different responses.
       return { error: { message: error.message || 'Failed to search multi-source' } };
     }
   },
@@ -636,13 +704,22 @@ async function start(
     // Helper to get annotations with proper typing
     const ann = (name: string) => toolAnnotations[name] as ToolAnnotations;
 
+    // Every handler below receives `extra.signal`, which aborts when the client
+    // cancels or times out the request. Passing it down is what turns that
+    // cancellation into a killed subprocess instead of one still running
+    // against a dead provider with nobody left to receive the result.
+
     // 1. search_books
     server.tool(
       'search_books',
       'Search for books in Z-Library by title, author, or keywords. Returns matching books with metadata including title (string), author (string), name, authors (array), year, format, and file size. Use exact=true for precise title matching. Filter results by year range, language, or file format.',
       SearchBooksParamsSchema.shape,
       ann('search_books'),
-      async (args) => wrapResult(await handlers.searchBooks(args as any), 'search_books'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.searchBooks(args as any, { signal: extra?.signal }),
+          'search_books',
+        ),
     );
 
     // 2. full_text_search
@@ -651,7 +728,11 @@ async function start(
       'Search for books containing specific text within their content. Returns books with title (string), author (string), name, authors (array), and other metadata. Useful for finding books that discuss particular topics, quotes, or concepts.',
       FullTextSearchParamsSchema.shape,
       ann('full_text_search'),
-      async (args) => wrapResult(await handlers.fullTextSearch(args as any), 'full_text_search'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.fullTextSearch(args as any, { signal: extra?.signal }),
+          'full_text_search',
+        ),
     );
 
     // 3. get_download_history
@@ -660,8 +741,11 @@ async function start(
       "Get the user's Z-Library download history. Returns a list of previously downloaded books with their metadata.",
       GetDownloadHistoryParamsSchema.shape,
       ann('get_download_history'),
-      async (args) =>
-        wrapResult(await handlers.getDownloadHistory(args as any), 'get_download_history'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.getDownloadHistory(args as any, { signal: extra?.signal }),
+          'get_download_history',
+        ),
     );
 
     // 4. get_download_limits
@@ -670,7 +754,11 @@ async function start(
       "Get the user's current Z-Library download limits. Shows daily download quota, downloads used today, and remaining downloads.",
       GetDownloadLimitsParamsSchema.shape,
       ann('get_download_limits'),
-      async (_args) => wrapResult(await handlers.getDownloadLimits(_args), 'get_download_limits'),
+      async (_args, extra) =>
+        wrapResult(
+          await handlers.getDownloadLimits(_args, { signal: extra?.signal }),
+          'get_download_limits',
+        ),
     );
 
     // 5. get_recent_books
@@ -679,9 +767,11 @@ async function start(
       'Get recently added books to Z-Library. Optionally filter by file format.',
       GetRecentBooksParamsSchema.shape,
       ann('search_books'),
-      async (args) => {
+      async (args, extra) => {
         try {
-          const result = await (zlibraryApi as any).getRecentBooks(args);
+          const result = await (zlibraryApi as any).getRecentBooks(args, {
+            signal: extra?.signal,
+          });
           return wrapResult(result, 'get_recent_books');
         } catch (error: any) {
           return {
@@ -698,8 +788,11 @@ async function start(
       'Download a book to a local file. Pass the full bookDetails object from search_books results. Optionally process the document for RAG (text extraction) after download. Returns file paths for both the original book and processed text.',
       DownloadBookToFileParamsSchema.shape,
       ann('download_book_to_file'),
-      async (args) =>
-        wrapResult(await handlers.downloadBookToFile(args as any), 'download_book_to_file'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.downloadBookToFile(args as any, { signal: extra?.signal }),
+          'download_book_to_file',
+        ),
     );
 
     // 7. process_document_for_rag
@@ -708,8 +801,11 @@ async function start(
       'Process a downloaded document (EPUB, TXT, PDF) to extract clean text content for RAG (Retrieval-Augmented Generation). Extracts text, preserves structure, detects footnotes, and outputs a text file.',
       ProcessDocumentForRagParamsSchema.shape,
       ann('process_document_for_rag'),
-      async (args) =>
-        wrapResult(await handlers.processDocumentForRag(args as any), 'process_document_for_rag'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.processDocumentForRag(args as any, { signal: extra?.signal }),
+          'process_document_for_rag',
+        ),
     );
 
     // 8. get_book_metadata
@@ -718,7 +814,11 @@ async function start(
       'Get metadata for a book. By default returns core fields (title, author, year, publisher, language, pages, isbn, rating, cover, categories). Use the include parameter to add optional field groups: terms (60+ conceptual keywords), booklists (11+ curated collections), ipfs (IPFS CIDs), ratings (quality score), description (full text). Requires bookId and bookHash from search results.',
       GetBookMetadataParamsSchema.shape,
       ann('get_book_metadata'),
-      async (args) => wrapResult(await handlers.getBookMetadata(args as any), 'get_book_metadata'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.getBookMetadata(args as any, { signal: extra?.signal }),
+          'get_book_metadata',
+        ),
     );
 
     // 9. search_by_term
@@ -727,7 +827,11 @@ async function start(
       'Search for books by conceptual term (e.g., "phenomenology", "dialectic", "epistemology"). Returns books with title (string), author (string), and other metadata. Books in Z-Library are tagged with 60+ conceptual terms.',
       SearchByTermParamsSchema.shape,
       ann('search_by_term'),
-      async (args) => wrapResult(await handlers.searchByTerm(args as any), 'search_by_term'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.searchByTerm(args as any, { signal: extra?.signal }),
+          'search_by_term',
+        ),
     );
 
     // 10. search_by_author
@@ -736,7 +840,11 @@ async function start(
       'Advanced author search with support for various name formats. Returns books with title (string), author (string), and other metadata. Use exact=true for precise matching. Filter by publication year, language, or file format.',
       SearchByAuthorParamsSchema.shape,
       ann('search_by_author'),
-      async (args) => wrapResult(await handlers.searchByAuthor(args as any), 'search_by_author'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.searchByAuthor(args as any, { signal: extra?.signal }),
+          'search_by_author',
+        ),
     );
 
     // 11. fetch_booklist
@@ -745,7 +853,11 @@ async function start(
       'Fetch books from an expert-curated booklist. Z-Library books belong to 11+ booklists with up to 954 books per list. Get booklist IDs from get_book_metadata.',
       FetchBooklistParamsSchema.shape,
       ann('fetch_booklist'),
-      async (args) => wrapResult(await handlers.fetchBooklist(args as any), 'fetch_booklist'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.fetchBooklist(args as any, { signal: extra?.signal }),
+          'fetch_booklist',
+        ),
     );
 
     // 12. search_advanced
@@ -754,7 +866,11 @@ async function start(
       'Advanced search with automatic separation of exact matches from fuzzy/approximate matches. Returns two arrays: exact_matches and fuzzy_matches, each containing books with title (string), author (string), and other metadata.',
       SearchAdvancedParamsSchema.shape,
       ann('search_advanced'),
-      async (args) => wrapResult(await handlers.searchAdvanced(args as any), 'search_advanced'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.searchAdvanced(args as any, { signal: extra?.signal }),
+          'search_advanced',
+        ),
     );
 
     // 13. search_multi_source
@@ -763,8 +879,11 @@ async function start(
       "Search for books across Anna's Archive and LibGen. Alternative to Z-Library EAPI. Returns books with md5, title, author, year, extension, size, source, download_url. Use source=auto to prefer Anna's Archive with LibGen fallback, or force a specific source.",
       SearchMultiSourceParamsSchema.shape,
       ann('search_multi_source'),
-      async (args) =>
-        wrapResult(await handlers.searchMultiSource(args as any), 'search_multi_source'),
+      async (args, extra) =>
+        wrapResult(
+          await handlers.searchMultiSource(args as any, { signal: extra?.signal }),
+          'search_multi_source',
+        ),
     );
 
     // Create and connect the Stdio transport

--- a/src/lib/circuit-breaker.ts
+++ b/src/lib/circuit-breaker.ts
@@ -12,6 +12,13 @@ export interface CircuitBreakerOptions {
   threshold?: number;
   timeout?: number;
   onStateChange?: (oldState: CircuitState, newState: CircuitState) => void;
+  /**
+   * Whether a rejection counts toward opening the circuit. Defaults to
+   * counting everything. Override to exclude rejections that say nothing
+   * about the dependency's health — a caller cancelling its own request,
+   * for instance.
+   */
+  isFailure?: (error: any) => boolean;
 }
 
 export class CircuitBreaker {
@@ -21,11 +28,13 @@ export class CircuitBreaker {
   private readonly threshold: number;
   private readonly timeout: number;
   private readonly onStateChange?: (oldState: CircuitState, newState: CircuitState) => void;
+  private readonly isFailure: (error: any) => boolean;
 
   constructor(options: CircuitBreakerOptions = {}) {
     this.threshold = options.threshold ?? 5;
     this.timeout = options.timeout ?? 60000;
     this.onStateChange = options.onStateChange;
+    this.isFailure = options.isFailure ?? (() => true);
   }
 
   /**
@@ -48,7 +57,13 @@ export class CircuitBreaker {
       this.onSuccess();
       return result;
     } catch (error) {
-      this.onFailure();
+      // Not every rejection is evidence the dependency is unhealthy. A caller
+      // that cancelled its own request tells us nothing about the far side, and
+      // counting those would let a user who aborts five searches trip the
+      // breaker and fail unrelated tools for the whole timeout window.
+      if (this.isFailure(error)) {
+        this.onFailure();
+      }
       throw error;
     }
   }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -120,3 +120,20 @@ export class TimeoutError extends ZLibraryError {
     this.name = 'TimeoutError';
   }
 }
+
+/**
+ * Error thrown when the Python bridge subprocess exceeded its wall-clock
+ * budget (or the caller aborted) and was killed.
+ *
+ * Deliberately fatal, unlike TimeoutError. The bridge budget is minutes long
+ * and the Python side has already exhausted its own per-provider retries and
+ * mirror failover by the time it fires, so retrying multiplies a wait the
+ * caller is plainly not getting value from. `isRetryableError` short-circuits
+ * on `fatal`, so this stops the retry loop before the code-based rules.
+ */
+export class BridgeTimeoutError extends ZLibraryError {
+  constructor(message: string, context?: ErrorContext) {
+    super(message, 'TIMEOUT', context, false, true);
+    this.name = 'BridgeTimeoutError';
+  }
+}

--- a/src/lib/python-bridge.ts
+++ b/src/lib/python-bridge.ts
@@ -2,11 +2,12 @@ import { existsSync } from 'fs';
 import type { Options as PythonShellOptions } from 'python-shell';
 import { getManagedPythonPath } from './venv-manager.js'; // Import from the TS file
 import { getPythonLibDirectory, getPythonScriptPath } from './paths.js';
-import { runPythonBridge } from './python-runner.js';
+import { LONG_BRIDGE_TIMEOUT_MS, runPythonBridge } from './python-runner.js';
 import type { RunBridgeOptions } from './python-runner.js';
 import { PythonBridgeError } from './errors.js';
 
 const BRIDGE_SCRIPT_NAME = 'python_bridge.py';
+const LONG_RUNNING_FUNCTIONS = new Set(['download_book', 'process_document']);
 
 export interface BridgeErrorEnvelope {
   error: string;
@@ -99,6 +100,9 @@ export async function callPythonFunction(
   try {
     const lines = await runPythonBridge(BRIDGE_SCRIPT_NAME, options, {
       ...runOptions,
+      timeoutMs:
+        runOptions.timeoutMs ??
+        (LONG_RUNNING_FUNCTIONS.has(functionName) ? LONG_BRIDGE_TIMEOUT_MS : undefined),
       label: runOptions.label ?? `python_bridge.${functionName}`,
     });
     output = lines.join('\n');

--- a/src/lib/python-bridge.ts
+++ b/src/lib/python-bridge.ts
@@ -4,8 +4,60 @@ import { getManagedPythonPath } from './venv-manager.js'; // Import from the TS 
 import { getPythonLibDirectory, getPythonScriptPath } from './paths.js';
 import { runPythonBridge } from './python-runner.js';
 import type { RunBridgeOptions } from './python-runner.js';
+import { PythonBridgeError } from './errors.js';
 
 const BRIDGE_SCRIPT_NAME = 'python_bridge.py';
+
+export interface BridgeErrorEnvelope {
+  error: string;
+  type?: string;
+  details?: any;
+}
+
+const UNREACHABLE_REASONS = new Set([
+  'dns_failure',
+  'dns_timeout',
+  'connect_timeout',
+  'connect_refused',
+  'connect_error',
+  'tls_error',
+]);
+
+function everyFailureHasReason(details: any, predicate: (reason: unknown) => boolean): boolean {
+  if (!details || typeof details !== 'object') return false;
+  if (typeof details.reason === 'string') return predicate(details.reason);
+  return (
+    Array.isArray(details.failures) &&
+    details.failures.length > 0 &&
+    details.failures.every((failure: any) => predicate(failure?.reason))
+  );
+}
+
+export function isConfigurationBridgeDetail(details: any): boolean {
+  return everyFailureHasReason(details, (reason) => reason === 'configuration_error');
+}
+
+export function isBridgeDetailRetryable(details: any): boolean {
+  if (isConfigurationBridgeDetail(details)) return false;
+  return !everyFailureHasReason(details, (reason) => UNREACHABLE_REASONS.has(String(reason)));
+}
+
+/** Extract the final JSON provider-error envelope from mixed stderr logs. */
+export function parseBridgeErrorEnvelope(stderr: unknown): BridgeErrorEnvelope | null {
+  if (typeof stderr !== 'string' || stderr.length === 0) return null;
+  const lines = stderr.split('\n');
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = (lines[index] ?? '').trim();
+    if (!line.startsWith('{')) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed.error === 'string') return parsed;
+    } catch {
+      // Diagnostic line, not the envelope.
+    }
+  }
+  return null;
+}
 
 /**
  * Execute a Python function from the python_bridge.py script.
@@ -52,11 +104,23 @@ export async function callPythonFunction(
     output = lines.join('\n');
   } catch (error: any) {
     if (typeof error?.exitCode === 'number') {
-      throw new Error(
-        `Python process exited with code ${error.exitCode}: ${error.stderr ?? error.message}. ` +
-          `Raw stdout: ${error.stdout ?? ''}`,
-        { cause: error },
-      );
+      const envelope = parseBridgeErrorEnvelope(error.stderr);
+      const message = `Python process exited with code ${error.exitCode}: ${error.stderr ?? error.message}. Raw stdout: ${error.stdout ?? ''}`;
+      if (envelope) {
+        throw new PythonBridgeError(
+          message,
+          {
+            functionName,
+            args,
+            details: envelope.details,
+            pythonErrorType: envelope.type,
+            stderr: error.stderr,
+            originalError: error,
+          },
+          isBridgeDetailRetryable(envelope.details),
+        );
+      }
+      throw new Error(message, { cause: error });
     }
     throw error;
   }

--- a/src/lib/python-bridge.ts
+++ b/src/lib/python-bridge.ts
@@ -23,6 +23,7 @@ const UNREACHABLE_REASONS = new Set([
   'connect_error',
   'tls_error',
 ]);
+const PERMANENT_CALLER_REASONS = new Set(['configuration_error', 'quota_exhausted']);
 
 function everyFailureHasReason(details: any, predicate: (reason: unknown) => boolean): boolean {
   if (!details || typeof details !== 'object') return false;
@@ -38,8 +39,12 @@ export function isConfigurationBridgeDetail(details: any): boolean {
   return everyFailureHasReason(details, (reason) => reason === 'configuration_error');
 }
 
+export function isPermanentBridgeDetail(details: any): boolean {
+  return everyFailureHasReason(details, (reason) => PERMANENT_CALLER_REASONS.has(String(reason)));
+}
+
 export function isBridgeDetailRetryable(details: any): boolean {
-  if (isConfigurationBridgeDetail(details)) return false;
+  if (isPermanentBridgeDetail(details)) return false;
   return !everyFailureHasReason(details, (reason) => UNREACHABLE_REASONS.has(String(reason)));
 }
 

--- a/src/lib/python-bridge.ts
+++ b/src/lib/python-bridge.ts
@@ -1,28 +1,29 @@
-import { spawn } from 'child_process';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
+import type { Options as PythonShellOptions } from 'python-shell';
 import { getManagedPythonPath } from './venv-manager.js'; // Import from the TS file
+import { getPythonLibDirectory, getPythonScriptPath } from './paths.js';
+import { runPythonBridge } from './python-runner.js';
+import type { RunBridgeOptions } from './python-runner.js';
 
-// Recreate __dirname for ESM
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const BRIDGE_SCRIPT_NAME = 'python_bridge.py';
 
 /**
  * Execute a Python function from the python_bridge.py script.
  * @param functionName - Name of the Python function to call.
  * @param args - Arguments to pass to the function.
+ * @param runOptions - Optional timeout and abort signal for the owned runner.
  * @returns Promise resolving with the result from the Python function.
  * @throws {Error} If the Python process fails or returns an error.
  */
-export async function callPythonFunction(functionName: string, args: Record<string, any> = {}): Promise<any> {
+export async function callPythonFunction(
+  functionName: string,
+  args: Record<string, any> = {},
+  runOptions: RunBridgeOptions = {},
+): Promise<any> {
   // Await async setup before creating the Promise (avoids async promise executor)
   const pythonExecutable = await getManagedPythonPath();
 
-  // Path to the Python bridge script
-  // Navigate from dist/lib/ up to project root, then into source lib/ directory
-  // This keeps Python scripts in a single source of truth location (lib/)
-  const scriptPath = path.resolve(__dirname, '..', '..', 'lib', 'python_bridge.py');
+  const scriptPath = getPythonScriptPath(BRIDGE_SCRIPT_NAME);
 
   // Validate script exists before attempting to spawn
   if (!existsSync(scriptPath)) {
@@ -35,49 +36,37 @@ export async function callPythonFunction(functionName: string, args: Record<stri
 
   // Serialize arguments as JSON
   const serializedArgs = JSON.stringify(args);
+  const options: PythonShellOptions = {
+    mode: 'text',
+    pythonPath: pythonExecutable,
+    scriptPath: getPythonLibDirectory(),
+    args: [functionName, serializedArgs],
+  };
 
-  return new Promise((resolve, reject) => {
-    // Spawn Python process using the venv Python
-    const pythonProcess = spawn(pythonExecutable, [
-      scriptPath,
-      functionName,
-      serializedArgs
-    ]);
-
-    let result = '';
-    let errorOutput = '';
-
-    // Collect output
-    if (pythonProcess.stdout) {
-      pythonProcess.stdout.on('data', (data) => {
-        result += data.toString();
-      });
-    }
-
-    if (pythonProcess.stderr) {
-      pythonProcess.stderr.on('data', (data) => {
-        errorOutput += data.toString();
-      });
-    }
-
-    // Handle process completion
-    pythonProcess.on('close', (code) => {
-      if (code === 0) {
-        try {
-          // Parse the JSON result
-          const parsedResult = JSON.parse(result);
-          resolve(parsedResult);
-        } catch (e: any) {
-          // If parsing fails, reject with potentially useful raw output
-          reject(new Error(`Failed to parse Python result JSON: ${e.message}. Raw output: ${result}. Stderr: ${errorOutput}`));
-        }
-      } else {
-        reject(new Error(`Python process exited with code ${code}: ${errorOutput}. Raw stdout: ${result}`));
-      }
+  let output: string;
+  try {
+    const lines = await runPythonBridge(BRIDGE_SCRIPT_NAME, options, {
+      ...runOptions,
+      label: runOptions.label ?? `python_bridge.${functionName}`,
     });
+    output = lines.join('\n');
+  } catch (error: any) {
+    if (typeof error?.exitCode === 'number') {
+      throw new Error(
+        `Python process exited with code ${error.exitCode}: ${error.stderr ?? error.message}. ` +
+          `Raw stdout: ${error.stdout ?? ''}`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 
-    pythonProcess.on('error', (err) => {
-      reject(new Error(`Failed to start Python process: ${err.message}`));
-    });
-  });
+  try {
+    return JSON.parse(output);
+  } catch (error: any) {
+    throw new Error(
+      `Failed to parse Python result JSON: ${error.message}. Raw output: ${output}. Stderr: `,
+      { cause: error },
+    );
+  }
 }

--- a/src/lib/python-runner.ts
+++ b/src/lib/python-runner.ts
@@ -29,16 +29,20 @@ import { BridgeTimeoutError } from './errors.js';
 /**
  * Read a positive-integer millisecond budget from the environment.
  *
- * `parseInt('abc')` is NaN, and `setTimeout(fn, NaN)` fires on the next tick —
- * so a typo in the env var would not loosen the budget, it would kill every
- * bridge call instantly. Nonsense falls back to the default, matching
- * `_positive_float` on the Python side (lib/sources/config.py).
+ * A malformed value must not shorten the budget: `setTimeout(fn, NaN)` fires on
+ * the next tick, so a typo would kill every bridge call instantly rather than
+ * loosen anything. `parseInt` is not enough of a guard on its own — it stops at
+ * the first character it cannot use, so `'1.5'` and `'1e6'` both yield 1 (a 1ms
+ * deadline) and `'240000abc'` yields 240000. The whole string must therefore be
+ * a plain positive integer, or we fall back to the default. Mirrors
+ * `_positive_float` on the Python side (lib/sources/config.py), which is
+ * already safe here because it parses a float.
  */
 function positiveIntEnv(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const value = parseInt(raw, 10);
-  return Number.isFinite(value) && value > 0 ? value : fallback;
+  const raw = process.env[name]?.trim();
+  if (!raw || !/^\d+$/.test(raw)) return fallback;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
 }
 
 /** Wall-clock budget for one bridge call. */

--- a/src/lib/python-runner.ts
+++ b/src/lib/python-runner.ts
@@ -24,6 +24,7 @@
 import { PythonShell } from 'python-shell';
 import type { Options as PythonShellOptions } from 'python-shell';
 import { spawnSync } from 'child_process';
+import { readdirSync, readFileSync } from 'fs';
 import { logger } from './logger.js';
 import { BridgeTimeoutError } from './errors.js';
 
@@ -69,7 +70,14 @@ export const KILL_GRACE_MS = positiveIntEnv('PYTHON_BRIDGE_KILL_GRACE', 3000);
  * child outlives its parent by default, so without this an exiting server
  * leaves orphans behind exactly like an abandoned promise does.
  */
-const liveShells = new Set<PythonShell>();
+interface ProcessTreeRecord {
+  shell: PythonShell;
+  /** POSIX process-group id, retained after the direct child exits. */
+  pid: number;
+  livenessTimer?: NodeJS.Timeout;
+}
+
+const liveTrees = new Set<ProcessTreeRecord>();
 
 let exitHooksInstalled = false;
 
@@ -80,9 +88,8 @@ let exitHooksInstalled = false;
  * targets the whole group. Windows has no equivalent in Node's kill API;
  * taskkill /T is the platform facility for terminating a process tree.
  */
-function signalProcessTree(shell: PythonShell, signal: NodeJS.Signals): boolean {
-  const pid = shell.childProcess?.pid;
-  if (!pid) return false;
+function signalProcessTree(tree: ProcessTreeRecord, signal: NodeJS.Signals): boolean {
+  const { shell, pid } = tree;
 
   if (process.platform === 'win32') {
     const result = spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
@@ -113,16 +120,47 @@ function signalProcessTree(shell: PythonShell, signal: NodeJS.Signals): boolean 
 }
 
 /** Whether any member of the isolated POSIX process group still exists. */
-function processTreeIsAlive(shell: PythonShell): boolean {
-  const pid = shell.childProcess?.pid;
-  if (!pid) return false;
+function processTreeIsAlive(tree: ProcessTreeRecord): boolean {
+  const { shell, pid } = tree;
   if (process.platform === 'win32') return shell.childProcess.exitCode === null;
   try {
     process.kill(-pid, 0);
-    return true;
+    if (process.platform !== 'linux') return true;
+
+    // kill(0) also succeeds for zombies. A descendant whose direct parent
+    // exited can remain as a zombie until the container's init reaps it; such
+    // a task cannot execute or hold resources and must not pin the ownership
+    // record forever. Inspect the Linux process-group field and require at
+    // least one non-zombie member. Other POSIX hosts retain kill(0) semantics.
+    for (const entry of readdirSync('/proc')) {
+      if (!/^\d+$/.test(entry)) continue;
+      try {
+        const stat = readFileSync(`/proc/${entry}/stat`, 'utf8');
+        const fields = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
+        const state = fields[0];
+        const processGroup = Number(fields[2]);
+        if (processGroup === pid && state !== 'Z') return true;
+      } catch {
+        // Process exited between directory listing and stat read.
+      }
+    }
+    return false;
   } catch {
     return false;
   }
+}
+
+function releaseTreeIfGone(tree: ProcessTreeRecord): boolean {
+  if (processTreeIsAlive(tree)) return false;
+  if (tree.livenessTimer) clearInterval(tree.livenessTimer);
+  liveTrees.delete(tree);
+  return true;
+}
+
+function monitorTree(tree: ProcessTreeRecord): void {
+  if (releaseTreeIfGone(tree) || tree.livenessTimer) return;
+  tree.livenessTimer = setInterval(() => releaseTreeIfGone(tree), 250);
+  tree.livenessTimer.unref?.();
 }
 
 /**
@@ -133,8 +171,10 @@ function processTreeIsAlive(shell: PythonShell): boolean {
  */
 export function killAllPythonChildren(signal: NodeJS.Signals = 'SIGTERM'): number {
   let killed = 0;
-  for (const shell of Array.from(liveShells)) {
-    if (signalProcessTree(shell, signal)) killed += 1;
+  for (const tree of Array.from(liveTrees)) {
+    if (releaseTreeIfGone(tree)) continue;
+    if (signalProcessTree(tree, signal)) killed += 1;
+    monitorTree(tree);
   }
   return killed;
 }
@@ -216,12 +256,18 @@ export function runPythonBridge(
       // bridge-owned tree addressable without walking /proc.
       detached: process.platform === 'win32' ? options.detached : true,
     });
-    liveShells.add(shell);
+    const pid = shell.childProcess?.pid;
+    if (!pid) {
+      return reject(new Error(`${label} did not expose a child process id`));
+    }
+    const tree: ProcessTreeRecord = { shell, pid };
+    liveTrees.add(tree);
 
     const output: string[] = [];
     const stderrLines: string[] = [];
     let settled = false;
     let killTimer: NodeJS.Timeout | undefined;
+    let terminationStarted = false;
 
     // Armed here so `cleanup` below can close over it. Its callback calls
     // `failWith`, which is declared further down — safe because a setTimeout
@@ -230,7 +276,7 @@ export function runPythonBridge(
       failWith(
         new BridgeTimeoutError(
           `${label} exceeded its ${timeoutMs}ms budget and was terminated. ` +
-            `The subprocess was killed, so no orphan remains. ` +
+            `Termination was requested and the process group remains owned until exit. ` +
             `Raise PYTHON_BRIDGE_TIMEOUT if this operation is legitimately slower.`,
           { label, timeoutMs, reason: 'timeout', stderr: stderrLines.join('\n') },
         ),
@@ -239,10 +285,8 @@ export function runPythonBridge(
     }, timeoutMs);
     if (typeof timer.unref === 'function') timer.unref();
 
-    const cleanup = () => {
-      liveShells.delete(shell);
+    const cleanupCall = () => {
       clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
       if (runOptions.signal) runOptions.signal.removeEventListener('abort', onAbort);
     };
 
@@ -253,12 +297,19 @@ export function runPythonBridge(
      * which is the case this exists for.
      */
     const terminate = (why: string) => {
-      signalProcessTree(shell, 'SIGTERM');
+      if (terminationStarted || releaseTreeIfGone(tree)) return;
+      terminationStarted = true;
+      signalProcessTree(tree, 'SIGTERM');
       killTimer = setTimeout(() => {
-        if (process.platform === 'win32' || processTreeIsAlive(shell)) {
+        if (process.platform === 'win32' || processTreeIsAlive(tree)) {
           logger.warn(`${label}: process tree survived SIGTERM after ${why}; sending SIGKILL`);
-          signalProcessTree(shell, 'SIGKILL');
+          signalProcessTree(tree, 'SIGKILL');
         }
+        // A kill request is not proof of exit: SIGKILL can remain pending
+        // while a POSIX task is stuck in uninterruptible I/O, and Windows
+        // termination can fail. Keep survivors registered so shutdown can
+        // retry; the liveness monitor removes them once exit is observed.
+        monitorTree(tree);
       }, KILL_GRACE_MS);
       if (typeof killTimer.unref === 'function') killTimer.unref();
     };
@@ -271,7 +322,6 @@ export function runPythonBridge(
       // a shutdown in the meantime still SIGKILLs it.
       clearTimeout(timer);
       if (runOptions.signal) runOptions.signal.removeEventListener('abort', onAbort);
-      setTimeout(() => liveShells.delete(shell), KILL_GRACE_MS + 100).unref?.();
       reject(error);
     };
 
@@ -297,9 +347,18 @@ export function runPythonBridge(
     });
 
     shell.end((err: any) => {
-      if (settled) return;
+      if (settled) {
+        cleanupCall();
+        monitorTree(tree);
+        return;
+      }
       settled = true;
-      cleanup();
+      cleanupCall();
+      // A successful direct child can leave detached-stdio descendants in its
+      // process group. Preserve its output/result, but bound ownership of the
+      // surviving group with the same TERM/grace/KILL lifecycle as a timeout.
+      if (processTreeIsAlive(tree)) terminate('direct parent exit');
+      else monitorTree(tree);
       if (err) {
         if (stderrLines.length > 0 && !err.stderr) {
           err.stderr = stderrLines.join('\n');
@@ -314,5 +373,6 @@ export function runPythonBridge(
 
 /** Number of bridge children currently registered (used by tests). */
 export function liveChildCount(): number {
-  return liveShells.size;
+  for (const tree of Array.from(liveTrees)) releaseTreeIfGone(tree);
+  return liveTrees.size;
 }

--- a/src/lib/python-runner.ts
+++ b/src/lib/python-runner.ts
@@ -23,6 +23,7 @@
 
 import { PythonShell } from 'python-shell';
 import type { Options as PythonShellOptions } from 'python-shell';
+import { spawnSync } from 'child_process';
 import { logger } from './logger.js';
 import { BridgeTimeoutError } from './errors.js';
 
@@ -70,6 +71,58 @@ const liveShells = new Set<PythonShell>();
 let exitHooksInstalled = false;
 
 /**
+ * Signal the bridge and every subprocess it spawned.
+ *
+ * POSIX children are launched as their own process group, so a negative pid
+ * targets the whole group. Windows has no equivalent in Node's kill API;
+ * taskkill /T is the platform facility for terminating a process tree.
+ */
+function signalProcessTree(shell: PythonShell, signal: NodeJS.Signals): boolean {
+  const pid = shell.childProcess?.pid;
+  if (!pid) return false;
+
+  if (process.platform === 'win32') {
+    const result = spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    if (result.status === 0) return true;
+    try {
+      return shell.childProcess.kill(signal);
+    } catch {
+      return false;
+    }
+  }
+
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch {
+    // The group may already be gone, or a caller may have supplied a Python
+    // implementation that cannot start a new session. Direct-child fallback
+    // preserves the old best effort in either case.
+    try {
+      return shell.childProcess.kill(signal);
+    } catch {
+      return false;
+    }
+  }
+}
+
+/** Whether any member of the isolated POSIX process group still exists. */
+function processTreeIsAlive(shell: PythonShell): boolean {
+  const pid = shell.childProcess?.pid;
+  if (!pid) return false;
+  if (process.platform === 'win32') return shell.childProcess.exitCode === null;
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Kill every bridge subprocess still running.
  *
  * @param signal - Signal to send (SIGTERM by default)
@@ -78,12 +131,7 @@ let exitHooksInstalled = false;
 export function killAllPythonChildren(signal: NodeJS.Signals = 'SIGTERM'): number {
   let killed = 0;
   for (const shell of Array.from(liveShells)) {
-    try {
-      shell.kill(signal);
-      killed += 1;
-    } catch {
-      // Already gone; nothing to do.
-    }
+    if (signalProcessTree(shell, signal)) killed += 1;
   }
   return killed;
 }
@@ -155,7 +203,13 @@ export function runPythonBridge(
   }
 
   return new Promise<string[]>((resolve, reject) => {
-    const shell = new PythonShell(scriptName, options);
+    const shell = new PythonShell(scriptName, {
+      ...options,
+      // On POSIX this creates a new session/process group whose id is the
+      // Python pid. OCR and other grandchildren inherit it, making the whole
+      // bridge-owned tree addressable without walking /proc.
+      detached: process.platform === 'win32' ? options.detached : true,
+    });
     liveShells.add(shell);
 
     const output: string[] = [];
@@ -193,19 +247,11 @@ export function runPythonBridge(
      * which is the case this exists for.
      */
     const terminate = (why: string) => {
-      try {
-        shell.kill('SIGTERM');
-      } catch {
-        /* already gone */
-      }
+      signalProcessTree(shell, 'SIGTERM');
       killTimer = setTimeout(() => {
-        if (shell.childProcess && shell.childProcess.exitCode === null) {
-          logger.warn(`${label}: child survived SIGTERM after ${why}; sending SIGKILL`);
-          try {
-            shell.kill('SIGKILL');
-          } catch {
-            /* already gone */
-          }
+        if (process.platform === 'win32' || processTreeIsAlive(shell)) {
+          logger.warn(`${label}: process tree survived SIGTERM after ${why}; sending SIGKILL`);
+          signalProcessTree(shell, 'SIGKILL');
         }
       }, KILL_GRACE_MS);
       if (typeof killTimer.unref === 'function') killTimer.unref();

--- a/src/lib/python-runner.ts
+++ b/src/lib/python-runner.ts
@@ -74,12 +74,17 @@ interface ProcessTreeRecord {
   shell: PythonShell;
   /** POSIX process-group id, retained after the direct child exits. */
   pid: number;
+  label: string;
   livenessTimer?: NodeJS.Timeout;
+  killTimer?: NodeJS.Timeout;
+  terminationStarted?: boolean;
 }
 
 const liveTrees = new Set<ProcessTreeRecord>();
 
 let exitHooksInstalled = false;
+let shutdownSignal: NodeJS.Signals | undefined;
+let shutdownObservationTimer: NodeJS.Timeout | undefined;
 
 /**
  * Signal the bridge and every subprocess it spawned.
@@ -153,6 +158,7 @@ function processTreeIsAlive(tree: ProcessTreeRecord): boolean {
 function releaseTreeIfGone(tree: ProcessTreeRecord): boolean {
   if (processTreeIsAlive(tree)) return false;
   if (tree.livenessTimer) clearInterval(tree.livenessTimer);
+  if (tree.killTimer) clearTimeout(tree.killTimer);
   liveTrees.delete(tree);
   return true;
 }
@@ -161,6 +167,80 @@ function monitorTree(tree: ProcessTreeRecord): void {
   if (releaseTreeIfGone(tree) || tree.livenessTimer) return;
   tree.livenessTimer = setInterval(() => releaseTreeIfGone(tree), 250);
   tree.livenessTimer.unref?.();
+}
+
+/** Apply the one shared TERM -> grace -> KILL lifecycle to an owned tree. */
+function terminateProcessTree(
+  tree: ProcessTreeRecord,
+  why: string,
+  keepEventLoopAlive = false,
+): boolean {
+  if (releaseTreeIfGone(tree)) return false;
+  if (tree.terminationStarted) {
+    if (keepEventLoopAlive) tree.killTimer?.ref?.();
+    return false;
+  }
+
+  tree.terminationStarted = true;
+  const signalled = signalProcessTree(tree, 'SIGTERM');
+  tree.killTimer = setTimeout(() => {
+    if (process.platform === 'win32' || processTreeIsAlive(tree)) {
+      logger.warn(`${tree.label}: process tree survived SIGTERM after ${why}; sending SIGKILL`);
+      signalProcessTree(tree, 'SIGKILL');
+    }
+    monitorTree(tree);
+  }, KILL_GRACE_MS);
+  if (!keepEventLoopAlive) tree.killTimer.unref?.();
+  return signalled;
+}
+
+function forceProcessTree(tree: ProcessTreeRecord): boolean {
+  if (releaseTreeIfGone(tree)) return false;
+  if (tree.killTimer) clearTimeout(tree.killTimer);
+  tree.killTimer = undefined;
+  const signalled = signalProcessTree(tree, 'SIGKILL');
+  monitorTree(tree);
+  return signalled;
+}
+
+function observeShutdownUntilGone(): void {
+  if (shutdownObservationTimer) return;
+  const observe = () => {
+    shutdownObservationTimer = undefined;
+    for (const tree of Array.from(liveTrees)) releaseTreeIfGone(tree);
+    if (liveTrees.size > 0) {
+      shutdownObservationTimer = setTimeout(observe, 25);
+      return;
+    }
+
+    const signal = shutdownSignal;
+    if (!signal) return;
+    process.removeAllListeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+    process.kill(process.pid, signal);
+  };
+  shutdownObservationTimer = setTimeout(observe, 0);
+}
+
+function beginShutdown(signal: NodeJS.Signals): void {
+  if (shutdownSignal) {
+    // A second signal is the operator's request to skip the remaining grace
+    // period, but the parent still waits until the owned groups are observed gone.
+    shutdownSignal = signal;
+    for (const tree of Array.from(liveTrees)) forceProcessTree(tree);
+    observeShutdownUntilGone();
+    return;
+  }
+
+  shutdownSignal = signal;
+  let signalled = 0;
+  for (const tree of Array.from(liveTrees)) {
+    if (terminateProcessTree(tree, 'server shutdown', true)) signalled += 1;
+  }
+  if (signalled > 0) {
+    logger.info(`Received ${signal}; signalled ${signalled} Python bridge child(ren)`);
+  }
+  observeShutdownUntilGone();
 }
 
 /**
@@ -173,8 +253,11 @@ export function killAllPythonChildren(signal: NodeJS.Signals = 'SIGTERM'): numbe
   let killed = 0;
   for (const tree of Array.from(liveTrees)) {
     if (releaseTreeIfGone(tree)) continue;
-    if (signalProcessTree(tree, signal)) killed += 1;
-    monitorTree(tree);
+    const signalled =
+      signal === 'SIGTERM'
+        ? terminateProcessTree(tree, 'shutdown request')
+        : forceProcessTree(tree);
+    if (signalled) killed += 1;
   }
   return killed;
 }
@@ -195,13 +278,7 @@ export function installExitHooks(): void {
 
   for (const signal of ['SIGINT', 'SIGTERM'] as NodeJS.Signals[]) {
     process.on(signal, () => {
-      const killed = killAllPythonChildren('SIGTERM');
-      if (killed > 0) {
-        logger.info(`Received ${signal}; signalled ${killed} Python bridge child(ren)`);
-      }
-      // Re-raise with the default disposition so normal exit semantics hold.
-      process.removeAllListeners(signal);
-      process.kill(process.pid, signal);
+      beginShutdown(signal);
     });
   }
 }
@@ -238,6 +315,10 @@ export function runPythonBridge(
 
   installExitHooks();
 
+  if (shutdownSignal) {
+    return Promise.reject(new Error(`${label} rejected because the bridge runner is shutting down`));
+  }
+
   // Never spawn work the caller has already given up on.
   if (runOptions.signal?.aborted) {
     return Promise.reject(
@@ -260,14 +341,12 @@ export function runPythonBridge(
     if (!pid) {
       return reject(new Error(`${label} did not expose a child process id`));
     }
-    const tree: ProcessTreeRecord = { shell, pid };
+    const tree: ProcessTreeRecord = { shell, pid, label };
     liveTrees.add(tree);
 
     const output: string[] = [];
     const stderrLines: string[] = [];
     let settled = false;
-    let killTimer: NodeJS.Timeout | undefined;
-    let terminationStarted = false;
 
     // Armed here so `cleanup` below can close over it. Its callback calls
     // `failWith`, which is declared further down — safe because a setTimeout
@@ -297,21 +376,7 @@ export function runPythonBridge(
      * which is the case this exists for.
      */
     const terminate = (why: string) => {
-      if (terminationStarted || releaseTreeIfGone(tree)) return;
-      terminationStarted = true;
-      signalProcessTree(tree, 'SIGTERM');
-      killTimer = setTimeout(() => {
-        if (process.platform === 'win32' || processTreeIsAlive(tree)) {
-          logger.warn(`${label}: process tree survived SIGTERM after ${why}; sending SIGKILL`);
-          signalProcessTree(tree, 'SIGKILL');
-        }
-        // A kill request is not proof of exit: SIGKILL can remain pending
-        // while a POSIX task is stuck in uninterruptible I/O, and Windows
-        // termination can fail. Keep survivors registered so shutdown can
-        // retry; the liveness monitor removes them once exit is observed.
-        monitorTree(tree);
-      }, KILL_GRACE_MS);
-      if (typeof killTimer.unref === 'function') killTimer.unref();
+      terminateProcessTree(tree, why);
     };
 
     const failWith = (error: Error, why: string) => {

--- a/src/lib/python-runner.ts
+++ b/src/lib/python-runner.ts
@@ -39,11 +39,14 @@ import { BridgeTimeoutError } from './errors.js';
  * `_positive_float` on the Python side (lib/sources/config.py), which is
  * already safe here because it parses a float.
  */
+function positiveIntOrFallback(value: unknown, fallback: number): number {
+  return Number.isSafeInteger(value) && (value as number) > 0 ? (value as number) : fallback;
+}
+
 function positiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
   if (!raw || !/^\d+$/.test(raw)) return fallback;
-  const value = Number(raw);
-  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
+  return positiveIntOrFallback(Number(raw), fallback);
 }
 
 /** Wall-clock budget for one bridge call. */
@@ -187,7 +190,10 @@ export function runPythonBridge(
   options: PythonShellOptions,
   runOptions: RunBridgeOptions = {},
 ): Promise<string[]> {
-  const timeoutMs = runOptions.timeoutMs ?? DEFAULT_BRIDGE_TIMEOUT_MS;
+  const timeoutMs = positiveIntOrFallback(
+    runOptions.timeoutMs ?? DEFAULT_BRIDGE_TIMEOUT_MS,
+    DEFAULT_BRIDGE_TIMEOUT_MS,
+  );
   const label = runOptions.label ?? scriptName;
 
   installExitHooks();

--- a/src/lib/python-runner.ts
+++ b/src/lib/python-runner.ts
@@ -60,7 +60,7 @@ export const DEFAULT_BRIDGE_TIMEOUT_MS = positiveIntEnv('PYTHON_BRIDGE_TIMEOUT',
  * these would kill real work, which is a worse failure than the orphan this
  * module exists to prevent.
  */
-export const LONG_BRIDGE_TIMEOUT_MS = positiveIntEnv('PYTHON_BRIDGE_LONG_TIMEOUT', 1800000);
+export const LONG_BRIDGE_TIMEOUT_MS = positiveIntEnv('PYTHON_BRIDGE_LONG_TIMEOUT', 2400000);
 
 /** Grace period between SIGTERM and SIGKILL. */
 export const KILL_GRACE_MS = positiveIntEnv('PYTHON_BRIDGE_KILL_GRACE', 3000);

--- a/src/lib/python-runner.ts
+++ b/src/lib/python-runner.ts
@@ -1,0 +1,262 @@
+/**
+ * Bounded, killable execution of the Python bridge subprocess.
+ *
+ * `PythonShell.run()` returns a promise with no timeout and no handle on the
+ * child, so a bridge call that never finishes has no way to end: abandoning the
+ * promise (as an MCP client does when it hits its own idle timeout) leaves the
+ * Python process running with nothing waiting on it. That is how three
+ * `python_bridge.py search...` processes were found alive on dionysus
+ * 2026-08-11, the oldest 9h10m old and belonging to a session that had already
+ * exited.
+ *
+ * This module owns the child instead:
+ *  - every run has a wall-clock deadline,
+ *  - expiry (or an AbortSignal from the MCP request) sends SIGTERM and then
+ *    SIGKILL, so a process wedged in an uninterruptible syscall still dies,
+ *  - every live child is registered, and the registry is drained when the
+ *    server itself exits.
+ *
+ * The Python side has its own per-provider budgets (lib/sources/config.py);
+ * PYTHON_BRIDGE_TIMEOUT must stay above their worst-case sum, or the kill here
+ * preempts a legitimate slow provider walk instead of catching a hang.
+ */
+
+import { PythonShell } from 'python-shell';
+import type { Options as PythonShellOptions } from 'python-shell';
+import { logger } from './logger.js';
+import { BridgeTimeoutError } from './errors.js';
+
+/**
+ * Read a positive-integer millisecond budget from the environment.
+ *
+ * `parseInt('abc')` is NaN, and `setTimeout(fn, NaN)` fires on the next tick —
+ * so a typo in the env var would not loosen the budget, it would kill every
+ * bridge call instantly. Nonsense falls back to the default, matching
+ * `_positive_float` on the Python side (lib/sources/config.py).
+ */
+function positiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+/** Wall-clock budget for one bridge call. */
+export const DEFAULT_BRIDGE_TIMEOUT_MS = positiveIntEnv('PYTHON_BRIDGE_TIMEOUT', 240000);
+
+/**
+ * Budget for operations that are legitimately slow rather than hung: fetching
+ * a multi-hundred-megabyte book, or OCR-ing a scanned one. The ordinary budget
+ * is sized for a provider walk that should answer in seconds; applying it to
+ * these would kill real work, which is a worse failure than the orphan this
+ * module exists to prevent.
+ */
+export const LONG_BRIDGE_TIMEOUT_MS = positiveIntEnv('PYTHON_BRIDGE_LONG_TIMEOUT', 1800000);
+
+/** Grace period between SIGTERM and SIGKILL. */
+export const KILL_GRACE_MS = positiveIntEnv('PYTHON_BRIDGE_KILL_GRACE', 3000);
+
+/**
+ * Every bridge child currently running. Held so shutdown can reap them: a
+ * child outlives its parent by default, so without this an exiting server
+ * leaves orphans behind exactly like an abandoned promise does.
+ */
+const liveShells = new Set<PythonShell>();
+
+let exitHooksInstalled = false;
+
+/**
+ * Kill every bridge subprocess still running.
+ *
+ * @param signal - Signal to send (SIGTERM by default)
+ * @returns Number of children signalled
+ */
+export function killAllPythonChildren(signal: NodeJS.Signals = 'SIGTERM'): number {
+  let killed = 0;
+  for (const shell of Array.from(liveShells)) {
+    try {
+      shell.kill(signal);
+      killed += 1;
+    } catch {
+      // Already gone; nothing to do.
+    }
+  }
+  return killed;
+}
+
+/**
+ * Install process-level handlers that reap bridge children on shutdown.
+ * Idempotent, and safe to call from module scope.
+ */
+export function installExitHooks(): void {
+  if (exitHooksInstalled) return;
+  exitHooksInstalled = true;
+
+  // 'exit' is synchronous, so only a synchronous kill is possible here — which
+  // is all that is needed, since the signal itself is delivered synchronously.
+  process.on('exit', () => {
+    killAllPythonChildren('SIGKILL');
+  });
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as NodeJS.Signals[]) {
+    process.on(signal, () => {
+      const killed = killAllPythonChildren('SIGTERM');
+      if (killed > 0) {
+        logger.info(`Received ${signal}; signalled ${killed} Python bridge child(ren)`);
+      }
+      // Re-raise with the default disposition so normal exit semantics hold.
+      process.removeAllListeners(signal);
+      process.kill(process.pid, signal);
+    });
+  }
+}
+
+export interface RunBridgeOptions {
+  /** Wall-clock budget in ms. Defaults to DEFAULT_BRIDGE_TIMEOUT_MS. */
+  timeoutMs?: number;
+  /** Abort signal from the MCP request, if the transport supplies one. */
+  signal?: AbortSignal;
+  /** Short label used in log lines and error messages. */
+  label?: string;
+}
+
+/**
+ * Run the Python bridge and collect its stdout lines.
+ *
+ * @param scriptName - Script filename, resolved against options.scriptPath
+ * @param options - PythonShell options (pythonPath, scriptPath, args, mode)
+ * @param runOptions - Timeout, abort signal, and log label
+ * @returns Lines the script wrote to stdout
+ * @throws {BridgeTimeoutError} If the budget expires or the caller aborts.
+ *   Marked fatal so the retry layer does not multiply an already-long wait.
+ */
+export function runPythonBridge(
+  scriptName: string,
+  options: PythonShellOptions,
+  runOptions: RunBridgeOptions = {},
+): Promise<string[]> {
+  const timeoutMs = runOptions.timeoutMs ?? DEFAULT_BRIDGE_TIMEOUT_MS;
+  const label = runOptions.label ?? scriptName;
+
+  installExitHooks();
+
+  // Never spawn work the caller has already given up on.
+  if (runOptions.signal?.aborted) {
+    return Promise.reject(
+      new BridgeTimeoutError(`${label} aborted before it started`, {
+        label,
+        reason: 'aborted',
+      }),
+    );
+  }
+
+  return new Promise<string[]>((resolve, reject) => {
+    const shell = new PythonShell(scriptName, options);
+    liveShells.add(shell);
+
+    const output: string[] = [];
+    const stderrLines: string[] = [];
+    let settled = false;
+    let killTimer: NodeJS.Timeout | undefined;
+
+    // Armed here so `cleanup` below can close over it. Its callback calls
+    // `failWith`, which is declared further down — safe because a setTimeout
+    // callback cannot run until this synchronous block has finished.
+    const timer: NodeJS.Timeout = setTimeout(() => {
+      failWith(
+        new BridgeTimeoutError(
+          `${label} exceeded its ${timeoutMs}ms budget and was terminated. ` +
+            `The subprocess was killed, so no orphan remains. ` +
+            `Raise PYTHON_BRIDGE_TIMEOUT if this operation is legitimately slower.`,
+          { label, timeoutMs, reason: 'timeout', stderr: stderrLines.join('\n') },
+        ),
+        'timeout',
+      );
+    }, timeoutMs);
+    if (typeof timer.unref === 'function') timer.unref();
+
+    const cleanup = () => {
+      liveShells.delete(shell);
+      clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+      if (runOptions.signal) runOptions.signal.removeEventListener('abort', onAbort);
+    };
+
+    /**
+     * Terminate the child: SIGTERM first, SIGKILL if it is still alive after
+     * the grace period. SIGKILL alone would skip Python's own cleanup; SIGTERM
+     * alone cannot dislodge a process blocked in an uninterruptible syscall,
+     * which is the case this exists for.
+     */
+    const terminate = (why: string) => {
+      try {
+        shell.kill('SIGTERM');
+      } catch {
+        /* already gone */
+      }
+      killTimer = setTimeout(() => {
+        if (shell.childProcess && shell.childProcess.exitCode === null) {
+          logger.warn(`${label}: child survived SIGTERM after ${why}; sending SIGKILL`);
+          try {
+            shell.kill('SIGKILL');
+          } catch {
+            /* already gone */
+          }
+        }
+      }, KILL_GRACE_MS);
+      if (typeof killTimer.unref === 'function') killTimer.unref();
+    };
+
+    const failWith = (error: Error, why: string) => {
+      if (settled) return;
+      settled = true;
+      terminate(why);
+      // Leave the shell registered until terminate's grace window elapses so
+      // a shutdown in the meantime still SIGKILLs it.
+      clearTimeout(timer);
+      if (runOptions.signal) runOptions.signal.removeEventListener('abort', onAbort);
+      setTimeout(() => liveShells.delete(shell), KILL_GRACE_MS + 100).unref?.();
+      reject(error);
+    };
+
+    function onAbort() {
+      failWith(
+        new BridgeTimeoutError(
+          `${label} was aborted by the caller; the subprocess was killed.`,
+          { label, reason: 'aborted', stderr: stderrLines.join('\n') },
+        ),
+        'abort',
+      );
+    }
+
+    runOptions.signal?.addEventListener('abort', onAbort, { once: true });
+
+    shell.on('message', (message: string) => {
+      output.push(message);
+    });
+
+    shell.on('stderr', (line: string) => {
+      // Bounded: a runaway child must not be able to grow this without limit.
+      if (stderrLines.length < 200) stderrLines.push(line);
+    });
+
+    shell.end((err: any) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (err) {
+        if (stderrLines.length > 0 && !err.stderr) {
+          err.stderr = stderrLines.join('\n');
+        }
+        reject(err);
+      } else {
+        resolve(output);
+      }
+    });
+  });
+}
+
+/** Number of bridge children currently registered (used by tests). */
+export function liveChildCount(): number {
+  return liveShells.size;
+}

--- a/src/lib/retry-manager.ts
+++ b/src/lib/retry-manager.ts
@@ -91,6 +91,12 @@ export function isRetryableError(error: any): boolean {
   if (error.retryable === false) {
     return false;
   }
+  if (
+    error.retryable === true &&
+    (error.code !== 'PYTHON_ERROR' || error.context?.details)
+  ) {
+    return true;
+  }
 
   // Authentication/authorization errors are not retryable
   if (error.code === 'AUTH_ERROR' || error.code === 'FORBIDDEN') {

--- a/src/lib/retry-manager.ts
+++ b/src/lib/retry-manager.ts
@@ -83,6 +83,15 @@ export function isRetryableError(error: any): boolean {
     return false;
   }
 
+  // An explicit verdict from whoever built the error beats the heuristics
+  // below. Those heuristics match on message text, so a provider error like
+  // "resolved but did not accept a connection before the deadline" would
+  // otherwise be retried on the strength of the word "connection" — even
+  // though the caller already established the host is not answering.
+  if (error.retryable === false) {
+    return false;
+  }
+
   // Authentication/authorization errors are not retryable
   if (error.code === 'AUTH_ERROR' || error.code === 'FORBIDDEN') {
     return false;

--- a/src/lib/venv-manager.ts
+++ b/src/lib/venv-manager.ts
@@ -15,10 +15,8 @@
  */
 
 import * as path from 'path';
-import { existsSync } from 'fs';
-import { execSync } from 'child_process';
+import { accessSync, constants, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { logger } from './logger.js';
 
 // Recreate __dirname for ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -86,15 +84,11 @@ export async function getManagedPythonPath(): Promise<string> {
     );
   }
 
-  // Verify Python is executable and working
+  // Validate only filesystem state here. Executing `python --version` created
+  // a second, synchronous and unbounded subprocess path outside the bridge
+  // lifecycle owner. The first real bridge invocation is the execution check.
   try {
-    const version = execSync(`"${uvVenvPython}" --version`, {
-      stdio: 'pipe',
-      encoding: 'utf8'
-    }).trim();
-
-    // Log Python version for debugging (optional, can be removed)
-    logger.debug(`[venv-manager] Using Python: ${version} from .venv`);
+    accessSync(uvVenvPython, process.platform === 'win32' ? constants.F_OK : constants.X_OK);
   } catch (error) {
     throw new Error(
       `Python at ${uvVenvPython} is not executable.\n` +

--- a/src/lib/zlibrary-api.ts
+++ b/src/lib/zlibrary-api.ts
@@ -27,7 +27,12 @@ const pythonBridgeCircuitBreaker = new CircuitBreaker({
   timeout: parseInt(process.env.CIRCUIT_BREAKER_TIMEOUT || '60000'),
   onStateChange: (oldState, newState) => {
     logger.info(`Python bridge circuit breaker: ${oldState} -> ${newState}`);
-  }
+  },
+  // A client that cancels its own request has told us nothing about the
+  // bridge's health. Counting cancellations would mean five aborted searches
+  // open the breaker and fail every unrelated tool for the timeout window —
+  // turning a user's own impatience into an outage.
+  isFailure: (error) => error?.context?.reason !== 'aborted',
 });
 
 /** Reason codes meaning the provider's host never answered at all. */

--- a/src/lib/zlibrary-api.ts
+++ b/src/lib/zlibrary-api.ts
@@ -1,5 +1,4 @@
 import type { Options as PythonShellOptions } from 'python-shell';
-import { PythonShell } from 'python-shell';
 import * as path from 'path';
 import { getManagedPythonPath } from './venv-manager.js'; // Import ESM style
 import { appendFile as appendFileAsyncFS, mkdir as mkdirAsyncFS } from 'fs/promises'; // Import fs/promises for async file operations, aliased
@@ -10,6 +9,7 @@ import { withRetry, isRetryableError } from './retry-manager.js';
 import { CircuitBreaker } from './circuit-breaker.js';
 import { ZLibraryError, PythonBridgeError } from './errors.js';
 import { logger } from './logger.js';
+import { runPythonBridge, LONG_BRIDGE_TIMEOUT_MS } from './python-runner.js';
 
 // Recreate __dirname for ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -30,14 +30,109 @@ const pythonBridgeCircuitBreaker = new CircuitBreaker({
   }
 });
 
+/** Reason codes meaning the provider's host never answered at all. */
+const UNREACHABLE_REASONS = new Set([
+  'dns_failure',
+  'dns_timeout',
+  'connect_timeout',
+  'connect_refused',
+  'connect_error',
+  'tls_error',
+]);
+
+interface BridgeErrorEnvelope {
+  error: string;
+  type?: string;
+  details?: any;
+}
+
+/**
+ * Parse the JSON error envelope python_bridge.py writes to stderr.
+ *
+ * The bridge may also emit log lines on stderr, so the envelope is found by
+ * scanning lines from the end rather than assuming it is the whole stream.
+ *
+ * @param stderr - Raw stderr text from the subprocess
+ * @returns The envelope, or null if stderr holds no parseable one
+ */
+function parseBridgeError(stderr: unknown): BridgeErrorEnvelope | null {
+  if (typeof stderr !== 'string' || stderr.length === 0) return null;
+  const lines = stderr.split('\n');
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = (lines[i] ?? '').trim();
+    if (!line.startsWith('{')) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed.error === 'string') return parsed;
+    } catch {
+      // Not the envelope; keep scanning.
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether a bridge error's details describe a host that never answered.
+ *
+ * @param details - The `details` field of a bridge error envelope
+ * @returns true if every reported failure is a reachability failure
+ */
+function isUnreachableDetail(details: any): boolean {
+  if (!details || typeof details !== 'object') return false;
+  if (typeof details.reason === 'string') return UNREACHABLE_REASONS.has(details.reason);
+  if (Array.isArray(details.failures) && details.failures.length > 0) {
+    return details.failures.every((f: any) => UNREACHABLE_REASONS.has(f?.reason));
+  }
+  return false;
+}
+
+/**
+ * Bridge functions whose work is bounded by file size and CPU, not by a
+ * network round trip. Downloading a large book and OCR-ing a scanned one both
+ * routinely outrun the ordinary budget, and killing them would turn a slow
+ * success into a hard failure — the opposite of what the budget is for. They
+ * are still bounded (PYTHON_BRIDGE_LONG_TIMEOUT), just far more generously.
+ */
+const LONG_RUNNING_FUNCTIONS = new Set(['download_book', 'process_document']);
+
+/**
+ * Default wall-clock budget for a bridge function, in ms.
+ *
+ * @param functionName - Bridge function being called
+ * @returns Budget in ms
+ */
+function defaultTimeoutFor(functionName: string): number | undefined {
+  return LONG_RUNNING_FUNCTIONS.has(functionName) ? LONG_BRIDGE_TIMEOUT_MS : undefined;
+}
+
+/**
+ * Per-call options for the Python bridge.
+ */
+export interface CallOptions {
+  /**
+   * Wall-clock budget in ms. Defaults to PYTHON_BRIDGE_TIMEOUT, or
+   * PYTHON_BRIDGE_LONG_TIMEOUT for download/processing calls.
+   */
+  timeoutMs?: number;
+  /** Abort signal from the MCP request, so a cancelled call kills the child. */
+  signal?: AbortSignal;
+}
+
 /**
  * Execute a Python function from the Z-Library repository
  * @param functionName - Name of the Python function to call
  * @param args - Arguments to pass to the function
+ * @param callOptions - Timeout and abort signal for the subprocess
  * @returns Promise resolving with the result from the Python function
  * @throws {ZLibraryError} If the Python process fails or returns an error.
+ * @throws {BridgeTimeoutError} If the subprocess exceeds its budget; the child
+ *   is killed rather than abandoned.
  */
-async function callPythonFunction(functionName: string, args: Record<string, any> = {}): Promise<any> {
+async function callPythonFunction(
+  functionName: string,
+  args: Record<string, any> = {},
+  callOptions: CallOptions = {},
+): Promise<any> {
   // Wrap the entire operation with retry logic and circuit breaker
   return withRetry(
     async () => {
@@ -54,11 +149,15 @@ async function callPythonFunction(functionName: string, args: Record<string, any
             args: [functionName, serializedArgs] // Pass serialized string directly
           };
 
-          // PythonShell.run call is already inside the try block (from line 33 in original)
-          // PythonShell.run returns Promise<string[] | undefined>
-          // We expect JSON, so results[0] should be the JSON string if successful
-          // PythonShell with mode: 'json' should return an array of parsed JSON objects (or throw an error)
-          const results = await PythonShell.run(BRIDGE_SCRIPT_NAME, options); // results will be string[] | undefined
+          // runPythonBridge, not PythonShell.run: the latter hands back a
+          // promise with no deadline and no handle on the child, so a hung
+          // call can only be abandoned — which leaves the Python process
+          // running forever (see src/lib/python-runner.ts).
+          const results = await runPythonBridge(BRIDGE_SCRIPT_NAME, options, {
+            timeoutMs: callOptions.timeoutMs ?? defaultTimeoutFor(functionName),
+            signal: callOptions.signal,
+            label: `python_bridge.${functionName}`,
+          });
 
           // Check if results exist and contain at least one element
           if (!results || results.length === 0) {
@@ -123,8 +222,32 @@ async function callPythonFunction(functionName: string, args: Record<string, any
             throw err;
           }
 
-          // Capture stderr if available
+          // The bridge writes a JSON envelope to stderr on failure. When the
+          // failure is a provider outage that envelope carries `details`
+          // naming the provider, host and reason (dns_failure vs
+          // connect_timeout vs http_error); lead with that instead of a
+          // traceback, so the caller can tell "this domain is gone" from
+          // "this mirror is dropping packets".
+          const bridgeError = parseBridgeError(err.stderr);
           const stderrOutput = err.stderr ? ` Stderr: ${err.stderr}` : '';
+
+          if (bridgeError) {
+            throw new PythonBridgeError(
+              `${functionName} failed: ${bridgeError.error}`,
+              {
+                functionName,
+                args,
+                details: bridgeError.details,
+                pythonErrorType: bridgeError.type,
+                stderr: err.stderr,
+                originalError: err
+              },
+              // A provider that is not reachable at all will not become
+              // reachable inside the retry window; retrying just re-pays the
+              // probe. Response-level failures may be transient.
+              !isUnreachableDetail(bridgeError.details)
+            );
+          }
 
           // Wrap in PythonBridgeError with context
           throw new PythonBridgeError(
@@ -276,7 +399,7 @@ export async function searchBooks({
   extensions = [],
   content_types = [],
   count = 10
-}: SearchBooksArgs): Promise<any> {
+}: SearchBooksArgs, options: CallOptions = {}): Promise<any> {
   // Pass arguments as an object matching Python function signature
   // Python bridge main() expects 'language' (singular) and 'content_types'
   const pythonArgs = {
@@ -297,7 +420,7 @@ export async function searchBooks({
     await mkdirAsyncFS(path.dirname(logFilePath), { recursive: true });
     await appendFileAsyncFS(logFilePath, searchBooksPythonArgsLog);
   } catch (e) { console.error('Failed to write to logs/nodejs_debug.log', e); }
-  return await callPythonFunction('search', pythonArgs);
+  return await callPythonFunction('search', pythonArgs, options);
 }
 /**
  * Perform full text search
@@ -311,7 +434,7 @@ export async function fullTextSearch({
   extensions = [],
   content_types = [],
   count = 10
-}: FullTextSearchArgs): Promise<any> {
+}: FullTextSearchArgs, options: CallOptions = {}): Promise<any> {
   // Pass arguments as an object matching Python function signature
   // Python bridge main() expects 'language' (singular) and 'content_types'
   const pythonArgsFTS = {
@@ -332,23 +455,23 @@ export async function fullTextSearch({
     await mkdirAsyncFS(path.dirname(logFilePath), { recursive: true });
     await appendFileAsyncFS(logFilePath, ftsPythonArgsLog);
   } catch (e) { console.error('Failed to write to logs/nodejs_debug.log', e); }
-  return await callPythonFunction('full_text_search', pythonArgsFTS);
+  return await callPythonFunction('full_text_search', pythonArgsFTS, options);
 }
 
 /**
  * Get user's download history
  */
-export async function getDownloadHistory({ count = 10 }: GetDownloadHistoryArgs): Promise<any> {
+export async function getDownloadHistory({ count = 10 }: GetDownloadHistoryArgs, options: CallOptions = {}): Promise<any> {
   // Pass arguments as an object matching Python function signature
-  return await callPythonFunction('get_download_history', { count });
+  return await callPythonFunction('get_download_history', { count }, options);
 }
 
 /**
  * Get user's download limits
  */
-export async function getDownloadLimits(): Promise<any> {
+export async function getDownloadLimits(options: CallOptions = {}): Promise<any> {
   // Pass arguments as an object matching Python function signature
-  return await callPythonFunction('get_download_limits', {});
+  return await callPythonFunction('get_download_limits', {}, options);
 }
 
 
@@ -358,7 +481,7 @@ export async function getDownloadLimits(): Promise<any> {
 export async function processDocumentForRag({
   filePath,
   outputFormat = 'txt',
-}: ProcessDocumentForRagArgs): Promise<ProcessedDocumentBundle> {
+}: ProcessDocumentForRagArgs, options: CallOptions = {}): Promise<ProcessedDocumentBundle> {
   if (!filePath) {
     throw new Error("Missing required argument: filePath");
   }
@@ -366,7 +489,7 @@ export async function processDocumentForRag({
   // Ensure the file path is absolute or correctly relative for the Python script
   const absoluteFilePath = path.resolve(filePath);
   // Pass arguments as an object matching Python function signature
-  const result = await callPythonFunction('process_document', { file_path_str: absoluteFilePath, output_format: outputFormat });
+  const result = await callPythonFunction('process_document', { file_path_str: absoluteFilePath, output_format: outputFormat }, options);
 
   // Check if the Python script returned an error structure
   if (result && result.error) {
@@ -389,7 +512,7 @@ export async function downloadBookToFile({
     outputDir = './downloads',
     process_for_rag = false,
     processed_output_format = 'txt'
-}: DownloadBookToFileArgs): Promise<DownloadBookResult> {
+}: DownloadBookToFileArgs, options: CallOptions = {}): Promise<DownloadBookResult> {
   try {
     // Call the Python function, passing the bookDetails object
     const result = await callPythonFunction('download_book', {
@@ -399,7 +522,7 @@ export async function downloadBookToFile({
         output_dir: outputDir,
         process_for_rag: process_for_rag,
         processed_output_format: processed_output_format
-    });
+    }, options);
 
     // Check if the Python script returned an error structure
     if (result && result.error) {
@@ -485,11 +608,11 @@ function filterMetadataResponse(fullMetadata: any, include?: string[]): any {
   return result;
 }
 
-export async function getBookMetadata(bookId: string, bookHash: string, include?: string[]): Promise<any> {
+export async function getBookMetadata(bookId: string, bookHash: string, include?: string[], options: CallOptions = {}): Promise<any> {
   const fullMetadata = await callPythonFunction('get_book_metadata_complete', {
     book_id: bookId,
     book_hash: bookHash
-  });
+  }, options);
   return filterMetadataResponse(fullMetadata, include);
 }
 
@@ -500,7 +623,7 @@ export async function searchByTerm(args: {
   languages?: string[];
   extensions?: string[];
   limit?: number;
-}): Promise<any> {
+}, options: CallOptions = {}): Promise<any> {
   return callPythonFunction('search_by_term_bridge', {
     term: args.term,
     year_from: args.yearFrom,
@@ -508,7 +631,7 @@ export async function searchByTerm(args: {
     languages: args.languages,
     extensions: args.extensions,
     limit: args.limit || 25
-  });
+  }, options);
 }
 
 export async function searchByAuthor(args: {
@@ -519,7 +642,7 @@ export async function searchByAuthor(args: {
   languages?: string[];
   extensions?: string[];
   limit?: number;
-}): Promise<any> {
+}, options: CallOptions = {}): Promise<any> {
   return callPythonFunction('search_by_author_bridge', {
     author: args.author,
     exact: args.exact || false,
@@ -528,7 +651,7 @@ export async function searchByAuthor(args: {
     languages: args.languages,
     extensions: args.extensions,
     limit: args.limit || 25
-  });
+  }, options);
 }
 
 export async function fetchBooklist(args: {
@@ -536,13 +659,13 @@ export async function fetchBooklist(args: {
   booklistHash: string;
   topic: string;
   page?: number;
-}): Promise<any> {
+}, options: CallOptions = {}): Promise<any> {
   return callPythonFunction('fetch_booklist_bridge', {
     booklist_id: args.booklistId,
     booklist_hash: args.booklistHash,
     topic: args.topic,
     page: args.page || 1
-  });
+  }, options);
 }
 
 export async function searchAdvanced(args: {
@@ -551,26 +674,41 @@ export async function searchAdvanced(args: {
   yearFrom?: number;
   yearTo?: number;
   count?: number;
-}): Promise<any> {
+}, options: CallOptions = {}): Promise<any> {
   return callPythonFunction('search_advanced', {
     query: args.query,
     exact: args.exact || false,
     from_year: args.yearFrom,
     to_year: args.yearTo,
     count: args.count || 10
-  });
+  }, options);
 }
 
-export async function searchMultiSource(args: {
-  query: string;
-  source?: 'auto' | 'annas' | 'libgen';
-  count?: number;
-}): Promise<any> {
-  return callPythonFunction('search_multi_source', {
-    query: args.query,
-    source: args.source || 'auto',
-    count: args.count || 10
-  });
+/**
+ * Search Anna's Archive / LibGen through the multi-source router.
+ *
+ * @param args - Query, source selection, and result count
+ * @param options - Timeout and abort signal. Passing the MCP request's signal
+ *   is what makes a client-side cancellation actually kill the subprocess
+ *   instead of leaving it running against an unreachable provider.
+ */
+export async function searchMultiSource(
+  args: {
+    query: string;
+    source?: 'auto' | 'annas' | 'libgen';
+    count?: number;
+  },
+  options: CallOptions = {},
+): Promise<any> {
+  return callPythonFunction(
+    'search_multi_source',
+    {
+      query: args.query,
+      source: args.source || 'auto',
+      count: args.count || 10,
+    },
+    options,
+  );
 }
 
 // Removed unused downloadFile helper function

--- a/src/lib/zlibrary-api.ts
+++ b/src/lib/zlibrary-api.ts
@@ -10,6 +10,11 @@ import { CircuitBreaker } from './circuit-breaker.js';
 import { ZLibraryError, PythonBridgeError } from './errors.js';
 import { logger } from './logger.js';
 import { runPythonBridge, LONG_BRIDGE_TIMEOUT_MS } from './python-runner.js';
+import {
+  isBridgeDetailRetryable,
+  isConfigurationBridgeDetail,
+  parseBridgeErrorEnvelope,
+} from './python-bridge.js';
 
 // Recreate __dirname for ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -32,64 +37,10 @@ const pythonBridgeCircuitBreaker = new CircuitBreaker({
   // bridge's health. Counting cancellations would mean five aborted searches
   // open the breaker and fail every unrelated tool for the timeout window —
   // turning a user's own impatience into an outage.
-  isFailure: (error) => error?.context?.reason !== 'aborted',
+  isFailure: (error) =>
+    error?.context?.reason !== 'aborted' &&
+    !isConfigurationBridgeDetail(error?.context?.details),
 });
-
-/** Reason codes meaning the provider's host never answered at all. */
-const UNREACHABLE_REASONS = new Set([
-  'dns_failure',
-  'dns_timeout',
-  'connect_timeout',
-  'connect_refused',
-  'connect_error',
-  'tls_error',
-]);
-
-interface BridgeErrorEnvelope {
-  error: string;
-  type?: string;
-  details?: any;
-}
-
-/**
- * Parse the JSON error envelope python_bridge.py writes to stderr.
- *
- * The bridge may also emit log lines on stderr, so the envelope is found by
- * scanning lines from the end rather than assuming it is the whole stream.
- *
- * @param stderr - Raw stderr text from the subprocess
- * @returns The envelope, or null if stderr holds no parseable one
- */
-function parseBridgeError(stderr: unknown): BridgeErrorEnvelope | null {
-  if (typeof stderr !== 'string' || stderr.length === 0) return null;
-  const lines = stderr.split('\n');
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    const line = (lines[i] ?? '').trim();
-    if (!line.startsWith('{')) continue;
-    try {
-      const parsed = JSON.parse(line);
-      if (parsed && typeof parsed.error === 'string') return parsed;
-    } catch {
-      // Not the envelope; keep scanning.
-    }
-  }
-  return null;
-}
-
-/**
- * Whether a bridge error's details describe a host that never answered.
- *
- * @param details - The `details` field of a bridge error envelope
- * @returns true if every reported failure is a reachability failure
- */
-function isUnreachableDetail(details: any): boolean {
-  if (!details || typeof details !== 'object') return false;
-  if (typeof details.reason === 'string') return UNREACHABLE_REASONS.has(details.reason);
-  if (Array.isArray(details.failures) && details.failures.length > 0) {
-    return details.failures.every((f: any) => UNREACHABLE_REASONS.has(f?.reason));
-  }
-  return false;
-}
 
 /**
  * Bridge functions whose work is bounded by file size and CPU, not by a
@@ -233,7 +184,7 @@ async function callPythonFunction(
           // connect_timeout vs http_error); lead with that instead of a
           // traceback, so the caller can tell "this domain is gone" from
           // "this mirror is dropping packets".
-          const bridgeError = parseBridgeError(err.stderr);
+          const bridgeError = parseBridgeErrorEnvelope(err.stderr);
           const stderrOutput = err.stderr ? ` Stderr: ${err.stderr}` : '';
 
           if (bridgeError) {
@@ -250,7 +201,7 @@ async function callPythonFunction(
               // A provider that is not reachable at all will not become
               // reachable inside the retry window; retrying just re-pays the
               // probe. Response-level failures may be transient.
-              !isUnreachableDetail(bridgeError.details)
+              isBridgeDetailRetryable(bridgeError.details)
             );
           }
 
@@ -558,8 +509,20 @@ export async function downloadBookToFile({
     return result as DownloadBookResult;
 
   } catch (error: any) {
-    // Re-throw errors from callPythonFunction or validation checks
-    throw new Error(`Failed to download book: ${error.message || 'Unknown error'}`, { cause: error });
+    // Keep the normalized bridge context on the public error itself. A generic
+    // Error with details hidden under cause made every direct consumer invent
+    // its own traversal rule and dropped structuredContent at the handler.
+    if (error instanceof ZLibraryError) {
+      throw new PythonBridgeError(
+        `Failed to download book: ${error.message || 'Unknown error'}`,
+        error.context,
+        error.retryable,
+      );
+    }
+    throw new Error(
+      `Failed to download book: ${error.message || 'Unknown error'}`,
+      { cause: error },
+    );
   }
 }
 

--- a/src/lib/zlibrary-api.ts
+++ b/src/lib/zlibrary-api.ts
@@ -12,7 +12,7 @@ import { logger } from './logger.js';
 import { runPythonBridge, LONG_BRIDGE_TIMEOUT_MS } from './python-runner.js';
 import {
   isBridgeDetailRetryable,
-  isConfigurationBridgeDetail,
+  isPermanentBridgeDetail,
   parseBridgeErrorEnvelope,
 } from './python-bridge.js';
 
@@ -39,7 +39,7 @@ const pythonBridgeCircuitBreaker = new CircuitBreaker({
   // turning a user's own impatience into an outage.
   isFailure: (error) =>
     error?.context?.reason !== 'aborted' &&
-    !isConfigurationBridgeDetail(error?.context?.details),
+    !isPermanentBridgeDetail(error?.context?.details),
 });
 
 /**


### PR DESCRIPTION
## Summary

Nothing in the multi-source path can run unbounded, and an aborted or completed bridge call cannot leave its Python or OCR process tree behind on the POSIX lifecycle path covered by this PR. Windows retains a documented best-effort termination path pending #116.

- bound DNS, TCP, HTTP phases, complete provider operations, and full source-file transfers with finite configurable deadlines
- put Anna's requests and LibGen search, mirror resolution, byte probes, and downloads under real wall-clock budgets
- preserve stable `operation`, `provider`, `host`, `reason`, and child-failure details through Python envelopes, both Node bridge APIs, handlers, and MCP `structuredContent`
- kill the complete POSIX bridge process tree on abort, timeout, parent exit with surviving descendants, and shutdown
- route source downloads before unrelated Z-Library authentication so credential-free LibGen acquisition remains supported
- distinguish explicit-source failure from caller-requested `auto` fallback, and surface partial provider failure instead of a misleading empty result
- classify permanent Anna configuration errors without consuming retry or circuit-breaker health budgets
- separate the finite source-transfer budget from provider resolution and keep the composed long-operation budget large enough for optional OCR

## Review follow-up

All five findings from the review of `c5a1bd0` were technically valid and are addressed in `ff93d25`:

1. Download failures keep normalized provider details directly on the public bridge error rather than hiding them under `cause`.
2. LibGen retains typed per-mirror failures and raises an aggregate structured error.
3. TCP probes reuse daemon-resolved numeric addresses, while the actual httpx/AnyIO path uses the same bounded resolver contract.
4. Process ownership is keyed to the process group and remains registered until every executable member is gone.
5. Missing Anna credentials are typed configuration errors excluded from retries and circuit-breaker failure accounting.

A third-round class audit found related consumers outside the reported lines. The correction therefore also removes the unbounded synchronous Python-version check, routes LibGen before Z-Library authentication, applies the error envelope to both exported Node bridge wrappers, bounds and classifies the full redirected source transfer, preserves the failing CDN host after redirects, and handles both timeout-parent and successful-parent descendant survival. The design and stop conditions are recorded in `docs/specifications/ISSUE_106_LIFECYCLE_ERROR_ENVELOPE_DESIGN.md`.

The completed local correction received an independent read-only closure audit after the full test matrix. No P0-P2 finding remained at that audited head.

The final Codex pass on `ff93d25` found three additional valid budget/retry parity issues. Commit `aab84d4` gives full transfers a finite 1,500-second budget distinct from 45-second provider resolution, raises the default outer long-operation budget to 2,400 seconds using the documented `165 + 1500 + 600 + 135` composition, honors normalized structured retry verdicts without changing generic legacy Python-error behavior, and applies the shared long budget in the secondary bridge wrapper.

The subsequent review of `e4ea8f3` found seven valid lifecycle, bounded-probe, and error-envelope gaps. Commit `5c866e7` closes them as one audited consequence set: cooperative POSIX signal cleanup, shared server shutdown ownership, DNS marker precedence, streamed LibGen inspection, permanent rejected-key and quota handling, and canonical Anna transfer attribution.

## Current review status

The review of `e4ea8f3` opened seven valid #106 findings. Commit `5c866e7` addresses all seven: cooperative POSIX cancellation and partial-artifact cleanup; shared shutdown TERM/grace/KILL ownership with shutdown-time rejection and second-signal acceleration; DNS timeout-marker precedence; bounded streaming for Range-ignoring LibGen probes; permanent rejected Anna credentials; typed Anna quota envelopes with retry/breaker exclusion; and canonical Anna transfer-provider attribution.

Each finding has one parseable fenced verdict naming `5c866e7`, and all 28 review threads are resolved. Native Windows Job Object ownership remains deliberately deferred to unslotted issue #116 with the documented best-effort `taskkill /T /F` boundary unchanged.

The exact committed-tree matrix is green. A final `@codex review` confirmation is requested below; this PR remains unmerged and auto-merge remains disabled.

## Behavior changes

1. An explicit `source` is no longer silently rerouted. Fallback remains the contract of `source="auto"`.
2. An empty result means all attempted providers answered and none matched. Any partial provider failure is surfaced with structured details.
3. Provider and bridge timeout values reject malformed or non-finite overrides instead of accidentally removing the deadline.
4. LibGen downloads do not require or initialize Z-Library credentials.
5. A source transfer reports the host that actually failed after redirects and removes any partial artifact.
6. A valid large source transfer can exceed the short resolution deadline while remaining bounded; the default outer budget includes worst-case LibGen resolution, transfer, OCR, and finalization headroom.

## Why

`search_multi_source` and source downloads could outlive their advertised provider budgets and leave one-shot bridge work behind. The causes crossed both layers: phase-only HTTP timeouts, joined DNS resolution, direct-child lifecycle tracking, eager unrelated authentication, and independently reconstructed error shapes. The provider/host/reason vocabulary introduced here is also the contract required by #101 and #107.

Resolves ISSUE-NET-001 and ISSUE-API-003 in `ISSUES.md`.

## Verification

The live PR base remained `1fad14f`, matching `origin/master`, so no additional rebase or history rewrite was required. The complete required matrix then ran on committed tip `5c866e7`.

Because Jest deliberately ignores `/.claude/worktrees/`, its exact command ran from an immutable `/tmp` export of the same commit. Real child-process tests ran with process execution enabled rather than weakening discovery rules.

- `npm run build` — passed (15/15 bridge/build files)
- `node --experimental-vm-modules node_modules/jest/bin/jest.js` — 260 passed, 13 suites; 87.14% statements and 88.54% lines
- `uv run pytest -m "not slow and not integration and not performance" --benchmark-disable -rs` — 1,173 passed, 3 skipped, 184 deselected, 7 xfailed
- `npx eslint src/` — passed
- `npx prettier --check src/` — passed

The three Python skips are the repository's Tesseract-dependent OCR cases in this environment. The immutable Jest snapshot contains only this committed tree; no sibling-worktree tests were discoverable.

## Deliberately unverified

- The retained Windows `taskkill /T /F` fallback was not exercised on a Windows host. Native hard ownership and Windows-host corroboration are tracked in #116.
- No live provider authentication or upstream file transfer was exercised. Unit tests mock third-party services by repository policy; live drift remains covered by `npm run doctor` and the upstream workflow.
- No merge or auto-merge is requested by this PR.
