### PR TITLE
fix(doctor): assert Anna search titles

### DIFF
--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -462,6 +462,28 @@ def test_libgen_download_probe_targets_the_configured_mirror_first(check_upstrea
     )
 
 
+def test_annas_probe_rejects_md5_links_without_an_extracted_title(check_upstream):
+    """An empty cover link is reachable but cannot produce a book result title."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/search"
+        return httpx.Response(
+            200,
+            text='<a href="/md5/deadbeef"><img alt="Cover"></a>',
+        )
+
+    async def probe() -> object:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), follow_redirects=True
+        ) as client:
+            return await check_upstream.probe_annas(client)
+
+    result = asyncio.run(probe())
+
+    assert result.ok is False
+    assert "no non-empty title" in result.detail
+
+
 def test_annas_parking_page_is_reported_as_parked(check_upstream):
     """A parked domain returns HTTP 200 with no /md5/ links; the report must say
     'parked', not just 'no links found', so the operator knows the domain is gone."""

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -484,6 +484,31 @@ def test_annas_probe_rejects_md5_links_without_an_extracted_title(check_upstream
     assert "no non-empty title" in result.detail
 
 
+def test_annas_probe_accepts_and_reports_an_extracted_title(check_upstream):
+    """A text-bearing result proves the field assertion can also succeed."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/search"
+        return httpx.Response(
+            200,
+            text=(
+                '<a href="/md5/deadbeef"><img alt="Cover"></a>'
+                '<a href="/md5/deadbeef"> Critique of Pure Reason </a>'
+            ),
+        )
+
+    async def probe() -> object:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), follow_redirects=True
+        ) as client:
+            return await check_upstream.probe_annas(client)
+
+    result = asyncio.run(probe())
+
+    assert result.ok is True
+    assert result.detail == "search extracted title: 'Critique of Pure Reason'"
+
+
 def test_annas_parking_page_is_reported_as_parked(check_upstream):
     """A parked domain returns HTTP 200 with no /md5/ links; the report must say
     'parked', not just 'no links found', so the operator knows the domain is gone."""

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -30,6 +30,7 @@ from typing import Any, Optional
 from urllib.parse import parse_qs, urljoin, urlsplit
 
 import httpx
+from bs4 import BeautifulSoup
 
 # Import the runtime defaults directly from lib/sources/config.py so the probe
 # cannot drift from what the server actually contacts (it previously hardcoded
@@ -233,16 +234,21 @@ async def probe_zlibrary_eapi(client: httpx.AsyncClient) -> list[ProbeResult]:
 
 
 async def probe_annas(client: httpx.AsyncClient) -> ProbeResult:
-    """Anna's Archive is HTML-scraped, so reachability alone is worth reporting."""
+    """Check that Anna's HTML adapter can extract a search-result title."""
     try:
         resp = await client.get(f"{ANNAS_BASE_URL}/search", params={"q": "philosophy"})
         resp.raise_for_status()
         body = resp.text
-        # The adapter keys off result anchors; their absence means either a layout
-        # change, a block page, or a parked domain.
-        looks_like_results = "/md5/" in body
-        if looks_like_results:
-            detail = "search page contains /md5/ result links"
+        soup = BeautifulSoup(body, "html.parser")
+        # The runtime adapter skips the empty cover anchor and uses the text-bearing
+        # /md5/ anchor as the result title. Probe that extracted field directly.
+        titles = [
+            link.get_text(strip=True)
+            for link in soup.select("a[href^='/md5/']")
+            if link.get_text(strip=True)
+        ]
+        if titles:
+            detail = f"search extracted title: {titles[0]!r}"
         else:
             lower_body = body.lower()
             parked = any(marker in lower_body for marker in PARKING_MARKERS)
@@ -251,12 +257,12 @@ async def probe_annas(client: httpx.AsyncClient) -> ProbeResult:
                 "the configured base URL no longer belongs to Anna's Archive; "
                 "update ANNAS_BASE_URL / lib/sources/config.py"
                 if parked
-                else "reachable but no /md5/ links found "
+                else "reachable but no non-empty title extracted "
                 "(layout change or block page — the HTML adapter will return nothing)"
             )
         return ProbeResult(
             name="annas-archive:search",
-            ok=looks_like_results,
+            ok=bool(titles),
             detail=detail,
             # Anna's is optional: the router falls back to LibGen without a key.
             required=False,


### PR DESCRIPTION
## Summary

- make Anna's upstream probe parse the same `a[href^='/md5/']` result anchors as the runtime adapter
- require at least one non-empty extracted title instead of treating reachability alone as health
- cover both the historical empty-cover-anchor false positive and a successful extracted title

## Verification

- `npm run build` — passed (15/15 bridge/build files)
- `node --experimental-vm-modules node_modules/jest/bin/jest.js` — 178 passed, 12 suites
- `uv run pytest -m "not slow and not integration and not performance" --benchmark-disable -rs` — 1076 passed, 184 deselected, 7 xfailed
- `npx eslint src/` — passed
- `npx prettier --check src/` — passed

The Python count is two above the fully provisioned local master baseline because this branch adds two probe tests. Locally installed OCR dependencies turn the known three baseline skips into passes.

Closes #102.
