### PR TITLE
docs(adr): decide Z-Library source adapter architecture

### DIFF
--- a/docs/adr/ADR-005-EAPI-Migration.md
+++ b/docs/adr/ADR-005-EAPI-Migration.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-02-01
 
-**Status:** Accepted
+**Status:** Accepted — decision 4 (downloads) superseded by ADR-011
 
 ## Context
 
@@ -17,7 +17,7 @@ Migrate all API calls from HTML scraping to EAPI JSON endpoints:
 1. **Search operations**: Use `/eapi/book/search` instead of HTML search pages
 2. **Book metadata**: Use `/eapi/book/{id}/{hash}` instead of scraping book detail pages
 3. **Recent books**: Use EAPI recent endpoint instead of HTML browse pages
-4. **Downloads**: Keep legacy AsyncZlib client for file downloads (EAPI returns download URL, but actual file download requires cookies from the legacy client)
+4. ~~**Downloads**: Keep legacy AsyncZlib client for file downloads (EAPI returns download URL, but actual file download requires cookies from the legacy client)~~ — **superseded by ADR-011.** The implementation diverged from this clause: `EAPIClient` grew its own `download_file` and the live Z-Library transfer runs through it. ADR-011 records that as the decision it had become.
 
 Implement an `EAPIClient` class in the vendored zlibrary fork (`zlibrary/eapi.py`) that:
 - Uses httpx with lazy initialization and cookie-based auth
@@ -36,8 +36,8 @@ Implement an `EAPIClient` class in the vendored zlibrary fork (`zlibrary/eapi.py
 - **Booklists gracefully degrade**: EAPI has no booklist endpoint; tools return empty/search fallback
 - **Full-text search limited**: No dedicated full-text search mode in EAPI; routes through regular search
 - **Terms/IPFS CIDs unavailable**: EAPI does not expose these fields; return empty defaults
-- **Downloads still use legacy client**: EAPI returns URL but file download needs AsyncZlib with session cookies
+- ~~**Downloads still use legacy client**: EAPI returns URL but file download needs AsyncZlib with session cookies~~ — no longer holds; see ADR-011.
 
 ### Neutral
-- **Dual client architecture**: EAPIClient for queries, AsyncZlib for downloads (acceptable complexity)
+- ~~**Dual client architecture**: EAPIClient for queries, AsyncZlib for downloads (acceptable complexity)~~ — the split closed; see ADR-011.
 - **EAPI client initialized in main()**: Avoids import side effects, requires passing client to tool functions

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -336,6 +336,24 @@ at its compatibility façade. That is a property of the legacy tool contract,
 not a default inside the generic router.
 
 `source="auto"` has an explicit migration path. A new optional
+**A three-source order does not fit the current timeout budget, and the order
+cannot ship before that is resolved.** `lib/sources/config.py` documents the
+arithmetic: one provider attempt costs at worst `2 x preflight + total` = 55s,
+LibGen walks three mirrors, and today's worst case is 4 attempts = 220s against
+a 240-second `PYTHON_BRIDGE_TIMEOUT` — a 20-second margin. An order of
+`[zlibrary, annas_archive, libgen]` is **five** attempts = 275s, so Node would
+kill a legitimate walk 35 seconds before the router returned its structured
+result, and the operator would see a subprocess timeout instead of the
+attributed failures the whole error taxonomy exists to produce.
+
+This is a precondition, not a follow-up. Before three-source orders become
+valid, the migration must either share one total budget across the ordered walk
+rather than granting each provider its own, or raise `PYTHON_BRIDGE_TIMEOUT`
+with the margin recomputed and written down where the existing arithmetic
+lives. A full-order timeout test covering the longest permitted order lands in
+the same stage; without it the regression is invisible until a slow walk in
+production.
+
 `BOOK_SOURCE_ORDER` is a validated, non-empty ordered list of canonical
 `SourceType` values (`annas_archive`, `libgen`, or `zlibrary`) and controls
 `auto` only when set. Selector aliases are normalised before validation:
@@ -355,9 +373,21 @@ the key they do not have.
 
 The migration therefore preserves `auto` exactly as it behaves now:
 
-- **Unset or `auto`, no key** → `[libgen]`.
-- **Unset or `auto`, key present** → `[annas_archive, libgen]` when fallback is
-  enabled, `[annas_archive]` when it is not.
+**Search and acquisition already differ, and the migration must keep them
+differing.** `_search_candidates` appends every other provider for `auto`
+regardless of credentials, because Anna's **key-free search** works;
+`_download_candidates` appends Anna's only when a key is present, because
+Anna's supported acquisition needs one. Flattening the two into a single order
+would silently drop key-free Anna's results for every operator without a key.
+
+- **Search, unset or `auto`, no key** → `[libgen, annas_archive]` when fallback
+  is enabled, `[libgen]` when it is not.
+- **Search, unset or `auto`, key present** → `[annas_archive, libgen]` when
+  fallback is enabled, `[annas_archive]` when it is not.
+- **Acquisition, unset or `auto`, no key** → `[libgen]`. Anna's is not appended:
+  its key-free search cannot be followed by a supported key-free download.
+- **Acquisition, unset or `auto`, key present** → `[annas_archive, libgen]` when
+  fallback is enabled, `[annas_archive]` when it is not.
 - **`BOOK_SOURCE_DEFAULT` set to anything** → *ignored for ordering*, exactly as
   today, and logged once at startup as inert with a pointer to
   `BOOK_SOURCE_ORDER`. Silence would leave an operator believing a setting
@@ -427,9 +457,52 @@ depend on, and has done so while believing it preserved #106.
   `invalid_book_ref`, `not_found`, `dependency_unavailable`, `aborted`, and
   `partial_failure`.
 
+**Every added reason ships with its retry and breaker classification in the
+same change, and a test for it.** A reason code is not a label; it is an input
+to `src/lib/python-bridge.ts::isBridgeDetailRetryable` and, through
+`isPermanentBridgeDetail`, to the global circuit breaker in
+`zlibrary-api.ts`. A code Node has never heard of is retryable by default and
+counts as a bridge failure — so **five ordinary searches by an operator with no
+Z-Library credentials would open the breaker and start rejecting
+credential-free LibGen operations.** A source that was never configured would
+take down the source that needs no configuration, which is the specific outcome
+#129 already fixed once by another route.
+
+Classification for the added set:
+
+| Reason | Retryable | Counts toward the breaker |
+|---|---|---|
+| `credentials_missing` | no — permanent caller state | no |
+| `authentication_failed` | no — permanent caller state | no |
+| `unsupported_operation` | no — permanent caller state | no |
+| `invalid_book_ref` | no — permanent caller state | no |
+| `dependency_unavailable` | no — permanent caller state | no |
+| `not_found` | no — the provider answered correctly | no |
+| `aborted` | no — the caller's own choice, per #106 | no |
+| `partial_failure` | inherits from its children | inherits |
+
+**Aggregate classification must be child-aware.** `everyFailureHasReason`
+returns on a top-level `reason` when one is present and never inspects
+`failures`. `AllSourcesFailedError.to_dict()` emits no top-level `reason`
+today, which is why the current classifier works — so if `all_sources_failed`
+is introduced as a top-level reason, it must be excluded from that short
+circuit and the children consulted, or every aggregate becomes retryable
+regardless of what it contains. Tests must cover retry behaviour *and* breaker
+state for a Z-Library-without-credentials failure alongside a healthy LibGen
+call, because the failure this prevents is cross-source.
+
 Aggregates also use `all_sources_failed` when every attempted capable source
 failed. The aggregate keeps each child reason in order; it never copies one
 child reason to the top level or uses `partial_failure` when nothing answered.
+
+**The wire value for acquisition failures stays `download`.**
+`python_bridge.py` constructs aggregates with `operation="download"`, and both
+`__tests__/python/test_python_bridge.py` and
+`__tests__/zlibrary-api-extended.test.js` enforce that shape. `acquire` is the
+internal adapter method name; renaming the discriminator to match it would
+break clients branching on `operation` during a migration that is otherwise
+additive. If the wire value is ever to change, that is its own decision with
+its own alias interval, and this ADR does not make it.
 
 An aggregate error retains each source failure in attempted order. A complete
 empty search result means every attempted capable source answered and none

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -268,9 +268,12 @@ result from another source. Cross-source availability hints remain hints under
 deduplication or matching remains #52.
 
 `get_book_metadata` should likewise migrate from raw `bookId`/`bookHash`
-parameters to the selected `bookDetails` result. The old parameters may be
-accepted during deprecation, but they must be converted at the façade and must
-not create a generic direct-ID route.
+parameters to the selected `bookDetails` result. The old parameters **must
+remain accepted** for the deprecation interval — `src/index.ts` currently
+*requires* them, so "may" would let Stage 5 replace them with `bookDetails`
+immediately and fail existing clients at schema validation, inside a migration
+this ADR calls additive. They must be converted at the façade and must not
+create a generic direct-ID route.
 
 ### 3. Capability protocols, not fake universal methods
 
@@ -357,11 +360,21 @@ state the precondition it cannot ship without.
 cannot ship before that is resolved.** `lib/sources/config.py` documents the
 arithmetic: one provider attempt costs at worst `2 x preflight + total` = 55s,
 LibGen walks three mirrors, and today's worst case is 4 attempts = 220s against
-a 240-second `PYTHON_BRIDGE_TIMEOUT` — a 20-second margin. An order of
-`[zlibrary, annas_archive, libgen]` is **five** attempts = 275s, so Node would
-kill a legitimate walk 35 seconds before the router returned its structured
-result, and the operator would see a subprocess timeout instead of the
-attributed failures the whole error taxonomy exists to produce.
+a 240-second `PYTHON_BRIDGE_TIMEOUT` — a 20-second margin.
+
+**LibGen does not always walk three mirrors.** `_mirror_candidates()` returns
+`[configured] + [m for m in ("li", "vg", "la") if m != configured]`, so a
+supported custom `LIBGEN_MIRROR` such as `rs` yields **four**. An order of
+`[zlibrary, annas_archive, libgen]` is therefore up to **six** attempts = 330s,
+not five — Node kills a legitimate walk 90 seconds before the router returns
+its structured result, and the operator sees a subprocess timeout instead of
+the attributed failures the whole error taxonomy exists to produce.
+
+The bound must be computed from the registry and the *configuration*, not from
+a constant: every source in the order, times that source's own worst-case
+attempt count, where LibGen's depends on whether `LIBGEN_MIRROR` names one of
+the fallbacks. Any arithmetic here that hardcodes three mirrors is wrong for a
+configuration this project supports.
 
 This is a precondition, not a follow-up. Before three-source orders become
 valid, the migration must either share one total budget across the ordered walk
@@ -370,6 +383,21 @@ with the margin recomputed and written down where the existing arithmetic
 lives. A full-order timeout test covering the longest permitted order lands in
 the same stage; without it the regression is invisible until a slow walk in
 production.
+
+**`BOOK_SOURCE_ORDER` is comma-separated, case-insensitive, whitespace-
+tolerant.** It is an environment variable, so it reaches Python as a string,
+and the abstract `[zlibrary, annas_archive, libgen]` notation used in this
+document is not an encoding — leaving it unstated lets one implementation
+accept JSON and another accept commas while both satisfy the ADR, so an
+operator's working configuration breaks on upgrade. Canonical form:
+
+```bash
+BOOK_SOURCE_ORDER=zlibrary,annas_archive,libgen
+```
+
+Empty entries are an error rather than being skipped, because a trailing comma
+should be diagnosed rather than silently tolerated into a different order than
+the operator wrote.
 
 **The order is a set, not a bag.** Validation rejects a repeated source:
 `[libgen, libgen, libgen, libgen, libgen]` would otherwise be valid, and since
@@ -435,14 +463,21 @@ chosen and it names its own source.
   `BOOK_SOURCE_ORDER`. Silence would leave an operator believing a setting
   works; honouring it would change routing under their feet.
 
-Legacy fallback is one-way **for acquisition only**: with a key, Anna's is
-primary and LibGen is appended; without one, acquisition is `[libgen]` and
-Anna's is not appended, because its key-free search cannot be followed by a
-supported key-free download. **Search is not one-way** — the orders above give
-an operator without an Anna's key `[libgen, annas_archive]`, matching
-`_search_candidates` today, and removing that would drop key-free Anna's
-results for every operator without a key. Stating the restriction without its
-scope is what made this paragraph contradict the orders three lines above it. `BOOK_SOURCE_ORDER` is the single opt-in way to choose an order, and
+**Search is not one-way** — the orders above give an operator without an
+Anna's key `[libgen, annas_archive]`, matching `_search_candidates` today, and
+removing that would drop key-free Anna's results for every operator without a
+key.
+
+**Acquisition has no cross-source fallback at all**, one-way or otherwise. A
+selected result names its source and carries only that source's `source_ref`,
+so an exhausted Anna's quota returns the attributed failure rather than
+appending LibGen — appending it would mean handing Anna's `source_ref` to an
+adapter that cannot resolve it. The earlier "one-way" wording described legacy
+behaviour that the source-binding rule above replaces, and keeping it left two
+contracts an implementation could not satisfy at once. A caller who wants
+another source retries the *search*.
+
+`BOOK_SOURCE_ORDER` is the single opt-in way to choose a search order, and
 adopting it is what makes a previously inert preference take effect. Z-Library is not added to
 the derived legacy order merely by registration; its named compatibility tools
 remain explicit. Invalid legacy or new order values fail configuration
@@ -529,6 +564,24 @@ Classification for the added set:
 | `not_found` | no — the provider answered correctly | no |
 | `aborted` | no — the caller's own choice, per #106 | no |
 | `partial_failure` | inherits from its children | inherits |
+
+**The circuit breaker must be scoped per source, and that is a precondition of
+this migration rather than a nicety.** `src/lib/zlibrary-api.ts` runs **one**
+breaker for every bridge operation, and its `isFailure` excludes only permanent
+reasons. The table above makes the *caller-state* reasons permanent, which was
+necessary and is not sufficient: `dns_failure`, `connect_timeout`,
+`http_error` and the rest are transient by design and therefore still count. So
+five Z-Library failures from a genuinely unreachable host open the shared
+breaker and reject subsequent **credential-free LibGen** requests, which is the
+same cross-source outage the reason table was written to prevent, arriving
+through the other door.
+
+Routing more sources through one bridge makes this strictly worse: today only
+Z-Library and the two multi-source adapters share it; after this migration
+every source does. The migration therefore keys breaker state by source — a
+Z-Library outage opens the Z-Library breaker and nothing else — and the tests
+cover breaker state across sources, since a single-source test cannot see this
+failure at all.
 
 **Aggregate classification must be child-aware.** `everyFailureHasReason`
 returns on a top-level `reason` when one is present and never inspects

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -29,22 +29,22 @@ must enter through `SourceRouter`. No direct-from-ID download path is added.
 
 ## Decision state and tracker reconciliation
 
-The live tracker is authoritative for release placement:
+**This ADR records no release placement.** `AGENTS.md` requires priorities to be
+read from GitHub milestones rather than from any document in this repo, and a
+document that names one becomes a second, slower copy of the release plan — the
+exact drift the milestone scheme exists to prevent, and which this repo has
+already suffered once. Read #40's milestone from the tracker:
 
-- As observed on 2026-08-12, #40 is open in the live `v1.5 — Anna's Archive
-  is a real source` milestone.
-- The closed v1.4 map, #75, explicitly moved #40 out of v1.4 and called it
-  v1.5 work.
-- #109's current milestone description records the release-record repair: the
-  old roadmap-derived v1.4 milestone became `Source layer as a first-class
-  citizen (unslotted)`, while #40 moved to v1.5.
-- #95 still calls this work a successor leg named “v1.6.” That sentence is
-  historical narrative, not the release index. It does not override the live
-  milestone or the decision owner's instruction that #40 is current open
-  work.
+```bash
+gh issue view 40 --json milestone
+```
 
-This ADR therefore treats #40 as v1.5 work. It does not create or preserve a
-v1.6 promise.
+One reconciliation is worth recording, because it is a contradiction a reader
+will hit and cannot resolve from the tracker alone: **#95's prose calls this
+work a successor leg named "v1.6."** That sentence is historical narrative, not
+the release index, and it does not override #40's live milestone. It is noted
+here so the next reader stops at "the document is stale" rather than concluding
+the tracker is wrong — not to assert what the placement is.
 
 ## Context
 
@@ -64,12 +64,14 @@ The source abstraction is only partial on current `master`.
 - `lib/python_bridge.py::download_book` contains the architectural fork: an
   Anna's/LibGen result goes through `_fetch_from_source`, while a Z-Library
   result goes directly through `EAPIClient.download_file`.
-- `lib/python_bridge.py::main` eagerly calls `initialize_eapi_client` for every
-  operation except document processing and multi-source search. Consequently,
-  credential-free LibGen search works today, but `download_book` fails before
-  `_fetch_from_source` can run. The migration must make EAPI initialisation
-  operation- and source-specific before it can claim credential-free LibGen
-  acquisition as a working baseline.
+- `lib/python_bridge.py::main` gates EAPI initialisation on
+  `_requires_eapi_client`, which already exempts document processing,
+  multi-source search, **and** a `download_book` whose result came from a
+  multi-source search (#129). Credential-free LibGen search *and* acquisition
+  therefore both work today. This is existing behaviour the migration must
+  preserve, not a failure it must fix: the eager-initialisation defect this
+  section originally described was fixed before this ADR's rebase parent, and
+  Stage 0 records the working path as a baseline accordingly.
 - `lib/term_tools.py`, `lib/author_tools.py`, `lib/booklist_tools.py`, and
   `lib/enhanced_metadata.py` each know how to create and authenticate an EAPI
   client when a shared client is not supplied. Their public shapes are richer
@@ -499,9 +501,12 @@ until parity is demonstrated.
 
 ### Stage 2: add `ZLibraryAdapter` behind a dispatch gate
 
-- Make bridge EAPI initialisation lazy and source-specific: a LibGen result
-  reaches router acquisition without Z-Library credentials, while legacy
-  Z-Library operations still initialise the shared client when selected.
+- Preserve the source-conditional EAPI initialisation that already exists
+  (`_requires_eapi_client`): a LibGen result must keep reaching router
+  acquisition without Z-Library credentials, while legacy Z-Library operations
+  still initialise the shared client when selected. Routing Z-Library through
+  an adapter changes what `_requires_eapi_client` has to answer for, so this is
+  a regression to guard against, not a behaviour to introduce.
 - Remove raw bridge-payload, copied-argument, query-text, and secret-bearing URL
   logging before routing production traffic through adapters; retain only the
   bounded structured fields in the observability plan.
@@ -715,8 +720,8 @@ source-specific conditional to the common path.
 - ADR-005, EAPI migration
 - ADR-010, current `McpServer.tool()` registration surface
 - #40, Z-Library adapter work
-- #75, shipped v1.4 map and deferral of #40
-- #95, current v1.5 map
+- #75, the shipped map that deferred #40
+- #95, Anna's Archive map issue
 - #96, source/route reporting decision
 - #101 and #107, implementation of the #96 reporting contract
 - #103, optional dependency packaging and registration sequencing

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -650,9 +650,13 @@ tool nor treats passive failure reporting as a decided replacement.
 - PR #106 was not merged when this ADR was written; conflict resolution may
   change exact class or function names. The semantic dependencies above remain
   required and must be rechecked against its merged form.
-- #103 is now slotted in v1.5 because its sequencing constraint is binding.
-  #40 must still stop before changing TypeScript registration until #103 lands;
-  milestone membership records the dependency but does not make unfinished
+- #40 is recorded in the tracker as blocked by #103, using GitHub's native issue
+  dependency. That relation is where the sequencing is enforced and read. This
+  ADR deliberately does not name #103's milestone: AGENTS.md requires priorities
+  to be read from milestones rather than from any document in this repo, and an
+  earlier revision of this line asserted a slot that moved underneath it within
+  days. #40 must still stop before changing TypeScript registration until #103
+  lands; the dependency records that ordering without making unfinished
   registration work safe to build against.
 - The EAPI is undocumented. Adapter parity under fake-client tests does not
   predict endpoint drift, domain rotation, authentication throttling, or live

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -228,10 +228,20 @@ Examples are `{id, hash}` for Z-Library and `{md5}` for Anna's Archive or
 LibGen. The router checks only that `book.source` selects the same adapter that
 will consume `book.source_ref`; it must not inspect identifier keys.
 
-For a compatibility interval, existing top-level `id`, `hash`, `book_hash`,
-and `md5` fields may remain in tool responses. New routing and acquisition code
-uses `source_ref`. Tests must prove that removing a compatibility field does
-not change adapter dispatch.
+For the compatibility interval, existing top-level `id`, `hash`, `book_hash`,
+and `md5` fields **must remain** in tool responses — "may" would license
+removing them immediately, inside a migration this ADR declares additive and
+whose rollback contract depends on those fields staying readable. Clients that
+consume search responses, or pass one back as a legacy `bookDetails`, break the
+moment a field disappears, and they break before the deprecation interval they
+were promised has run.
+
+New routing and acquisition code uses `source_ref`. Tests must prove two
+things, not one: that removing a compatibility field does not change adapter
+dispatch (routing does not secretly depend on them), and that the fields are
+still **present** in responses (clients still get what they were promised).
+The first without the second is how a field gets dropped while the suite stays
+green.
 
 The compatibility facade normalises a full pre-migration Z-Library
 `bookDetails` search result before router validation: it adds
@@ -270,7 +280,10 @@ unavailable. A separate per-operation availability check reports whether the
 current user can invoke a supported operation and, when not, the stable reason
 such as `credentials_missing` or `quota_exhausted`. Optional protocols cover:
 
-- general, full-text, author, term, and advanced search modes;
+- full-text, author, term, and advanced search modes (**not** general search,
+  which the base contract above makes mandatory for every adapter — listing it
+  as optional let one implementation reject registration of a source without it
+  while another registered the source and returned `unsupported_operation`);
 - metadata lookup from a search result;
 - per-user download limits;
 - account history;
@@ -406,15 +419,17 @@ cross-source lookup this ADR explicitly defers. So the orders above govern
 earlier in this document requires.
 
 The ordered walk still matters for acquisition, but *within* the named
-provider: LibGen's mirrors, and Anna's partner servers. Cross-provider
-acquisition fallback is only reachable when the caller asked for `auto` and no
-result has been selected yet, and even then it is bounded by the timeout
-arithmetic below:
+provider: LibGen's mirrors, and Anna's partner servers.
 
-- **`auto` acquisition, no key** → `[libgen]`. Anna's is not appended: its
-  key-free search cannot be followed by a supported key-free download.
-- **`auto` acquisition, key present** → `[annas_archive, libgen]` when fallback
-  is enabled, `[annas_archive]` when it is not.
+**There is no result-less acquisition route, and this ADR does not create
+one.** `download_book_to_file` requires full `bookDetails`, and the adapter
+contract is `acquire(book, output_dir)` — so a request with no selected result
+has no `source` and no `source_ref` for any adapter to consume. Reaching a
+cross-provider `auto` order from there would mean inventing the direct lookup
+ADR-003 rejected or the cross-source matching this ADR defers. Fallback belongs
+to **search and result selection**, where a caller who wanted `auto` gets
+results from whichever provider answers; by acquisition time a result has been
+chosen and it names its own source.
 - **`BOOK_SOURCE_DEFAULT` set to anything** → *ignored for ordering*, exactly as
   today, and logged once at startup as inert with a pointer to
   `BOOK_SOURCE_ORDER`. Silence would leave an operator believing a setting
@@ -424,7 +439,7 @@ Legacy fallback is one-way **for acquisition only**: with a key, Anna's is
 primary and LibGen is appended; without one, acquisition is `[libgen]` and
 Anna's is not appended, because its key-free search cannot be followed by a
 supported key-free download. **Search is not one-way** — the orders above give
-a keyless operator `[libgen, annas_archive]`, matching
+an operator without an Anna's key `[libgen, annas_archive]`, matching
 `_search_candidates` today, and removing that would drop key-free Anna's
 results for every operator without a key. Stating the restriction without its
 scope is what made this paragraph contradict the orders three lines above it. `BOOK_SOURCE_ORDER` is the single opt-in way to choose an order, and

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -1,10 +1,10 @@
 # ADR-011: Promote Z-Library to a Source Adapter
 
-**Status:** Proposed
+**Status:** Accepted
 
 **Date:** 2026-08-12
 
-**Decision owner:** rookslog (acceptance occurs when this ADR is merged)
+**Decision owner:** rookslog (accepted by this ADR's merge; implementation remains #40)
 
 **Issue:** [#40](https://github.com/rookslog/zlibrary-mcp/issues/40)
 
@@ -65,9 +65,11 @@ The source abstraction is only partial on current `master`.
   Anna's/LibGen result goes through `_fetch_from_source`, while a Z-Library
   result goes directly through `EAPIClient.download_file`.
 - `lib/python_bridge.py::main` eagerly calls `initialize_eapi_client` for every
-  operation except document processing and multi-source search. This is why a
-  credential-free LibGen path can work, but it also keeps authentication and
-  source dispatch outside the router.
+  operation except document processing and multi-source search. Consequently,
+  credential-free LibGen search works today, but `download_book` fails before
+  `_fetch_from_source` can run. The migration must make EAPI initialisation
+  operation- and source-specific before it can claim credential-free LibGen
+  acquisition as a working baseline.
 - `lib/term_tools.py`, `lib/author_tools.py`, `lib/booklist_tools.py`, and
   `lib/enhanced_metadata.py` each know how to create and authenticate an EAPI
   client when a shared client is not supplied. Their public shapes are richer
@@ -174,6 +176,12 @@ transfer provenance. The existing shared rename and optional RAG-processing
 pipeline remains outside adapters, after raw acquisition, so every source
 produces the same final file bundle.
 
+Each acquisition attempt writes to an attempt-specific temporary path beneath
+`output_dir`. On failure or cancellation, the adapter removes that temporary
+file; only a completed raw file is atomically promoted to the path returned in
+`RawAcquisitionResult`. This prevents a failed attempt or retry from leaving a
+truncated artifact that a later stage could mistake for an acquisition.
+
 An adapter may use an internal `resolve_download` step, but a resolved URL is
 not part of the required cross-source contract and is never returned as the
 MCP acquisition result.
@@ -198,6 +206,15 @@ For a compatibility interval, existing top-level `id`, `hash`, `book_hash`,
 and `md5` fields may remain in tool responses. New routing and acquisition code
 uses `source_ref`. Tests must prove that removing a compatibility field does
 not change adapter dispatch.
+
+Acquisition is bound to the source that produced the selected result. Ordered
+fallback applies to discovery and other operations that do not consume a
+source-scoped reference; it must not pass a Z-Library `{id, hash}` reference to
+LibGen or invent an alternate lookup. A quota or acquisition failure is
+returned with the selected source's provenance. The caller may then select a
+result from another source. Cross-source availability hints remain hints under
+#96 and do not authorize automatic acquisition fallback; source-to-source
+deduplication or matching remains #52.
 
 `get_book_metadata` should likewise migrate from raw `bookId`/`bookHash`
 parameters to the selected `bookDetails` result. The old parameters may be
@@ -236,8 +253,10 @@ Routing rules are:
 
 1. One explicitly requested source means one attempt. It never silently falls
    back.
-2. Fallback requires an ordered source list supplied by the caller or operator
-   configuration. The router attempts that order exactly.
+2. Fallback for search and other reference-free operations requires an ordered
+   source list supplied by the caller or operator configuration. The router
+   attempts that order exactly. Acquisition remains source-bound as specified
+   above.
 3. The legacy `source="auto"` input is a compatibility alias for configured
    order. Adapter registration order is never used as the fallback order, and
    registering Z-Library does not silently put it first.
@@ -252,6 +271,19 @@ Routing rules are:
 Legacy Z-Library-named tool behaviour may supply an explicit Z-Library source
 at its compatibility façade. That is a property of the legacy tool contract,
 not a default inside the generic router.
+
+`source="auto"` has an explicit migration path. A new optional
+`BOOK_SOURCE_ORDER` is a validated, non-empty ordered list of registered source
+names and controls `auto` only when set. Until an operator sets it, the router
+normalises the legacy `BOOK_SOURCE_DEFAULT` and
+`BOOK_SOURCE_FALLBACK_ENABLED` scalars into an Anna's/LibGen-only order: a
+concrete legacy default starts the order, `auto`/unset preserves the current
+key-dependent primary, and enabled fallback appends the other capable legacy
+source. Z-Library is not added to that derived order merely by registration;
+its named compatibility tools remain explicit. Invalid legacy or new order
+values fail configuration validation before a network call. Contract tests
+cover the normaliser for keyed, unkeyed, fallback-disabled, explicit-default,
+and new-order cases.
 
 ### 5. Z-Library adapter lifecycle
 
@@ -268,10 +300,12 @@ is never treated as global.
 
 ## Error vocabulary
 
-All source-path failures use a structured envelope. The stable fields are:
+All source-path failures use a structured envelope. A single-source failure
+contains `source`; an aggregate omits it and attributes each child failure.
+The stable fields are:
 
 ```text
-source       SourceType value
+source       SourceType value, required only for a single-source failure
 operation    search, acquire, metadata, limits, history, recent, or booklist
 reason       stable machine-readable reason code
 retryable    explicit boolean when known
@@ -279,6 +313,7 @@ detail       bounded human-readable context
 host         optional host that failed
 mirror       optional source-internal mirror
 failures     optional ordered child failures for an aggregate
+attempts     optional ordered source outcomes for a mixed aggregate
 ```
 
 The transport and upstream reason codes introduced by PR #106 are retained:
@@ -290,12 +325,17 @@ The transport and upstream reason codes introduced by PR #106 are retained:
 #40 adds operation/contract reasons as needed:
 
 - `credentials_missing`, `authentication_failed`, `unsupported_operation`,
-  `invalid_book_ref`, `not_found`, `dependency_unavailable`, and `aborted`.
+  `invalid_book_ref`, `not_found`, `dependency_unavailable`, `aborted`, and
+  `partial_failure`.
 
-An aggregate error retains each source failure in attempted order. An empty
-search result means every attempted capable source answered and none matched;
-it never means that a source was unreachable. Public error data crosses the
-bridge as JSON. Tracebacks and diagnostics remain on stderr.
+An aggregate error retains each source failure in attempted order. A complete
+empty search result means every attempted capable source answered and none
+matched; it never means that a source was unreachable. If one source answers
+empty while another fails, the bridge returns an aggregate
+`partial_failure`—not `[]`—with ordered `attempts` recording the empty and
+failed outcomes and `failures` holding the attributed error details. Public
+error data crosses the bridge as JSON. Tracebacks and diagnostics remain on
+stderr.
 
 The permanent vocabulary says `source`, matching project language. If #106
 lands with its current serialized `provider` field, the migration serializer
@@ -357,7 +397,8 @@ until parity is demonstrated.
 - Rebase on merged #106, #103, #101, and #107 as applicable.
 - Record contract tests for current Z-Library search, metadata, limits,
   history, recent books, booklist degradation, and acquisition.
-- Record the existing credential-free LibGen startup/search/acquisition path.
+- Record the existing credential-free LibGen startup/search path and the
+  current acquisition failure caused by eager EAPI initialisation.
 - Confirm test counts before and after every stage; a lower count is a failure
   signal, not a simplification.
 
@@ -372,6 +413,9 @@ until parity is demonstrated.
 
 ### Stage 2: add `ZLibraryAdapter` behind a dispatch gate
 
+- Make bridge EAPI initialisation lazy and source-specific: a LibGen result
+  reaches router acquisition without Z-Library credentials, while legacy
+  Z-Library operations still initialise the shared client when selected.
 - Wrap the existing shared EAPI lifecycle; do not introduce another login
   path.
 - Implement general search and raw acquisition first.
@@ -421,10 +465,12 @@ until parity is demonstrated.
 
 - One shared adapter-contract suite runs against Anna's Archive, LibGen, and
   Z-Library fakes: source attribution, capability declarations, search result
-  shape, source/ref matching, raw file output, and close semantics.
+  shape, source/ref matching, raw file output, atomic promotion/failed-attempt
+  cleanup, and close semantics.
 - Router tests cover explicit-source no-fallback, caller-ordered fallback,
-  unsupported-capability skipping, aggregate failure order, quota exhaustion,
-  and the rule that partial failure is not an empty result.
+  unsupported-capability skipping, aggregate failure order, source-bound
+  acquisition quota exhaustion, and the rule that a mixed empty/failure search
+  is a `partial_failure`, not an empty result.
 - Z-Library adapter tests use a fake EAPI client and assert exactly one login
   lifecycle per bridge call, no credentials in errors/logs, and per-user quota
   reporting.

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -1,0 +1,565 @@
+# ADR-011: Promote Z-Library to a Source Adapter
+
+**Status:** Proposed
+
+**Date:** 2026-08-12
+
+**Decision owner:** rookslog (acceptance occurs when this ADR is merged)
+
+**Issue:** [#40](https://github.com/rookslog/zlibrary-mcp/issues/40)
+
+## Decision summary
+
+Promote Z-Library behind the same source boundary as Anna's Archive and
+LibGen, but do not widen the current MD5-shaped abstract base class or make
+Z-Library the first entry in a hard-coded fallback chain.
+
+Replace the current source boundary with:
+
+1. a small required adapter contract for search, acquisition, and lifecycle;
+2. an opaque, source-scoped reference carried by every search result;
+3. optional capability protocols for metadata, quota, history, recent-book,
+   curated-list, and specialised-search operations; and
+4. a registry-backed `SourceRouter` that follows caller- or operator-supplied
+   source order and reports what it did without ranking results.
+
+The MCP surface remains file-oriented and search-result-first. Existing tool
+names remain compatibility façades during migration, but their Python paths
+must enter through `SourceRouter`. No direct-from-ID download path is added.
+
+## Decision state and tracker reconciliation
+
+The live tracker is authoritative for release placement:
+
+- As observed on 2026-08-12, #40 is open in the live `v1.5 — Anna's Archive
+  is a real source` milestone.
+- The closed v1.4 map, #75, explicitly moved #40 out of v1.4 and called it
+  v1.5 work.
+- #109's current milestone description records the release-record repair: the
+  old roadmap-derived v1.4 milestone became `Source layer as a first-class
+  citizen (unslotted)`, while #40 moved to v1.5.
+- #95 still calls this work a successor leg named “v1.6.” That sentence is
+  historical narrative, not the release index. It does not override the live
+  milestone or the decision owner's instruction that #40 is current open
+  work.
+
+This ADR therefore treats #40 as v1.5 work. It does not create or preserve a
+v1.6 promise.
+
+## Context
+
+The source abstraction is only partial on current `master`.
+
+- `lib/sources/base.py::SourceAdapter` requires `search(query)`,
+  `get_download_url(md5)`, and `close()`. The `md5` parameter is an Anna's
+  Archive/LibGen identifier, not a source-neutral book reference.
+- `lib/sources/models.py::SourceType` contains only `ANNAS_ARCHIVE` and
+  `LIBGEN`. `UnifiedBookResult` requires `md5`, and `DownloadResult` exposes a
+  resolved URL plus optional Anna's quota information.
+- `lib/sources/router.py::SourceRouter` owns two hard-coded lazy adapter fields
+  and selects between those two names. It is not a registry.
+- `lib/python_bridge.py::search_multi_source` reaches the router, but
+  `search`, `full_text_search`, metadata, limits, history, recent books,
+  author/term searches, and booklist fallback reach the EAPI client directly.
+- `lib/python_bridge.py::download_book` contains the architectural fork: an
+  Anna's/LibGen result goes through `_fetch_from_source`, while a Z-Library
+  result goes directly through `EAPIClient.download_file`.
+- `lib/python_bridge.py::main` eagerly calls `initialize_eapi_client` for every
+  operation except document processing and multi-source search. This is why a
+  credential-free LibGen path can work, but it also keeps authentication and
+  source dispatch outside the router.
+- `lib/term_tools.py`, `lib/author_tools.py`, `lib/booklist_tools.py`, and
+  `lib/enhanced_metadata.py` each know how to create and authenticate an EAPI
+  client when a shared client is not supplied. Their public shapes are richer
+  than Anna's Archive or LibGen can necessarily implement.
+- `src/index.ts` registers 13 tools individually and exposes separate Zod
+  schemas and handlers for the Z-Library and multi-source paths. Its
+  `validateCredentials` function correctly warns rather than exiting when
+  Z-Library credentials are absent.
+- `zlibrary/src/zlibrary/eapi.py::EAPIClient` already centralises Z-Library
+  login, domain discovery, JSON search, profile data, book metadata, download,
+  and client close.
+
+The current download mechanism is not the detail-page scraping recorded in
+ADR-002. ADR-005 migrated the live Z-Library path to JSON EAPI calls, and
+`EAPIClient.download_file` now performs the Z-Library transfer. ADR-002 remains
+binding only for its search-result-first decision: acquisition consumes the
+book details returned by search. ADR-003's rejection of direct ID lookup also
+remains binding.
+
+## Forces and invariants
+
+The design must satisfy these constraints together:
+
+- **Files, not payloads.** MCP acquisition returns paths to durable files, not
+  document text or a resolved download URL as the public result.
+- **stdout purity.** JSON-RPC remains the only stdout traffic. Diagnostics use
+  the existing loggers and stderr.
+- **Per-user credentials and quotas.** The adapter reads the current user's
+  Z-Library credentials and quota. The router never pools accounts or hides a
+  per-user limit behind another source.
+- **No privileged source.** Registration does not imply preference. The
+  router does not rank, score, or deduplicate sources or results.
+- **Search-result-first acquisition.** The caller passes back the result it
+  selected. A source-specific identifier inside that result is not a new
+  direct-ID tool.
+- **Credential-free operation remains valid.** Missing Z-Library credentials
+  disable Z-Library capabilities; they do not prevent LibGen search or
+  acquisition and do not make server startup fatal.
+- **Undocumented upstreams drift.** Every new Z-Library adapter surface needs
+  a doctor/upstream probe or an explicit explanation that an existing EAPI
+  probe covers it.
+- **Heavy processing remains optional.** Source registration must compose
+  with #103's core/RAG/scholar packaging split rather than reinstating eager
+  RAG imports.
+
+## Alternatives considered
+
+### A. Keep `get_download_url(md5)` and special-case Z-Library in the router
+
+Rejected. It preserves an interface shaped around two sources and moves the
+existing `download_book` branch into `SourceRouter` instead of removing it.
+Z-Library needs an EAPI `id` and `hash`; proposed Gutenberg and DOAB adapters
+also should not be required to invent an MD5.
+
+### B. Pass the complete search result to a wider adapter contract
+
+This is the basis of the decision, with one refinement: the common acquisition
+operation returns a raw file path and provenance, not necessarily a URL.
+Anna's Archive and LibGen can continue to share a resolved-URL streaming
+helper, while Z-Library can keep using `EAPIClient.download_file` internally.
+
+### C. Give every adapter every current Z-Library method
+
+Rejected. History, recent books, enriched metadata, and curated booklists are
+capabilities, not universal source properties. Mandatory no-op or fake methods
+would make the contract secretly Z-Library-shaped.
+
+### D. Put Z-Library first in a fixed `zlibrary → annas → libgen` chain
+
+Rejected. Credentials and quota can make Z-Library available, but availability
+is not permission for the server to prefer it. A fixed order is source ranking
+encoded as control flow. The caller or operator must supply order when
+fallback is wanted.
+
+### E. Replace the 13 MCP tools with one generic source-operation tool
+
+Rejected. It would discard useful typed schemas, create a broad stringly typed
+surface, and combine an internal architecture migration with an unnecessary
+public API break. Tool count and discoverability are not the problem #40
+solves.
+
+## Decision
+
+### 1. Required adapter contract
+
+The required contract is intentionally small. Names below are normative
+concepts; exact Python spelling may follow repository conventions.
+
+```python
+class SourceAdapter(ABC):
+    source: SourceType
+
+    def capabilities(self) -> SourceCapabilities: ...
+    async def search(self, request: SearchRequest) -> SourceSearchResult: ...
+    async def acquire(
+        self, book: UnifiedBookResult, output_dir: str
+    ) -> RawAcquisitionResult: ...
+    async def close(self) -> None: ...
+```
+
+`acquire` receives the full selected search result and writes the upstream
+bytes to disk. `RawAcquisitionResult` contains the raw file path and nested
+transfer provenance. The existing shared rename and optional RAG-processing
+pipeline remains outside adapters, after raw acquisition, so every source
+produces the same final file bundle.
+
+An adapter may use an internal `resolve_download` step, but a resolved URL is
+not part of the required cross-source contract and is never returned as the
+MCP acquisition result.
+
+### 2. Source-scoped book reference
+
+`UnifiedBookResult` stops requiring MD5 as its universal identity. It carries:
+
+```text
+source              stable SourceType value
+source_ref          opaque JSON object owned and validated by that adapter
+title               display title
+author/year/format  common optional display fields
+source_metadata     nested source-specific fields
+```
+
+Examples are `{id, hash}` for Z-Library and `{md5}` for Anna's Archive or
+LibGen. The router checks only that `book.source` selects the same adapter that
+will consume `book.source_ref`; it must not inspect identifier keys.
+
+For a compatibility interval, existing top-level `id`, `hash`, `book_hash`,
+and `md5` fields may remain in tool responses. New routing and acquisition code
+uses `source_ref`. Tests must prove that removing a compatibility field does
+not change adapter dispatch.
+
+`get_book_metadata` should likewise migrate from raw `bookId`/`bookHash`
+parameters to the selected `bookDetails` result. The old parameters may be
+accepted during deprecation, but they must be converted at the façade and must
+not create a generic direct-ID route.
+
+### 3. Capability protocols, not fake universal methods
+
+`SourceCapabilities` declares locally knowable support and routes. Optional
+protocols cover:
+
+- general, full-text, author, term, and advanced search modes;
+- metadata lookup from a search result;
+- per-user download limits;
+- account history;
+- recent additions; and
+- curated lists.
+
+`SourceRouter` exposes typed entry points for the existing tool operations. It
+selects only adapters declaring the required capability. An explicit request
+for an unsupported source returns `unsupported_operation`. A fallback request
+skips an incapable adapter and reports that decision in routing metadata; it
+does not ask an adapter to fabricate a response.
+
+The existing Z-Library helper modules become implementation details of
+`ZLibraryAdapter` or thin query-shaping helpers called by it. They must receive
+the adapter's shared EAPI client; they must not log in independently.
+
+### 4. Registry and routing policy
+
+`SourceRouter` receives or builds a mapping from `SourceType` to lazy adapter
+factory. Adding a source means adding a registration and its capability tests,
+not another `_get_*` field plus conditionals.
+
+Routing rules are:
+
+1. One explicitly requested source means one attempt. It never silently falls
+   back.
+2. Fallback requires an ordered source list supplied by the caller or operator
+   configuration. The router attempts that order exactly.
+3. The legacy `source="auto"` input is a compatibility alias for configured
+   order. Adapter registration order is never used as the fallback order, and
+   registering Z-Library does not silently put it first.
+4. The router does not merge, score, deduplicate, or reorder successful
+   results. Cross-source deduplication remains #52.
+5. Responses follow #96: `requested`, `served_by`, `fell_back`, and symmetric
+   per-source route constraints are reported. `sources_used` is deprecated.
+6. Transfer results carry nested `provenance` with source, route, mirror, and
+   host when each value is applicable. Provenance describes the transfer, not
+   document content.
+
+Legacy Z-Library-named tool behaviour may supply an explicit Z-Library source
+at its compatibility façade. That is a property of the legacy tool contract,
+not a default inside the generic router.
+
+### 5. Z-Library adapter lifecycle
+
+`ZLibraryAdapter` wraps one lazily authenticated `EAPIClient` per Python bridge
+process. It reuses `initialize_eapi_client`/`get_eapi_client` behaviour or a
+factored equivalent; it never logs in once per adapter method. `close()` owns
+client cleanup and remains reachable from `python_bridge.py::main`'s `finally`
+path.
+
+Missing credentials are represented as local capability unavailability or a
+structured credential error when Z-Library is explicitly requested. They are
+not a startup failure. Quota comes from the authenticated user's profile and
+is never treated as global.
+
+## Error vocabulary
+
+All source-path failures use a structured envelope. The stable fields are:
+
+```text
+source       SourceType value
+operation    search, acquire, metadata, limits, history, recent, or booklist
+reason       stable machine-readable reason code
+retryable    explicit boolean when known
+detail       bounded human-readable context
+host         optional host that failed
+mirror       optional source-internal mirror
+failures     optional ordered child failures for an aggregate
+```
+
+The transport and upstream reason codes introduced by PR #106 are retained:
+
+- `dns_failure`, `dns_timeout`, `connect_timeout`, `connect_refused`,
+  `connect_error`, `tls_error`, `read_timeout`, `search_timeout`,
+  `http_error`, `quota_exhausted`, `protocol_error`, and `unknown`.
+
+#40 adds operation/contract reasons as needed:
+
+- `credentials_missing`, `authentication_failed`, `unsupported_operation`,
+  `invalid_book_ref`, `not_found`, `dependency_unavailable`, and `aborted`.
+
+An aggregate error retains each source failure in attempted order. An empty
+search result means every attempted capable source answered and none matched;
+it never means that a source was unreachable. Public error data crosses the
+bridge as JSON. Tracebacks and diagnostics remain on stderr.
+
+The permanent vocabulary says `source`, matching project language. If #106
+lands with its current serialized `provider` field, the migration serializer
+must emit `source` and retain `provider` only as a documented compatibility
+alias until callers have moved. No new code should branch on the alias.
+
+## Dependencies and sequencing
+
+### PR #106: bounded calls and structured source failures
+
+This ADR was reviewed against PR #106 at head
+`35886c2f1a76b176009b6a288e59ef2eed3f59ec`. #106 was open and not merged at
+the time of this decision, so every dependency below is conditional on it
+landing substantially as reviewed.
+
+| ADR element | Dependency on #106 as reviewed |
+|---|---|
+| Structured failures | Reuse `SourceError`, `AllSourcesFailedError`, `REASON_TEXT`, and the bridge's structured `details`; extend them rather than creating a parallel hierarchy. |
+| Explicit-source semantics | Preserve #106's rule that an explicit source never falls back and that an empty list means every attempted source answered. |
+| Network budgets | Reuse `SourceConfig` connect/read/total/preflight budgets and apply the same bounded policy to Z-Library operations. |
+| Cancellation | Preserve `CallOptions`, MCP `AbortSignal` forwarding, `runPythonBridge`, and child cleanup while changing handlers or registration. |
+| Adapter registry | Replace #106's two-source `_adapter_for` conditional with the registry; do not add a third branch. |
+| Process lifetime | Keep the one-shot Python bridge boundary. #106's `run_bounded` may abandon a daemon thread that is tolerable only because the process exits after the MCP call; it is not a long-lived adapter-runtime primitive. |
+
+This ADR does **not** depend on #106's current two-source primary order or on
+`provider` being the permanent wire term. If #106 does not land, the #40
+implementation must first supply equivalent bounded execution, cancellation,
+structured failures, and explicit-source semantics. It must not omit those
+protections to make the adapter migration smaller.
+
+Issues #101 and #107 already specify the #96 reporting contract and are
+blocked on #106. #40 consumes their routing, provenance, and per-source limit
+shapes; it does not reopen or duplicate those decisions.
+
+### Issue #103: optional dependency packaging
+
+#103 must establish the final conditional tool-registration surface before
+#40 changes TypeScript registration. The safe implementation order is:
+
+1. land/rebase #106's timeout and error surfaces;
+2. implement #103 against the resulting `lib/sources/config.py` and make
+   core/RAG/scholar capability detection authoritative;
+3. land the already-decided #101/#107 reporting work in whichever order avoids
+   overlapping router edits; and
+4. implement #40 against those merged surfaces.
+
+Python-only contract work may be prepared earlier, but no temporary
+`src/index.ts` registration abstraction should be merged. If #103 has not
+landed, #40 stops before the registration stage. This prevents a first rewrite
+for source capabilities followed by a second rewrite for installed extras.
+
+## Migration stages
+
+Each stage is independently reviewable and keeps the legacy path available
+until parity is demonstrated.
+
+### Stage 0: rebase and characterise
+
+- Rebase on merged #106, #103, #101, and #107 as applicable.
+- Record contract tests for current Z-Library search, metadata, limits,
+  history, recent books, booklist degradation, and acquisition.
+- Record the existing credential-free LibGen startup/search/acquisition path.
+- Confirm test counts before and after every stage; a lower count is a failure
+  signal, not a simplification.
+
+### Stage 1: introduce neutral models and registry
+
+- Add `ZLIBRARY` to `SourceType`.
+- Add `source_ref`, nested `source_metadata`, capabilities, acquisition result,
+  and the registry without routing Z-Library traffic through it yet.
+- Adapt Anna's Archive and LibGen to `acquire(book, output_dir)` while reusing
+  their current URL resolution and streaming helpers.
+- Add compatibility serializers for existing result fields.
+
+### Stage 2: add `ZLibraryAdapter` behind a dispatch gate
+
+- Wrap the existing shared EAPI lifecycle; do not introduce another login
+  path.
+- Implement general search and raw acquisition first.
+- Keep the legacy direct EAPI branch selectable by one temporary dispatch
+  flag. The flag chooses one path; it never performs duplicate live calls.
+
+### Stage 3: route acquisition
+
+- Make `download_book_to_file` pass the selected `bookDetails` to
+  `SourceRouter.acquire` for every source.
+- Keep rename, validation, RAG processing, and final bundle construction in
+  the shared post-acquisition pipeline.
+- Reject source/ref mismatches and raw-ID-only input at the router boundary.
+
+### Stage 4: route search and optional capabilities
+
+- Move general/full-text/advanced/author/term operations to typed router entry
+  points.
+- Move metadata, limits, history, recent books, and booklists through optional
+  capability protocols.
+- Preserve source-specific degraded behaviour only inside the adapter that
+  owns it; do not make it a universal contract.
+
+### Stage 5: update TypeScript registration once
+
+- Build on #103's installed-extra-aware registration.
+- Add source selection/order and search-result-shaped metadata input without
+  changing the 13-tool count.
+- Preserve #106's abort-signal forwarding for every registered handler.
+- Keep Z-Library credential validation non-fatal and make capability messages
+  source-specific.
+- Update tool documentation and the README tool list in the same production
+  change.
+
+### Stage 6: remove the legacy branch
+
+- Flip the adapter path on only after parity, cancellation, packaging, and
+  upstream checks pass.
+- Remove duplicated EAPI initialization and the direct/non-source branch in
+  `download_book`.
+- Remove the temporary dispatch flag in the same release or create a dated
+  removal issue; it must not become a permanent second architecture.
+
+## Test plan
+
+### Deterministic tests
+
+- One shared adapter-contract suite runs against Anna's Archive, LibGen, and
+  Z-Library fakes: source attribution, capability declarations, search result
+  shape, source/ref matching, raw file output, and close semantics.
+- Router tests cover explicit-source no-fallback, caller-ordered fallback,
+  unsupported-capability skipping, aggregate failure order, quota exhaustion,
+  and the rule that partial failure is not an empty result.
+- Z-Library adapter tests use a fake EAPI client and assert exactly one login
+  lifecycle per bridge call, no credentials in errors/logs, and per-user quota
+  reporting.
+- Acquisition tests start from a search result for every source and assert
+  durable file paths plus nested provenance. No test may introduce a raw-ID
+  download path.
+- Bridge tests assert structured error envelopes and stderr-only diagnostics.
+  `__tests__/stdio-purity.test.js` remains unchanged.
+- Node tests assert all registered handlers preserve #106 cancellation and
+  that the README/tool registry check still reports 13 tools.
+- #103 packaging tests run a core-only environment and prove source search and
+  acquisition do not import RAG/scholar dependencies. RAG tools are present
+  only when their extras are installed.
+- Tests compare both aggregate and per-file counts against the pre-stage
+  baseline so accidental test loss cannot hide behind a green exit status.
+
+### Upstream and representative checks
+
+Unit tests mock third-party calls and cannot establish upstream compatibility.
+Before flipping the default, run the existing doctor/upstream probes and one
+credentialed Z-Library search-to-file acquisition in an isolated test account,
+plus credential-free LibGen search-to-file acquisition. Do not record
+credentials, cookies, query text, document content, or downloaded files in
+test artifacts.
+
+If a Z-Library adapter method exercises an EAPI endpoint not covered by the
+current probe, extend the probe or record why an existing field assertion
+catches its drift.
+
+## Rollback plan
+
+Before Stage 6, set the temporary dispatch gate back to the legacy EAPI path
+and rerun search-to-file acquisition. Because this migration changes routing
+and serialized metadata but creates no server-side account or catalogue
+state, rollback does not require data migration.
+
+Schema evolution is additive during the compatibility interval: old identifier
+fields remain readable while `source_ref` becomes authoritative. If a caller
+breaks on the new response, restore the old serializer while leaving internal
+adapter routing enabled; do not restore direct-ID acquisition.
+
+After the legacy branch is removed, rollback is a normal revert of the
+adapter-routing stage. The shared file pipeline and search-result-first input
+remain unchanged on both sides of the rollback.
+
+## Observability plan
+
+Source operations log structured, bounded fields to stderr:
+
+- source, operation, route, mirror/host when applicable;
+- duration and outcome;
+- attempted order, served source, and whether fallback occurred; and
+- stable error reason and retryability.
+
+Logs must not include credentials, API keys, cookies, full search result
+objects, query text, download URLs containing secrets, document content, or
+raw bridge payloads.
+
+The MCP response carries routing constraints, final provenance, and structured
+errors. It does not carry diagnostic traces. #109 remains the owner of whether
+a separate active health tool is still justified; this ADR neither adds that
+tool nor treats passive failure reporting as a decided replacement.
+
+## Consequences
+
+### Positive
+
+- Z-Library uses the same lifecycle, routing, error, provenance, and
+  cancellation boundaries as other sources.
+- The common contract is shaped around the project workflow rather than MD5 or
+  EAPI identifiers.
+- Future sources can implement the small required contract and only the
+  optional capabilities they actually have.
+- Credential-free LibGen remains usable, and Z-Library quotas remain attached
+  to the current user.
+- The direct/non-source acquisition branch and duplicated EAPI setup can be
+  removed after parity.
+
+### Costs and trade-offs
+
+- This is a staged migration across Python models, router, bridge dispatch,
+  TypeScript schemas, tests, and documentation; it is not a one-file adapter.
+- The router cannot statically validate the contents of an opaque
+  `source_ref`; validation belongs to the selected adapter and must produce a
+  structured error.
+- Compatibility fields temporarily duplicate identifier data.
+- Existing `auto` callers need a documented configured order before Z-Library
+  can participate in fallback without becoming a hidden preferred source.
+- Z-Library-only capabilities remain visible as such. Uniform routing does not
+  imply uniform upstream features.
+
+## Remaining uncertainty
+
+- #109 has not decided whether passive reporting is sufficient or a separate
+  active health tool remains useful.
+- The final public spelling and deprecation window for ordered source input
+  must be coordinated with the implementation of #101/#107 and the README
+  contract.
+- PR #106 was not merged when this ADR was written; conflict resolution may
+  change exact class or function names. The semantic dependencies above remain
+  required and must be rechecked against its merged form.
+- #103 is unslotted even though its sequencing constraint is binding. If it is
+  deferred, #40 can proceed through Python stages but must stop before changing
+  TypeScript registration.
+- The EAPI is undocumented. Adapter parity under fake-client tests does not
+  predict endpoint drift, domain rotation, authentication throttling, or live
+  quota behaviour.
+
+## Load-bearing assumption and flip condition
+
+**Load-bearing assumption:** the source-neutral commonality is the workflow:
+a search emits a result containing an adapter-owned reference, and acquisition
+consumes that result. Richer operations can remain declared capabilities. The
+router therefore never needs to understand source-specific identifier keys.
+
+**Flip condition:** if an implementation spike covering Z-Library and one
+non-MD5 future source shows that the router must inspect source-specific keys,
+retain session-only lookup state, or fabricate capability data to complete a
+normal search-to-file flow, stop the migration. Replace `UnifiedBookResult`'s
+opaque reference with operation-specific typed envelopes and reduce the router
+to a registry/dispatcher before adding more adapters. Do not add another
+source-specific conditional to the common path.
+
+## Related decisions and work
+
+- `VISION.md`, invariants 1–4, 6, and 7
+- ADR-002, search-result-first download workflow (mechanism updated by ADR-005)
+- ADR-003, direct ID lookup deprecation
+- ADR-005, EAPI migration
+- ADR-010, current `McpServer.tool()` registration surface
+- #40, Z-Library adapter work
+- #75, shipped v1.4 map and deferral of #40
+- #95, current v1.5 map
+- #96, source/route reporting decision
+- #101 and #107, implementation of the #96 reporting contract
+- #103, optional dependency packaging and registration sequencing
+- PR #106, bounded source calls, cancellation, and structured failures
+- #109, unresolved health-tool boundary

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -83,11 +83,26 @@ The source abstraction is only partial on current `master`.
   and client close.
 
 The current download mechanism is not the detail-page scraping recorded in
-ADR-002. ADR-005 migrated the live Z-Library path to JSON EAPI calls, and
-`EAPIClient.download_file` now performs the Z-Library transfer. ADR-002 remains
-binding only for its search-result-first decision: acquisition consumes the
-book details returned by search. ADR-003's rejection of direct ID lookup also
-remains binding.
+ADR-002. ADR-005 migrated the live Z-Library query path to JSON EAPI calls;
+ADR-002 remains binding only for its search-result-first decision, that
+acquisition consumes the book details returned by search. ADR-003's rejection
+of direct ID lookup also remains binding.
+
+**This ADR supersedes ADR-005's download clause.** ADR-005 decided that
+downloads would *keep* the legacy `AsyncZlib` client, on the reasoning that
+"EAPI returns download URL, but actual file download requires cookies from the
+legacy client." The implementation subsequently diverged: `EAPIClient` grew its
+own `download_file`, and the live Z-Library transfer runs through it today. The
+divergence was never recorded, so ADR-005 has been stating a decision the code
+stopped honouring — and an implementer reading it could not tell whether the
+EAPI download path was an intentional decision or drift.
+
+It is a decision, and it is recorded here: the Z-Library transfer runs on
+`EAPIClient.download_file`, and ADR-005's "Downloads: keep legacy AsyncZlib
+client" decision, together with its two matching consequence bullets, no longer
+binds. The Z-Library adapter this ADR designs targets `EAPIClient`, not
+`AsyncZlib`. ADR-005's search, metadata, and domain-discovery decisions are
+untouched.
 
 ## Forces and invariants
 
@@ -365,7 +380,16 @@ The transport and upstream reason codes introduced by PR #106 are retained:
 
 - `dns_failure`, `dns_timeout`, `connect_timeout`, `connect_refused`,
   `connect_error`, `tls_error`, `read_timeout`, `search_timeout`,
-  `http_error`, `quota_exhausted`, `protocol_error`, and `unknown`.
+  `http_error`, `quota_exhausted`, `protocol_error`, `integrity_mismatch`,
+  `configuration_error`, and `unknown`.
+
+`integrity_mismatch` and `configuration_error` are load-bearing and easy to
+drop by accident, because neither is a transport failure: the first is emitted
+when a completed transfer's digest does not match what was requested, the
+second when a provider cannot run with the configuration it was given. Both are
+covered by tests. Retained means retained — an adapter that folds either into
+`protocol_error` or `unknown` has lost a stable classification callers already
+depend on, and has done so while believing it preserved #106.
 
 #40 adds operation/contract reasons as needed:
 
@@ -453,8 +477,14 @@ until parity is demonstrated.
   history, recent books, booklist degradation, and acquisition.
 - Record failing privacy regressions for the current raw bridge payload and
   query logging, using sentinel values rather than credentials or live URLs.
-- Record the existing credential-free LibGen startup/search path and the
-  current acquisition failure caused by eager EAPI initialisation.
+- Record the existing credential-free LibGen startup, search **and
+  acquisition** paths as a baseline to preserve. The eager-EAPI-initialisation
+  failure this stage originally characterised no longer exists: the rebase
+  parent carries `python_bridge.py::_requires_eapi_client`, which exempts
+  downloads of multi-source results from EAPI initialisation (#129). Treat that
+  source-conditional initialisation as an existing constraint the adapter must
+  not regress, not as a defect to fix in Stage 2 — reimplementing a landed fix
+  is how a plan silently loses one.
 - Confirm test counts before and after every stage; a lower count is a failure
   signal, not a simplification.
 

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -492,12 +492,20 @@ the derived legacy order merely by registration; its named compatibility tools
 remain explicit. Invalid legacy or new order values fail configuration
 validation before a network call. Contract tests cover the derivation for
 keyed, unkeyed, fallback-disabled, explicit-default, and new-order cases, and
-must assert the search/acquisition asymmetry directly: **without a key, search
-derives `[libgen, annas_archive]` while acquisition derives `[libgen]`.** A
-single "unkeyed no-Anna's" assertion is what an earlier revision of this
-section asked for, and it is true of acquisition and false of search — a test
-suite that keeps it would enforce the loss of key-free Anna's search that this
-document elsewhere forbids.
+must assert two different things about search and acquisition, because the two
+are not the same kind of rule:
+
+- **Search derives an order.** Without a key it derives
+  `[libgen, annas_archive]`; a single "unkeyed no-Anna's" assertion, which an
+  earlier revision of this section asked for, would enforce the loss of
+  key-free Anna's search that this document elsewhere forbids.
+- **Acquisition derives nothing.** It dispatches to the adapter the selected
+  result names. So the assertion for an operator without a key who selected an
+  Anna's result from key-free search is that acquisition goes to **Anna's** and
+  returns its attributed `credentials_missing` — not that it derives
+  `[libgen]`. Asserting a derived acquisition order would either preserve the
+  result-less `_download_candidates` behaviour this ADR removes, or send
+  Anna's `source_ref` to LibGen.
 
 ### 5. Z-Library adapter lifecycle
 

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -182,6 +182,15 @@ file; only a completed raw file is atomically promoted to the path returned in
 `RawAcquisitionResult`. This prevents a failed attempt or retry from leaving a
 truncated artifact that a later stage could mistake for an acquisition.
 
+File-writing acquisition must not rely on an abandoned `run_bounded` worker to
+perform that cleanup. If an adapter must place blocking acquisition work behind
+that boundary, the parent creates and owns the attempt path plus a completion
+lease. Timeout or cancellation invalidates the lease and removes the path;
+after invalidation the worker may neither create nor promote a result. The
+implementation must join or cooperatively cancel file-writing workers where the
+underlying API permits it. Contract tests hold a worker past its deadline and
+prove that a late completion cannot recreate or promote the temporary file.
+
 An adapter may use an internal `resolve_download` step, but a resolved URL is
 not part of the required cross-source contract and is never returned as the
 MCP acquisition result.
@@ -210,11 +219,17 @@ not change adapter dispatch.
 The compatibility facade normalises a full pre-migration Z-Library
 `bookDetails` search result before router validation: it adds
 `source=zlibrary` and constructs `source_ref={id, hash}` from the legacy
-identifier fields. This conversion applies only to the existing
-search-result-shaped `bookDetails` input, not to a naked direct-ID request.
-Contract tests must distinguish the accepted legacy result shape from raw
-`id`/`hash` parameters so the compatibility interval does not recreate a
-generic direct-ID path.
+identifier fields. The exact legacy predicate is an object containing non-empty
+`id` and `hash`/`book_hash` values plus the search-result display keys
+`title`/`name` and `url` (key presence is required even when an upstream value
+is empty). That is the stable shape emitted by
+`normalize_eapi_book`; `{id, hash}` alone is not sufficient. This structural
+predicate preserves existing stateless callers but is not a claim of
+unforgeable provenance. It applies only inside the existing `bookDetails`
+compatibility facade; raw `bookId`/`bookHash` parameters and identifier-only
+objects remain rejected. Contract tests accept a representative legacy result
+and reject both raw parameter and identifier-only forms so the interval does
+not recreate a generic direct-ID path.
 
 Acquisition is bound to the source that produced the selected result. Ordered
 fallback applies to discovery and other operations that do not consume a
@@ -232,8 +247,11 @@ not create a generic direct-ID route.
 
 ### 3. Capability protocols, not fake universal methods
 
-`SourceCapabilities` declares locally knowable support and routes. Optional
-protocols cover:
+`SourceCapabilities` declares static, locally knowable implementation support;
+it does not change when credentials, quota, or an upstream host are
+unavailable. A separate per-operation availability check reports whether the
+current user can invoke a supported operation and, when not, the stable reason
+such as `credentials_missing` or `quota_exhausted`. Optional protocols cover:
 
 - general, full-text, author, term, and advanced search modes;
 - metadata lookup from a search result;
@@ -244,13 +262,16 @@ protocols cover:
 
 `SourceRouter` exposes typed entry points for the existing tool operations. It
 selects only adapters declaring the required capability. An explicit request
-for an unsupported source returns `unsupported_operation`. A fallback request
-skips an incapable adapter and reports that decision in routing metadata; it
-does not ask an adapter to fabricate a response. If every source in an ordered
-request is skipped as incapable, the router returns an aggregate
-`unsupported_operation` with no top-level `source` and with the ordered skipped
-attempts in routing metadata. It does not return an empty result or require an
-invented child failure.
+for an unsupported source returns `unsupported_operation`; a supported but
+currently unavailable explicit source returns its attributed availability
+reason, for example Z-Library without credentials returns
+`credentials_missing`. A fallback request skips statically incapable adapters
+in routing metadata. It records a supported but unavailable adapter as an
+attributed failed attempt without making a network call, then may continue in
+the supplied order. If every source in an ordered request is skipped as
+incapable, the router returns an aggregate `unsupported_operation` with no
+top-level `source` and with the ordered skipped attempts in routing metadata.
+It does not return an empty result or require an invented child failure.
 
 The existing Z-Library helper modules become implementation details of
 `ZLibraryAdapter` or thin query-shaping helpers called by it. They must receive
@@ -286,8 +307,12 @@ at its compatibility façade. That is a property of the legacy tool contract,
 not a default inside the generic router.
 
 `source="auto"` has an explicit migration path. A new optional
-`BOOK_SOURCE_ORDER` is a validated, non-empty ordered list of registered source
-names and controls `auto` only when set. Until an operator sets it, the router
+`BOOK_SOURCE_ORDER` is a validated, non-empty ordered list of canonical
+`SourceType` values (`annas_archive`, `libgen`, or `zlibrary`) and controls
+`auto` only when set. Selector aliases are normalised before validation:
+legacy `annas` becomes `annas_archive`, while canonical values pass unchanged;
+unknown values fail rather than becoming registry keys. Until an operator sets
+the new order, the router
 normalises the legacy `BOOK_SOURCE_DEFAULT` and
 `BOOK_SOURCE_FALLBACK_ENABLED` scalars into an Anna's/LibGen-only order: a
 concrete legacy default starts the order and `auto`/unset preserves the current
@@ -295,7 +320,7 @@ key-dependent primary. Legacy fallback is one-way: when Anna's Archive is the
 primary and fallback is enabled, LibGen is appended; LibGen never implicitly
 falls through to Anna's Archive. Therefore an unkeyed `auto`/unset default
 normalises to `[libgen]` even when fallback is enabled, while a keyed default
-normalises to `[annas, libgen]` when fallback is enabled. An operator may opt
+normalises to `[annas_archive, libgen]` when fallback is enabled. An operator may opt
 into another order only through `BOOK_SOURCE_ORDER`. Z-Library is not added to
 the derived legacy order merely by registration; its named compatibility tools
 remain explicit. Invalid legacy or new order values fail configuration
@@ -311,10 +336,12 @@ factored equivalent; it never logs in once per adapter method. `close()` owns
 client cleanup and remains reachable from `python_bridge.py::main`'s `finally`
 path.
 
-Missing credentials are represented as local capability unavailability or a
-structured credential error when Z-Library is explicitly requested. They are
-not a startup failure. Quota comes from the authenticated user's profile and
-is never treated as global.
+Missing credentials leave Z-Library's static support declarations intact but
+make its credentialed operations dynamically unavailable. An explicit request
+returns `credentials_missing`; an ordered request records that attributed
+failure without attempting login and continues to the next source. Missing
+credentials are not a startup failure. Quota comes from the authenticated
+user's profile and is never treated as global.
 
 ## Error vocabulary
 
@@ -345,6 +372,10 @@ The transport and upstream reason codes introduced by PR #106 are retained:
 - `credentials_missing`, `authentication_failed`, `unsupported_operation`,
   `invalid_book_ref`, `not_found`, `dependency_unavailable`, `aborted`, and
   `partial_failure`.
+
+Aggregates also use `all_sources_failed` when every attempted capable source
+failed. The aggregate keeps each child reason in order; it never copies one
+child reason to the top level or uses `partial_failure` when nothing answered.
 
 An aggregate error retains each source failure in attempted order. A complete
 empty search result means every attempted capable source answered and none
@@ -381,7 +412,7 @@ landing substantially as reviewed.
 | Network budgets | Reuse `SourceConfig` connect/read/total/preflight budgets and apply the same bounded policy to Z-Library operations. |
 | Cancellation | Preserve `CallOptions`, MCP `AbortSignal` forwarding, `runPythonBridge`, and child cleanup while changing handlers or registration. |
 | Adapter registry | Replace #106's two-source `_adapter_for` conditional with the registry; do not add a third branch. |
-| Process lifetime | Keep the one-shot Python bridge boundary. #106's `run_bounded` may abandon a daemon thread that is tolerable only because the process exits after the MCP call; it is not a long-lived adapter-runtime primitive. |
+| Process lifetime | Keep the one-shot Python bridge boundary. #106's `run_bounded` may abandon a daemon thread for non-file-writing calls; it is not a long-lived adapter-runtime primitive and must not own acquisition cleanup or promotion without the parent-owned lease defined above. |
 
 This ADR does **not** depend on #106's current two-source primary order or on
 `provider` being the permanent wire term. If #106 does not land, the #40
@@ -420,6 +451,8 @@ until parity is demonstrated.
 - Rebase on merged #106, #103, #101, and #107 as applicable.
 - Record contract tests for current Z-Library search, metadata, limits,
   history, recent books, booklist degradation, and acquisition.
+- Record failing privacy regressions for the current raw bridge payload and
+  query logging, using sentinel values rather than credentials or live URLs.
 - Record the existing credential-free LibGen startup/search path and the
   current acquisition failure caused by eager EAPI initialisation.
 - Confirm test counts before and after every stage; a lower count is a failure
@@ -439,6 +472,9 @@ until parity is demonstrated.
 - Make bridge EAPI initialisation lazy and source-specific: a LibGen result
   reaches router acquisition without Z-Library credentials, while legacy
   Z-Library operations still initialise the shared client when selected.
+- Remove raw bridge-payload, copied-argument, query-text, and secret-bearing URL
+  logging before routing production traffic through adapters; retain only the
+  bounded structured fields in the observability plan.
 - Wrap the existing shared EAPI lifecycle; do not introduce another login
   path.
 - Implement general search and raw acquisition first.
@@ -492,11 +528,13 @@ until parity is demonstrated.
 - One shared adapter-contract suite runs against Anna's Archive, LibGen, and
   Z-Library fakes: source attribution, capability declarations, search result
   shape, source/ref matching, raw file output, atomic promotion/failed-attempt
-  cleanup, and close semantics.
+  cleanup, late-worker lease invalidation, and close semantics.
 - Router tests cover explicit-source no-fallback, caller-ordered fallback,
-  unsupported-capability skipping, aggregate failure order, source-bound
-  acquisition quota exhaustion, and the rule that a mixed empty/failure search
-  is a `partial_failure`, not an empty result.
+  canonical source-order values and legacy alias normalisation, static support
+  versus dynamic availability, unsupported-capability skipping, aggregate
+  failure order and `all_sources_failed`, source-bound acquisition quota
+  exhaustion, and the rule that a mixed empty/failure search is a
+  `partial_failure`, not an empty result.
 - Z-Library adapter tests use a fake EAPI client and assert exactly one login
   lifecycle per bridge call, no credentials in errors/logs, and per-user quota
   reporting.
@@ -504,6 +542,8 @@ until parity is demonstrated.
   durable file paths plus nested provenance. No test may introduce a raw-ID
   download path.
 - Bridge tests assert structured error envelopes and stderr-only diagnostics.
+  Sentinel credentials, queries, raw payloads, full `bookDetails`, and
+  secret-bearing URLs must be absent from captured stderr as well as stdout.
   `__tests__/stdio-purity.test.js` remains unchanged.
 - Node tests assert all registered handlers preserve #106 cancellation and
   that the README/tool registry check still reports 13 tools.
@@ -518,9 +558,15 @@ until parity is demonstrated.
 Unit tests mock third-party calls and cannot establish upstream compatibility.
 Before flipping the default, run the existing doctor/upstream probes and one
 credentialed Z-Library search-to-file acquisition in an isolated test account,
-plus credential-free LibGen search-to-file acquisition. Do not record
-credentials, cookies, query text, document content, or downloaded files in
-test artifacts.
+one keyed Anna's Archive `fast_download` search-to-file acquisition using an
+isolated key, plus credential-free LibGen search-to-file acquisition. The
+Anna's check is an owner-authorised, quota-consuming release gate, not an
+unauthenticated doctor or routine CI probe. Use a bounded temporary directory,
+assert a non-empty expected file signature, and remove the downloaded artifact
+after the check. If the isolated key or approval is unavailable, the migration
+does not flip; fake-adapter coverage is not a substitute. Do not record
+credentials, API keys, cookies, query text, document content, download URLs, or
+downloaded files in test artifacts.
 
 If a Z-Library adapter method exercises an EAPI endpoint not covered by the
 current probe, extend the probe or record why an existing field assertion
@@ -538,9 +584,14 @@ fields remain readable while `source_ref` becomes authoritative. If a caller
 breaks on the new response, restore the old serializer while leaving internal
 adapter routing enabled; do not restore direct-ID acquisition.
 
-After the legacy branch is removed, rollback is a normal revert of the
-adapter-routing stage. The shared file pipeline and search-result-first input
-remain unchanged on both sides of the rollback.
+After the legacy branch is removed, rollback restores a known pre-migration
+revision or reverts the migration stages in reverse dependency order: restore
+Stage 6's removed legacy initialisation/direct branch first, then revert the
+dependent registration, capability-routing, acquisition-routing, adapter, and
+model stages as needed. Reverting only the earlier adapter-routing change after
+Stage 6 is not a valid rollback because that path depends on code Stage 6
+removed. The shared file pipeline and search-result-first input remain
+unchanged on both sides of the rollback.
 
 ## Observability plan
 
@@ -590,17 +641,19 @@ tool nor treats passive failure reporting as a decided replacement.
 
 ## Remaining uncertainty
 
-- #109 has not decided whether passive reporting is sufficient or a separate
-  active health tool remains useful.
+- #109 retained a narrow active-liveness tool rather than a broad health
+  surface. Its implementation remains separate from this adapter migration;
+  #40 must not duplicate routing, quota, or request-failure reporting there.
 - The final public spelling and deprecation window for ordered source input
   must be coordinated with the implementation of #101/#107 and the README
   contract.
 - PR #106 was not merged when this ADR was written; conflict resolution may
   change exact class or function names. The semantic dependencies above remain
   required and must be rechecked against its merged form.
-- #103 is unslotted even though its sequencing constraint is binding. If it is
-  deferred, #40 can proceed through Python stages but must stop before changing
-  TypeScript registration.
+- #103 is now slotted in v1.5 because its sequencing constraint is binding.
+  #40 must still stop before changing TypeScript registration until #103 lands;
+  milestone membership records the dependency but does not make unfinished
+  registration work safe to build against.
 - The EAPI is undocumented. Adapter parity under fake-client tests does not
   predict endpoint drift, domain rotation, authentication throttling, or live
   quota behaviour.
@@ -634,4 +687,4 @@ source-specific conditional to the common path.
 - #101 and #107, implementation of the #96 reporting contract
 - #103, optional dependency packaging and registration sequencing
 - PR #106, bounded source calls, cancellation, and structured failures
-- #109, unresolved health-tool boundary
+- #109, narrow active-liveness health-tool verdict

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -336,6 +336,10 @@ at its compatibility façade. That is a property of the legacy tool contract,
 not a default inside the generic router.
 
 `source="auto"` has an explicit migration path. A new optional
+`BOOK_SOURCE_ORDER` names the providers to attempt, in order, and is the only
+setting that changes routing; the paragraphs below define it, bound it, and
+state the precondition it cannot ship without.
+
 **A three-source order does not fit the current timeout budget, and the order
 cannot ship before that is resolved.** `lib/sources/config.py` documents the
 arithmetic: one provider attempt costs at worst `2 x preflight + total` = 55s,
@@ -354,6 +358,15 @@ lives. A full-order timeout test covering the longest permitted order lands in
 the same stage; without it the regression is invisible until a slow walk in
 production.
 
+**The order is a set, not a bag.** Validation rejects a repeated source:
+`[libgen, libgen, libgen, libgen, libgen]` would otherwise be valid, and since
+the router attempts the supplied order exactly, it multiplies the mirror walk
+without bound — reinstating the timeout overrun the paragraph above exists to
+prevent, with no way for the arithmetic to anticipate it. Each canonical value
+appears at most once, which also bounds the order's length at the number of
+registered sources and makes the worst-case attempt count computable from the
+registry rather than from operator input.
+
 `BOOK_SOURCE_ORDER` is a validated, non-empty ordered list of canonical
 `SourceType` values (`annas_archive`, `libgen`, or `zlibrary`) and controls
 `auto` only when set. Selector aliases are normalised before validation:
@@ -361,7 +374,7 @@ legacy `annas` becomes `annas_archive`, while canonical values pass unchanged;
 unknown values fail rather than becoming registry keys. 
 
 **`BOOK_SOURCE_DEFAULT` is currently inert, and this migration must not quietly
-activate it.** `SourceRouter._resolve_source` never reads
+activate it.** `SourceRouter._determine_source` never reads
 `config.default_source`; it resolves an omitted or `auto` request from
 `has_annas_key` alone. So an operator who set `BOOK_SOURCE_DEFAULT=annas`
 without a key is being routed to LibGen today, and one who set `libgen` with a
@@ -384,18 +397,37 @@ would silently drop key-free Anna's results for every operator without a key.
   is enabled, `[libgen]` when it is not.
 - **Search, unset or `auto`, key present** → `[annas_archive, libgen]` when
   fallback is enabled, `[annas_archive]` when it is not.
-- **Acquisition, unset or `auto`, no key** → `[libgen]`. Anna's is not appended:
-  its key-free search cannot be followed by a supported key-free download.
-- **Acquisition, unset or `auto`, key present** → `[annas_archive, libgen]` when
-  fallback is enabled, `[annas_archive]` when it is not.
+**Acquisition dispatches to the adapter the selected result names, not to a
+configured order.** A result carries its `source`, and the file lives at that
+provider — handing a LibGen result to Anna's would mean passing LibGen's
+`source_ref` to an adapter that cannot resolve it, or performing the
+cross-source lookup this ADR explicitly defers. So the orders above govern
+**search**; acquisition follows `book.source`, as the source-bound contract
+earlier in this document requires.
+
+The ordered walk still matters for acquisition, but *within* the named
+provider: LibGen's mirrors, and Anna's partner servers. Cross-provider
+acquisition fallback is only reachable when the caller asked for `auto` and no
+result has been selected yet, and even then it is bounded by the timeout
+arithmetic below:
+
+- **`auto` acquisition, no key** → `[libgen]`. Anna's is not appended: its
+  key-free search cannot be followed by a supported key-free download.
+- **`auto` acquisition, key present** → `[annas_archive, libgen]` when fallback
+  is enabled, `[annas_archive]` when it is not.
 - **`BOOK_SOURCE_DEFAULT` set to anything** → *ignored for ordering*, exactly as
   today, and logged once at startup as inert with a pointer to
   `BOOK_SOURCE_ORDER`. Silence would leave an operator believing a setting
   works; honouring it would change routing under their feet.
 
-Legacy fallback stays one-way: when Anna's Archive is the primary and fallback
-is enabled, LibGen is appended; LibGen never implicitly falls through to Anna's
-Archive. `BOOK_SOURCE_ORDER` is the single opt-in way to choose an order, and
+Legacy fallback is one-way **for acquisition only**: with a key, Anna's is
+primary and LibGen is appended; without one, acquisition is `[libgen]` and
+Anna's is not appended, because its key-free search cannot be followed by a
+supported key-free download. **Search is not one-way** — the orders above give
+a keyless operator `[libgen, annas_archive]`, matching
+`_search_candidates` today, and removing that would drop key-free Anna's
+results for every operator without a key. Stating the restriction without its
+scope is what made this paragraph contradict the orders three lines above it. `BOOK_SOURCE_ORDER` is the single opt-in way to choose an order, and
 adopting it is what makes a previously inert preference take effect. Z-Library is not added to
 the derived legacy order merely by registration; its named compatibility tools
 remain explicit. Invalid legacy or new order values fail configuration
@@ -426,7 +458,9 @@ The stable fields are:
 
 ```text
 source       SourceType value, required only for a single-source failure
-operation    search, acquire, metadata, limits, history, recent, or booklist
+operation    search, download, metadata, limits, history, recent, or booklist
+             (`download`, never `acquire` — see the wire-compatibility note
+             below; `acquire` is the adapter method name and stays internal)
 reason       stable machine-readable reason code
 retryable    explicit boolean when known
 detail       bounded human-readable context

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -284,8 +284,20 @@ currently unavailable explicit source returns its attributed availability
 reason, for example Z-Library without credentials returns
 `credentials_missing`. A fallback request skips statically incapable adapters
 in routing metadata. It records a supported but unavailable adapter as an
-attributed failed attempt without making a network call, then may continue in
-the supplied order. If every source in an ordered request is skipped as
+attributed failed attempt and may then continue in the supplied order.
+
+The no-network rule applies to **locally knowable** unavailability only —
+absent credentials, a missing optional dependency, a capability the adapter
+does not declare. Those are decidable from configuration and must never cost a
+request. Availability that is *not* locally knowable may cost a **bounded
+probe**: Z-Library learns the current account's quota through
+`EAPIClient.get_profile()`, and host reachability is established by the source
+preflight probe. Forbidding those outright would force an implementation to
+choose between stale state and reclassifying quota and reachability as ordinary
+operation failures — which is the fallback-metadata inconsistency this section
+exists to prevent. What stays forbidden is running the *requested operation*
+against an adapter already known to be unavailable: the probe is allowed, the
+search or download it would have replaced is not. If every source in an ordered request is skipped as
 incapable, the router returns an aggregate `unsupported_operation` with no
 top-level `source` and with the ordered skipped attempts in routing metadata.
 It does not return an empty result or require an invented child failure.
@@ -328,17 +340,33 @@ not a default inside the generic router.
 `SourceType` values (`annas_archive`, `libgen`, or `zlibrary`) and controls
 `auto` only when set. Selector aliases are normalised before validation:
 legacy `annas` becomes `annas_archive`, while canonical values pass unchanged;
-unknown values fail rather than becoming registry keys. Until an operator sets
-the new order, the router
-normalises the legacy `BOOK_SOURCE_DEFAULT` and
-`BOOK_SOURCE_FALLBACK_ENABLED` scalars into an Anna's/LibGen-only order: a
-concrete legacy default starts the order and `auto`/unset preserves the current
-key-dependent primary. Legacy fallback is one-way: when Anna's Archive is the
-primary and fallback is enabled, LibGen is appended; LibGen never implicitly
-falls through to Anna's Archive. Therefore an unkeyed `auto`/unset default
-normalises to `[libgen]` even when fallback is enabled, while a keyed default
-normalises to `[annas_archive, libgen]` when fallback is enabled. An operator may opt
-into another order only through `BOOK_SOURCE_ORDER`. Z-Library is not added to
+unknown values fail rather than becoming registry keys. 
+
+**`BOOK_SOURCE_DEFAULT` is currently inert, and this migration must not quietly
+activate it.** `SourceRouter._resolve_source` never reads
+`config.default_source`; it resolves an omitted or `auto` request from
+`has_annas_key` alone. So an operator who set `BOOK_SOURCE_DEFAULT=annas`
+without a key is being routed to LibGen today, and one who set `libgen` with a
+key is being routed to Anna's first. "Normalising the legacy scalar into an
+order" would change both, under a label that says compatibility — and one of
+those changes is worse than cosmetic, since it would select Anna's key-free
+search for an operator whose only supported Anna's acquisition path requires
+the key they do not have.
+
+The migration therefore preserves `auto` exactly as it behaves now:
+
+- **Unset or `auto`, no key** → `[libgen]`.
+- **Unset or `auto`, key present** → `[annas_archive, libgen]` when fallback is
+  enabled, `[annas_archive]` when it is not.
+- **`BOOK_SOURCE_DEFAULT` set to anything** → *ignored for ordering*, exactly as
+  today, and logged once at startup as inert with a pointer to
+  `BOOK_SOURCE_ORDER`. Silence would leave an operator believing a setting
+  works; honouring it would change routing under their feet.
+
+Legacy fallback stays one-way: when Anna's Archive is the primary and fallback
+is enabled, LibGen is appended; LibGen never implicitly falls through to Anna's
+Archive. `BOOK_SOURCE_ORDER` is the single opt-in way to choose an order, and
+adopting it is what makes a previously inert preference take effect. Z-Library is not added to
 the derived legacy order merely by registration; its named compatibility tools
 remain explicit. Invalid legacy or new order values fail configuration
 validation before a network call. Contract tests cover the normaliser for
@@ -577,9 +605,18 @@ until parity is demonstrated.
   durable file paths plus nested provenance. No test may introduce a raw-ID
   download path.
 - Bridge tests assert structured error envelopes and stderr-only diagnostics.
-  Sentinel credentials, queries, raw payloads, full `bookDetails`, and
-  secret-bearing URLs must be absent from captured stderr as well as stdout.
+  Sentinel credentials, raw payloads, full `bookDetails`, and secret-bearing
+  URLs must be absent from captured stderr **and** stdout.
   `__tests__/stdio-purity.test.js` remains unchanged.
+- **The query is exempt on stdout, and only there.** The bridge deliberately
+  serialises it into successful responses — `retrieved_from_url` carries
+  `f"EAPI search: {query}"` for general and full-text search, and advanced
+  search returns a `query` field. Those are response contract, not leakage, and
+  a blanket "no queries in stdout" assertion would either fail the migration
+  tests or force an undocumented protocol break under a privacy label. The
+  privacy defect this work addresses was diagnostic query *logging*, so the
+  assertion is scoped to stderr. Removing the query from the public response is
+  a separate decision, and this ADR does not make it.
 - Node tests assert all registered handlers preserve #106 cancellation and
   that the README/tool registry check still reports 13 tools.
 - #103 packaging tests run a core-only environment and prove source search and

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -207,6 +207,15 @@ and `md5` fields may remain in tool responses. New routing and acquisition code
 uses `source_ref`. Tests must prove that removing a compatibility field does
 not change adapter dispatch.
 
+The compatibility facade normalises a full pre-migration Z-Library
+`bookDetails` search result before router validation: it adds
+`source=zlibrary` and constructs `source_ref={id, hash}` from the legacy
+identifier fields. This conversion applies only to the existing
+search-result-shaped `bookDetails` input, not to a naked direct-ID request.
+Contract tests must distinguish the accepted legacy result shape from raw
+`id`/`hash` parameters so the compatibility interval does not recreate a
+generic direct-ID path.
+
 Acquisition is bound to the source that produced the selected result. Ordered
 fallback applies to discovery and other operations that do not consume a
 source-scoped reference; it must not pass a Z-Library `{id, hash}` reference to
@@ -237,7 +246,11 @@ protocols cover:
 selects only adapters declaring the required capability. An explicit request
 for an unsupported source returns `unsupported_operation`. A fallback request
 skips an incapable adapter and reports that decision in routing metadata; it
-does not ask an adapter to fabricate a response.
+does not ask an adapter to fabricate a response. If every source in an ordered
+request is skipped as incapable, the router returns an aggregate
+`unsupported_operation` with no top-level `source` and with the ordered skipped
+attempts in routing metadata. It does not return an empty result or require an
+invented child failure.
 
 The existing Z-Library helper modules become implementation details of
 `ZLibraryAdapter` or thin query-shaping helpers called by it. They must receive
@@ -277,13 +290,18 @@ not a default inside the generic router.
 names and controls `auto` only when set. Until an operator sets it, the router
 normalises the legacy `BOOK_SOURCE_DEFAULT` and
 `BOOK_SOURCE_FALLBACK_ENABLED` scalars into an Anna's/LibGen-only order: a
-concrete legacy default starts the order, `auto`/unset preserves the current
-key-dependent primary, and enabled fallback appends the other capable legacy
-source. Z-Library is not added to that derived order merely by registration;
-its named compatibility tools remain explicit. Invalid legacy or new order
-values fail configuration validation before a network call. Contract tests
-cover the normaliser for keyed, unkeyed, fallback-disabled, explicit-default,
-and new-order cases.
+concrete legacy default starts the order and `auto`/unset preserves the current
+key-dependent primary. Legacy fallback is one-way: when Anna's Archive is the
+primary and fallback is enabled, LibGen is appended; LibGen never implicitly
+falls through to Anna's Archive. Therefore an unkeyed `auto`/unset default
+normalises to `[libgen]` even when fallback is enabled, while a keyed default
+normalises to `[annas, libgen]` when fallback is enabled. An operator may opt
+into another order only through `BOOK_SOURCE_ORDER`. Z-Library is not added to
+the derived legacy order merely by registration; its named compatibility tools
+remain explicit. Invalid legacy or new order values fail configuration
+validation before a network call. Contract tests cover the normaliser for
+keyed, unkeyed, fallback-disabled, explicit-default, and new-order cases,
+including the unkeyed no-Anna's invariant.
 
 ### 5. Z-Library adapter lifecycle
 
@@ -336,6 +354,11 @@ empty while another fails, the bridge returns an aggregate
 failed outcomes and `failures` holding the attributed error details. Public
 error data crosses the bridge as JSON. Tracebacks and diagnostics remain on
 stderr.
+
+When every source in an ordered request lacks the requested capability, the
+bridge returns aggregate `unsupported_operation`. Its ordered `attempts`
+record each capability skip, `failures` may be empty, and the aggregate omits
+`source` because no adapter owned the outcome.
 
 The permanent vocabulary says `source`, matching project language. If #106
 lands with its current serialized `provider` field, the migration serializer
@@ -426,6 +449,9 @@ until parity is demonstrated.
 
 - Make `download_book_to_file` pass the selected `bookDetails` to
   `SourceRouter.acquire` for every source.
+- Before router validation, normalise a full legacy Z-Library `bookDetails`
+  result to `source=zlibrary` and `source_ref={id, hash}`; do not normalise raw
+  direct-ID parameters.
 - Keep rename, validation, RAG processing, and final bundle construction in
   the shared post-acquisition pipeline.
 - Reject source/ref mismatches and raw-ID-only input at the router boundary.

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -253,10 +253,18 @@ is empty). That is the stable shape emitted by
 `normalize_eapi_book`; `{id, hash}` alone is not sufficient. This structural
 predicate preserves existing stateless callers but is not a claim of
 unforgeable provenance. It applies only inside the existing `bookDetails`
-compatibility facade; raw `bookId`/`bookHash` parameters and identifier-only
-objects remain rejected. Contract tests accept a representative legacy result
-and reject both raw parameter and identifier-only forms so the interval does
-not recreate a generic direct-ID path.
+compatibility facade.
+
+**The rejection of raw `bookId`/`bookHash` is scoped to acquisition**, where a
+direct-ID download route is what ADR-003 ruled out. `get_book_metadata` must
+keep accepting them for the deprecation interval — `src/index.ts` requires them
+today — as the compatibility section below states; a blanket rejection here
+would contradict that and break existing clients at schema validation. What is
+banned everywhere is an identifier-only object standing in for a selected
+result. Contract tests accept a representative legacy result, reject
+identifier-only forms everywhere, and reject raw parameters **on the
+acquisition path**, so the interval does not recreate a generic direct-ID
+download while metadata keeps working.
 
 Acquisition is bound to the source that produced the selected result. Ordered
 fallback applies to discovery and other operations that do not consume a
@@ -355,6 +363,16 @@ not a default inside the generic router.
 `BOOK_SOURCE_ORDER` names the providers to attempt, in order, and is the only
 setting that changes routing; the paragraphs below define it, bound it, and
 state the precondition it cannot ship without.
+
+**An explicit order wins over `BOOK_SOURCE_FALLBACK_ENABLED=false`, and the
+conflict is logged once at startup.** The two settings otherwise have no
+determinate result: an explicit order names several providers to attempt while
+fallback-disabled means attempt only the first. Precedence goes to the explicit
+order because it is the newer, more specific instruction and the operator wrote
+it deliberately; `BOOK_SOURCE_FALLBACK_ENABLED` continues to govern the
+*derived* orders for `auto`, which is its whole existing purpose. Silently
+honouring one would leave an operator believing the other works — the same
+failure `BOOK_SOURCE_DEFAULT` produced by being inert.
 
 **A three-source order does not fit the current timeout budget, and the order
 cannot ship before that is resolved.** `lib/sources/config.py` documents the
@@ -536,6 +554,10 @@ operation    search, download, metadata, limits, history, recent, or booklist
 reason       stable machine-readable reason code
 retryable    explicit boolean when known
 detail       bounded human-readable context
+message      the existing human-readable summary, retained: both
+             SourceError.to_dict() and AllSourcesFailedError.to_dict() already
+             emit it and it is already public through the bridge `details`, so
+             a migration described as additive cannot drop it
 host         optional host that failed
 mirror       optional source-internal mirror
 failures     optional ordered child failures for an aggregate
@@ -646,6 +668,16 @@ The permanent vocabulary says `source`, matching project language. If #106
 lands with its current serialized `provider` field, the migration serializer
 must emit `source` and retain `provider` only as a documented compatibility
 alias until callers have moved. No new code should branch on the alias.
+
+**The alias must carry the legacy *value*, not just the legacy key.** Anna's
+adapter sets `PROVIDER = "annas"` and `SourceError.to_dict()` emits it, and
+Node tests assert that string; the canonical `SourceType` is `annas_archive`.
+So a serializer that aliases `provider` to the new value emits
+`provider="annas_archive"` and breaks every caller the alias exists to protect
+— the field survives and its content does not. During the interval `source`
+carries the canonical value and `provider` carries the legacy one, and a test
+asserts the two differ for Anna's, since they are identical for LibGen and a
+LibGen-only test would pass either way.
 
 ## Dependencies and sequencing
 

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -376,6 +376,15 @@ attempt count, where LibGen's depends on whether `LIBGEN_MIRROR` names one of
 the fallbacks. Any arithmetic here that hardcodes three mirrors is wrong for a
 configuration this project supports.
 
+**This is not only a future problem.** The same mistake is live on `master`
+today: `config.py`'s own documented sum assumes three mirrors, so an operator
+who sets `LIBGEN_MIRROR=rs` already reaches 5 attempts = 275s against the 240s
+bridge timeout on a plain `auto` search. Tracked as #152. A per-provider budget
+re-breaks the sum every time a source or mirror is added — the comment in
+`config.py` has now been wrong twice for that reason — which is the argument
+for sharing one budget across the ordered walk rather than recomputing a
+constant a third time.
+
 This is a precondition, not a follow-up. Before three-source orders become
 valid, the migration must either share one total budget across the ordered walk
 rather than granting each provider its own, or raise `PYTHON_BRIDGE_TIMEOUT`
@@ -481,9 +490,14 @@ another source retries the *search*.
 adopting it is what makes a previously inert preference take effect. Z-Library is not added to
 the derived legacy order merely by registration; its named compatibility tools
 remain explicit. Invalid legacy or new order values fail configuration
-validation before a network call. Contract tests cover the normaliser for
-keyed, unkeyed, fallback-disabled, explicit-default, and new-order cases,
-including the unkeyed no-Anna's invariant.
+validation before a network call. Contract tests cover the derivation for
+keyed, unkeyed, fallback-disabled, explicit-default, and new-order cases, and
+must assert the search/acquisition asymmetry directly: **without a key, search
+derives `[libgen, annas_archive]` while acquisition derives `[libgen]`.** A
+single "unkeyed no-Anna's" assertion is what an earlier revision of this
+section asked for, and it is true of acquisition and false of search — a test
+suite that keeps it would enforce the loss of key-free Anna's search that this
+document elsewhere forbids.
 
 ### 5. Z-Library adapter lifecycle
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -313,7 +313,7 @@ What other options did we evaluate?
 
 ### 4. Update This Index
 Add entry to:
-- Chronological list
+- The by-ADR-number list
 - Topic-based quick reference (if new category)
 
 ### 5. Link from Implementation

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Index of all architecture decisions for the Z-Library MCP server
 **Format**: ADR template follows [MADR](https://adr.github.io/madr/) lightweight format
-**Status**: 7 ADRs recorded (ADR-005 missing - under investigation)
+**Status**: 11 ADRs recorded
 
 ---
 
@@ -10,10 +10,15 @@
 
 ### Python Bridge & Integration
 - **[ADR-004](ADR-004-Python-Bridge-Path-Resolution.md)**: Python Bridge Path Resolution ⭐
+- **[ADR-009](ADR-009-Python-Monolith-Decomposition.md)**: Python Monolith Decomposition
 
 ### Z-Library API Integration
 - **[ADR-002](ADR-002-Download-Workflow-Redesign.md)**: Download Workflow Redesign ⭐
 - **[ADR-003](ADR-003-Handle-ID-Lookup-Failure.md)**: Handle ID Lookup Failure ⭐
+- **[ADR-005](ADR-005-EAPI-Migration.md)**: EAPI Migration ⭐
+
+### Source Adapters & Routing
+- **[ADR-011](ADR-011-Z-Library-Source-Adapter.md)**: Promote Z-Library to a Source Adapter
 
 ### RAG Pipeline & Quality
 - **[ADR-006](ADR-006-Quality-Pipeline-Architecture.md)**: Quality Pipeline Architecture ⭐
@@ -22,6 +27,7 @@
 
 ### Testing & Infrastructure
 - **[ADR-001](ADR-001-Jest-ESM-Migration.md)**: Jest ESM Migration
+- **[ADR-010](ADR-010-MCP-SDK-Upgrade.md)**: MCP SDK Upgrade to 1.25+
 
 ---
 
@@ -113,19 +119,15 @@ const scriptPath = getPythonScriptPath('python_bridge.py');
 
 ---
 
-### ADR-005: [MISSING]
-**Status**: ⚠️ Investigation Needed
-**Date**: Unknown
-**Context**: Gap in ADR sequence
-**Investigation**:
-- Check git history for deleted ADR-005
-- Determine if intentionally skipped or lost
-- Update this index once resolved
-
-**Action Items**:
-- [ ] Search git history: `git log --all --full-history -- "*ADR-005*"`
-- [ ] Check if number was skipped intentionally
-- [ ] Document findings in this index
+### ADR-005: EAPI Migration
+**Status**: ✅ Accepted
+**Date**: 2026-02-01
+**Context**: Browser verification made the HTML scraping path unusable
+**Decision**: Move Z-Library search, metadata, and domain discovery to JSON EAPI endpoints
+**Consequences**:
+- ✅ Removes HTML parsing from the Z-Library query path
+- ✅ Uses structured EAPI responses behind a shared client
+- ⚠️ Depends on an undocumented upstream API and runtime domain discovery
 
 ---
 
@@ -217,6 +219,47 @@ IF garbled detected (Stage 1 OR custom threshold)
 
 ---
 
+### ADR-009: Python Monolith Decomposition
+**Status**: ✅ Accepted
+**Date**: 2026-01-31
+**Context**: `lib/rag_processing.py` had grown into a 4,968-line multi-purpose module
+**Decision**: Split the RAG pipeline into domain modules under `lib/rag/` behind a compatibility facade
+**Consequences**:
+- ✅ Smaller focused modules with preserved imports
+- ✅ Existing callers continue through the facade
+- ⚠️ Cross-module access retains some indirection
+
+---
+
+### ADR-010: MCP SDK Upgrade to 1.25+
+**Status**: ✅ Accepted
+**Date**: 2026-01-30
+**Context**: The old MCP SDK version had a high-severity vulnerability and obsolete registration API
+**Decision**: Upgrade to `McpServer` and register typed tools through `server.tool()`
+**Consequences**:
+- ✅ Removes the vulnerable dependency version
+- ✅ Establishes the current typed registration surface
+- ⚠️ Tool schemas must be passed as Zod raw shapes
+
+---
+
+### ADR-011: Promote Z-Library to a Source Adapter
+**Status**: 🟡 Proposed
+**Date**: 2026-08-12
+**Context**: Z-Library still bypasses the adapter/router path used by Anna's Archive and LibGen
+**Decision**: Use a capability-based adapter contract with opaque source-scoped references and caller-ordered routing
+**Consequences**:
+- ✅ Removes MD5 and Z-Library EAPI shapes from the common source boundary
+- ✅ Preserves search-result-first, file-return, credential, quota, and source-neutrality invariants
+- ⚠️ Requires staged migration after #106 and #103 settle overlapping error, config, and registration surfaces
+
+**Related**:
+- [ADR-002](ADR-002-Download-Workflow-Redesign.md) - Search-result-first acquisition
+- [ADR-005](ADR-005-EAPI-Migration.md) - Current Z-Library EAPI mechanism
+- [Issue #40](https://github.com/rookslog/zlibrary-mcp/issues/40) - Implementation work
+
+---
+
 ## ADR Status Definitions
 
 | Status | Meaning | Can Be Changed? |
@@ -232,8 +275,8 @@ IF garbled detected (Stage 1 OR custom threshold)
 ## How to Create a New ADR
 
 ### 1. Choose the Next Number
-Current: ADR-008 (latest)
-Next: ADR-009
+Current: ADR-011 (latest)
+Next: ADR-012
 
 ### 2. Use the Template
 ```markdown
@@ -286,23 +329,15 @@ def quality_pipeline():
 ## ADR Topics Covered
 
 - [x] Testing Infrastructure (ADR-001)
-- [x] Z-Library API Integration (ADR-002, ADR-003)
-- [x] Python Bridge (ADR-004)
+- [x] Z-Library API Integration (ADR-002, ADR-003, ADR-005)
+- [x] Python Bridge (ADR-004, ADR-009)
 - [x] RAG Quality Pipeline (ADR-006, ADR-007, ADR-008)
+- [x] MCP SDK and tool registration (ADR-010)
+- [x] Source adapter architecture (ADR-011)
 - [ ] Performance Optimization (future)
 - [ ] Caching Strategy (future)
-- [ ] Error Handling Patterns (future)
+- [x] Error Handling Patterns (ADR-011)
 - [ ] Deployment Architecture (future)
-
----
-
-## Investigation Tasks
-
-**ADR-005 Missing**:
-- [ ] Search git history for deleted ADR-005
-- [ ] Determine if intentionally skipped
-- [ ] Document resolution in this index
-- [ ] If truly missing, use ADR-009 for next decision (don't reuse ADR-005)
 
 ---
 
@@ -317,7 +352,7 @@ def quality_pipeline():
 
 **Metadata**:
 - Created: 2025-10-21
-- Last Updated: 2025-10-21
-- Total ADRs: 7 active + 1 missing (8 total numbers used)
-- Next ADR Number: ADR-009
+- Last Updated: 2026-08-12
+- Total ADRs: 10 accepted + 1 proposed
+- Next ADR Number: ADR-012
 - Maintained by: Project contributors

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,7 +31,7 @@
 
 ---
 
-## All ADRs (Chronological)
+## All ADRs (by ADR number)
 
 ### ADR-001: Jest ESM Migration
 **Status**: 🟡 Proposed
@@ -120,7 +120,7 @@ const scriptPath = getPythonScriptPath('python_bridge.py');
 ---
 
 ### ADR-005: EAPI Migration
-**Status**: ✅ Accepted
+**Status**: ✅ Accepted — download clause superseded by ADR-011
 **Date**: 2026-02-01
 **Context**: Browser verification made the HTML scraping path unusable
 **Decision**: Move Z-Library search, metadata, and domain discovery to JSON EAPI endpoints

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,7 +34,7 @@
 ## All ADRs (Chronological)
 
 ### ADR-001: Jest ESM Migration
-**Status**: ✅ Accepted
+**Status**: 🟡 Proposed
 **Date**: 2024-04-13
 **Context**: Need to test ES modules in Node.js/TypeScript codebase
 **Decision**: Migrate Jest configuration to support ESM with `node --experimental-vm-modules`
@@ -353,6 +353,6 @@ def quality_pipeline():
 **Metadata**:
 - Created: 2025-10-21
 - Last Updated: 2026-08-12
-- Total ADRs: 10 accepted + 1 proposed
+- Total ADRs: 9 accepted + 2 proposed
 - Next ADR Number: ADR-012
 - Maintained by: Project contributors

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -244,7 +244,7 @@ IF garbled detected (Stage 1 OR custom threshold)
 ---
 
 ### ADR-011: Promote Z-Library to a Source Adapter
-**Status**: 🟡 Proposed
+**Status**: ✅ Accepted
 **Date**: 2026-08-12
 **Context**: Z-Library still bypasses the adapter/router path used by Anna's Archive and LibGen
 **Decision**: Use a capability-based adapter contract with opaque source-scoped references and caller-ordered routing
@@ -264,7 +264,7 @@ IF garbled detected (Stage 1 OR custom threshold)
 
 | Status | Meaning | Can Be Changed? |
 |--------|---------|-----------------|
-| ✅ Accepted | Decision made and implemented | No (supersede with new ADR) |
+| ✅ Accepted | Decision made; implementation may be staged separately | No (supersede with new ADR) |
 | 🟡 Proposed | Under discussion | Yes |
 | ❌ Rejected | Decision not adopted | No (keep for historical record) |
 | 🔄 Superseded | Replaced by newer ADR | No (keep for context) |
@@ -352,7 +352,6 @@ def quality_pipeline():
 
 **Metadata**:
 - Created: 2025-10-21
-- Last Updated: 2026-08-12
-- Total ADRs: 9 accepted + 2 proposed
+- Total ADRs: 10 accepted + 1 proposed
 - Next ADR Number: ADR-012
 - Maintained by: Project contributors


### PR DESCRIPTION
## Summary

- proposes ADR-011 for issue #40
- replaces the MD5-shaped common boundary with source-scoped references and capability protocols
- makes fallback caller- or operator-ordered so registration does not become source ranking
- records exact dependencies on PR #106 and sequencing behind issue #103
- repairs the ADR index so ADR-005 and ADRs 009 through 011 are discoverable

## Decision boundary

Documentation only. This PR does not implement the adapter, change runtime behavior, or close #40. Merging accepts the proposed architecture and staging plan.

## Verification

- npm run build: passed, 15 of 15 validation files
- Jest: 178 passed, 12 suites; the worktree exclusion was overridden at the CLI and child-process checks ran outside the sandbox
- pytest: 1074 passed, 7 xfailed, 184 deselected; same 1081 selected outcomes as baseline, with locally available OCR dependencies converting the baseline 3 skips into passes
- npx eslint src/ and npx prettier --check src/: passed
- staged and post-rebase diff checks: passed
- placeholder and stale-term scans: passed

Related: #40, #75, #95, #96, #103, #106, #109.