### PR TITLE
fix(sources): identifying User-Agent on every LibGen request; canary probes through the production adapter

### DIFF
--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -516,3 +516,51 @@ def test_annas_parking_page_is_reported_as_parked(check_upstream):
     # The markers list is what probe_annas scans the body with; keep them
     # lowercase because the body is lowercased before matching.
     assert all(m == m.lower() for m in check_upstream.PARKING_MARKERS)
+
+
+class TestLibgenSearchProbeUsesProductionAdapter:
+    """The search probe must exercise the production adapter, not a
+    hand-rolled fetch: on 2026-08-17 (#124) a transport-level probe passed
+    (admitted UA, 200, >500 bytes) while production parsed nothing.
+    """
+
+    def _run(self, check_upstream, search_impl):
+        import asyncio
+        from unittest.mock import patch
+
+        async def go():
+            with patch("lib.sources.libgen.LibgenAdapter.search", new=search_impl):
+                async with httpx.AsyncClient(
+                    transport=httpx.MockTransport(lambda request: httpx.Response(500))
+                ) as client:
+                    return await check_upstream.probe_libgen(client)
+
+        return asyncio.run(go())
+
+    def test_parsed_results_report_ok(self, check_upstream):
+        async def fake_search(self, query, **kwargs):
+            return [object(), object()]
+
+        result = self._run(check_upstream, fake_search)
+        assert result.ok is True
+        assert "2 result(s)" in result.detail
+        assert result.required is False
+
+    def test_zero_parsed_results_fail_even_on_http_200(self, check_upstream):
+        """The old byte-count threshold admitted the 639-byte failure stub;
+        zero parsed results for the canary must never report ok."""
+
+        async def fake_search(self, query, **kwargs):
+            return []
+
+        result = self._run(check_upstream, fake_search)
+        assert result.ok is False
+        assert "0 parsed results" in result.detail
+
+    def test_adapter_exception_reports_failure_detail(self, check_upstream):
+        async def fake_search(self, query, **kwargs):
+            raise RuntimeError("no results table (title 'Welcome to nginx!')")
+
+        result = self._run(check_upstream, fake_search)
+        assert result.ok is False
+        assert "Welcome to nginx!" in result.detail

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -359,3 +359,132 @@ class TestLibgenAdapterInterface:
 
         adapter = LibgenAdapter(config)
         await adapter.close()  # Should not raise
+
+
+class TestLibgenAdapterUserAgent:
+    """The mirror UA-blocklists tool defaults (#124): python-requests' and
+    python-httpx's default UAs get the default-nginx stub (HTTP 200, ~640
+    bytes, no results table) while an identifying UA gets the real page.
+    These tests pin the shim that carries the identifying UA into
+    libgen-api-enhanced, which exposes no headers hook of its own.
+    """
+
+    def test_shim_is_installed_in_library_module(self):
+        """libgen_api_enhanced.search_request must resolve `requests` to our shim."""
+        from libgen_api_enhanced import search_request as lge_search_request
+
+        from lib.sources import libgen as libgen_mod
+
+        assert lge_search_request.requests is libgen_mod._search_requests
+
+    def test_shim_get_sends_identifying_user_agent(self, monkeypatch):
+        """Shim .get() must add USER_AGENT (and never the requests default)."""
+        from lib.sources import libgen as libgen_mod
+
+        captured = {}
+
+        def fake_get(url, headers=None, **kwargs):
+            captured["headers"] = headers
+            response = MagicMock()
+            response.status_code = 200
+            response.text = '<table id="tablelibgen"></table>'
+            return response
+
+        monkeypatch.setattr(libgen_mod.requests, "get", fake_get)
+        libgen_mod._search_requests.get("https://libgen.li/index.php")
+
+        assert captured["headers"]["User-Agent"] == libgen_mod.USER_AGENT
+        assert "python-requests" not in captured["headers"]["User-Agent"]
+
+    def test_shim_preserves_caller_supplied_user_agent(self, monkeypatch):
+        """An explicit UA from the library must not be overwritten."""
+        from lib.sources import libgen as libgen_mod
+
+        captured = {}
+
+        def fake_get(url, headers=None, **kwargs):
+            captured["headers"] = headers
+            return MagicMock(status_code=200, text="")
+
+        monkeypatch.setattr(libgen_mod.requests, "get", fake_get)
+        libgen_mod._search_requests.get(
+            "https://libgen.li/index.php", headers={"User-Agent": "custom"}
+        )
+
+        assert captured["headers"]["User-Agent"] == "custom"
+
+
+class TestLibgenAdapterParseFailure:
+    """Empty result vs unparseable page must be distinguishable (#124):
+    a genuinely-empty search still renders the (empty) results table, so a
+    page WITHOUT `tablelibgen` is a parse failure, never "no matches".
+    """
+
+    @pytest.fixture
+    def config(self):
+        return SourceConfig(
+            libgen_mirror="li",
+            default_source="libgen",
+            fallback_enabled=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stub_page_raises_parse_error(self, config):
+        """Zero results + a page without the results table must raise."""
+        from lib.sources import libgen as libgen_mod
+        from lib.sources.libgen import LibgenAdapter, SourceParseError
+
+        adapter = LibgenAdapter(config)
+        stub_page = MagicMock()
+        stub_page.status_code = 200
+        stub_page.text = (
+            "<!DOCTYPE html><html><head><title>Welcome to nginx!</title>"
+            "</head><body><h1>Welcome to nginx!</h1></body></html>"
+        )
+
+        def fake_search_title(query):
+            # Mirror reality: the library fetches through the shim (setting
+            # last_response) and parses no table from the stub.
+            libgen_mod._search_requests.last_response = stub_page
+            return []
+
+        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
+            mock_search_class.return_value.search_title.side_effect = fake_search_title
+            with pytest.raises(SourceParseError) as excinfo:
+                await adapter.search("anything")
+
+        assert "Welcome to nginx!" in str(excinfo.value)
+        assert "no results table" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_empty_table_returns_empty_list(self, config):
+        """Zero results + a page WITH the results table is a real empty result."""
+        from lib.sources import libgen as libgen_mod
+        from lib.sources.libgen import LibgenAdapter
+
+        adapter = LibgenAdapter(config)
+        empty_results_page = MagicMock()
+        empty_results_page.status_code = 200
+        empty_results_page.text = '<html><table id="tablelibgen"></table></html>'
+
+        def fake_search_title(query):
+            libgen_mod._search_requests.last_response = empty_results_page
+            return []
+
+        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
+            mock_search_class.return_value.search_title.side_effect = fake_search_title
+            results = await adapter.search("xqzv nonexistent qqqzzz")
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_no_fetch_recorded_returns_empty_list(self, config):
+        """If no page was fetched (fully mocked library), [] stays []."""
+        from lib.sources.libgen import LibgenAdapter
+
+        adapter = LibgenAdapter(config)
+        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
+            mock_search_class.return_value.search_title.return_value = []
+            results = await adapter.search("anything")
+
+        assert results == []

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -660,3 +660,83 @@ async def test_process_document_pdf_encrypted(
     ):
         await process_document(str(pdf_path), book_id=None, author=None, title=None)
     mock_rag_process_document.assert_called_once()
+
+
+class TestRequiresEapiClient:
+    """EAPI login must happen only where the EAPI is actually used (#129):
+    forcing it on every call took LibGen — the credential-free fallback —
+    down with every Z-Library auth outage.
+    """
+
+    def test_zlibrary_functions_require_eapi(self):
+        from lib import python_bridge
+
+        for fn in ("search", "full_text_search", "get_download_limits"):
+            assert python_bridge._requires_eapi_client(fn, {}) is True
+
+    def test_local_and_multi_source_functions_do_not(self):
+        from lib import python_bridge
+
+        assert python_bridge._requires_eapi_client("process_document", {}) is False
+        assert python_bridge._requires_eapi_client("search_multi_source", {}) is False
+
+    def test_download_of_zlibrary_result_requires_eapi(self):
+        from lib import python_bridge
+
+        args = {"book_details": {"id": "123", "hash": "abc"}}
+        assert python_bridge._requires_eapi_client("download_book", args) is True
+
+    def test_download_of_multi_source_result_does_not(self):
+        from lib import python_bridge
+
+        for source in ("libgen", "annas", "annas_archive", "LIBGEN"):
+            args = {"book_details": {"md5": "f" * 32, "source": source}}
+            assert (
+                python_bridge._requires_eapi_client("download_book", args) is False
+            ), source
+
+    def test_download_with_missing_details_defaults_to_requiring_eapi(self):
+        from lib import python_bridge
+
+        assert python_bridge._requires_eapi_client("download_book", {}) is True
+
+
+class TestLibgenDownloadNeedsNoZlibraryLogin:
+    """A source-routed download must succeed while the EAPI client is
+    unavailable — the exact co-failure observed 2026-08-17 (#129).
+    """
+
+    @pytest.mark.asyncio
+    async def test_download_book_libgen_source_never_touches_eapi(
+        self, tmp_path, monkeypatch
+    ):
+        from lib import python_bridge
+
+        raw = tmp_path / "ffff.download"
+        raw.write_bytes(b"%PDF-1.4 fake body")
+
+        async def fake_fetch(book_details, output_dir):
+            return str(raw)
+
+        async def dead_eapi(*args, **kwargs):
+            raise RuntimeError("EAPI client must not be touched on this path")
+
+        monkeypatch.setattr(python_bridge, "_fetch_from_source", fake_fetch)
+        monkeypatch.setattr(python_bridge, "get_eapi_client", dead_eapi)
+        monkeypatch.setattr(python_bridge, "initialize_eapi_client", dead_eapi)
+
+        result = await python_bridge.download_book(
+            book_details={
+                "md5": "f" * 32,
+                "source": "libgen",
+                "title": "Fake Book",
+                "author": "Nobody",
+                "extension": "pdf",
+            },
+            output_dir=str(tmp_path),
+        )
+
+        assert result["file_path"]
+        from pathlib import Path as _P
+
+        assert _P(result["file_path"]).exists()

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -1090,6 +1090,23 @@ async def search_multi_source(
     }
 
 
+def _requires_eapi_client(function_name: str, args_dict: dict) -> bool:
+    """Whether this invocation needs an authenticated Z-Library EAPI client.
+
+    Local document processing and multi-source search never do. Neither does
+    a download whose bookDetails came from search_multi_source (source in
+    SOURCE_ALIASES): download_book only acquires the EAPI client on its
+    Z-Library branch, and logging in up front took LibGen — the
+    credential-free fallback — down with every Z-Library auth outage (#129).
+    """
+    if function_name in ("process_document", "search_multi_source"):
+        return False
+    if function_name == "download_book":
+        source = str((args_dict.get("book_details") or {}).get("source") or "").lower()
+        return source not in SOURCE_ALIASES
+    return True
+
+
 async def main():
     parser = argparse.ArgumentParser(description="Z-Library Python Bridge")
     parser.add_argument("function_name", help="Name of the function to call")
@@ -1117,8 +1134,9 @@ async def main():
         sys.exit(1)
 
     try:
-        # Initialize EAPI client for all functions except local file processing and multi-source search
-        if function_name not in ["process_document", "search_multi_source"]:
+        # Initialize the EAPI client only where it is actually needed —
+        # see _requires_eapi_client for the routing (#129).
+        if _requires_eapi_client(function_name, args_dict):
             await initialize_eapi_client()
 
         # Standardize 'language' key to 'languages' if present for search functions

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -672,10 +672,21 @@ async def _download_url_to_file(url: str, output_dir: str, md5: str) -> str:
     """
     import httpx
 
+    from lib.sources.libgen import USER_AGENT
+
     Path(output_dir).mkdir(parents=True, exist_ok=True)
     raw_path = Path(output_dir) / f"{md5}.download"
 
-    async with httpx.AsyncClient(timeout=180, follow_redirects=True) as client:
+    # The identifying UA is load-bearing: libgen's hosts serve an HTML stub
+    # to blocklisted tool UAs including python-httpx's default (#124), which
+    # this function's HTML guard then misreads as an expired key — the
+    # adapter verifies the URL with the right UA and the download dies here
+    # with the wrong one.
+    async with httpx.AsyncClient(
+        timeout=180,
+        follow_redirects=True,
+        headers={"User-Agent": USER_AGENT},
+    ) as client:
         async with client.stream("GET", url) as response:
             response.raise_for_status()
 

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -7,11 +7,13 @@ to avoid being blocked.
 
 import asyncio
 import logging
+import re
 import time
 from typing import List, Optional
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import httpx
+import requests
 from bs4 import BeautifulSoup
 
 from .base import SourceAdapter
@@ -20,8 +22,54 @@ from .models import DownloadResult, SourceType, UnifiedBookResult
 
 # CRITICAL: Import is libgen_api_enhanced, NOT libgen_api
 from libgen_api_enhanced import LibgenSearch
+from libgen_api_enhanced import search_request as _lge_search_request
 
 logger = logging.getLogger("zlibrary.sources")
+
+# libgen.li serves its default-nginx stub (HTTP 200, ~640 bytes, no results
+# table) to blocklisted tool User-Agents — python-requests' default, python-httpx's
+# default, and curl among them — while any identifying UA gets the real page
+# (measured 2026-08-17, issue #124). An honest self-identifying UA is admitted,
+# so no browser string is needed. Used by BOTH the search path (via the shim
+# below) and the download path (ads.php serves the same stub to blocked UAs).
+USER_AGENT = "zlibrary-mcp (+https://github.com/rookslog/zlibrary-mcp)"
+
+
+class SourceParseError(Exception):
+    """A source served a page the adapter could not parse.
+
+    Distinct from an empty result: the page did not contain the structure
+    results live in, so reporting "no matches" would be false (#124).
+    """
+
+
+class _RequestsWithUA:
+    """Stand-in for the `requests` module inside libgen-api-enhanced.
+
+    libgen-api-enhanced 1.3 calls the module-level ``requests.get`` with no
+    headers hook, which sends the blocklisted default UA (see USER_AGENT note
+    above). This shim is swapped in for the ``requests`` reference inside its
+    ``search_request`` module: same ``.get``/``.exceptions`` surface, the
+    identifying UA added, and the last search response recorded so
+    ``LibgenAdapter.search`` can tell "no matches" from "served a page with no
+    results table".
+    """
+
+    exceptions = requests.exceptions
+
+    def __init__(self) -> None:
+        self.last_response: Optional[requests.Response] = None
+
+    def get(self, url: str, **kwargs) -> requests.Response:
+        headers = kwargs.pop("headers", None) or {}
+        headers.setdefault("User-Agent", USER_AGENT)
+        response = requests.get(url, headers=headers, **kwargs)
+        self.last_response = response
+        return response
+
+
+_search_requests = _RequestsWithUA()
+_lge_search_request.requests = _search_requests
 
 # Mirrors tried in order when resolving a download. Different mirrors hand off
 # to different CDN nodes (cdn3/cdn4/... .booksdl.lc) and those nodes fail
@@ -77,6 +125,7 @@ class LibgenAdapter(SourceAdapter):
             List of UnifiedBookResult with source=LIBGEN
         """
         await self._rate_limit()
+        _search_requests.last_response = None
 
         def _search_sync():
             s = LibgenSearch(mirror=self.mirror)
@@ -85,6 +134,19 @@ class LibgenAdapter(SourceAdapter):
         results = await asyncio.to_thread(_search_sync)
 
         if not results:
+            # A genuinely-empty search still renders the (empty) results
+            # table (verified 2026-08-17), so a page WITHOUT the table means
+            # the mirror served something else entirely — a UA-block stub or
+            # a layout change — and "no results" would be a false report.
+            page = _search_requests.last_response
+            if page is not None and "tablelibgen" not in page.text:
+                title_match = re.search(r"<title>([^<]*)</title>", page.text, re.I)
+                page_title = title_match.group(1).strip() if title_match else ""
+                raise SourceParseError(
+                    f"LibGen search page had no results table (HTTP "
+                    f"{page.status_code}, {len(page.text)} bytes, title "
+                    f"{page_title!r}) — parse failure, not an empty result"
+                )
             return []
 
         return [
@@ -197,7 +259,14 @@ class LibgenAdapter(SourceAdapter):
         """
         attempts = []
 
-        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+        # The identifying UA matters here too: ads.php serves the same
+        # UA-blocklist stub to python-httpx's default UA (measured
+        # 2026-08-17, #124), which surfaces as "no GET link" on every mirror.
+        async with httpx.AsyncClient(
+            timeout=30,
+            follow_redirects=True,
+            headers={"User-Agent": USER_AGENT},
+        ) as client:
             for mirror in self._mirror_candidates():
                 await self._rate_limit()
                 try:

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -38,6 +38,7 @@ from bs4 import BeautifulSoup
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "zlibrary" / "src"))
 from lib.sources.config import get_source_config  # noqa: E402
+from lib.sources.libgen import USER_AGENT as LIBGEN_PRODUCTION_UA  # noqa: E402
 from zlibrary.eapi import DEFAULT_EAPI_DOMAINS, WALLED_STATUS_CODES  # noqa: E402
 
 TIMEOUT = httpx.Timeout(20.0, connect=10.0)
@@ -277,26 +278,50 @@ async def probe_annas(client: httpx.AsyncClient) -> ProbeResult:
 
 
 async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
-    """LibGen is the router's fallback source; mirrors rotate frequently."""
+    """LibGen is the router's fallback source; mirrors rotate frequently.
+
+    The probe goes through the PRODUCTION adapter, not a hand-rolled fetch.
+    On 2026-08-17 (#124) the mirror served its UA-blocklist stub (default
+    nginx page, HTTP 200, 639 bytes) to the search library's default UA
+    while this script's own UA was admitted — so a transport-level probe
+    reported OK across a fully broken production search path, and the
+    stub's 639 bytes would have passed the old ``> 500`` byte threshold
+    even with the right UA. ``ok`` therefore means "the adapter parsed at
+    least one result for a canary query that cannot plausibly be empty",
+    never a status code or byte count. ``client`` is unused by design: the
+    adapter builds production's own HTTP stack.
+    """
+    from lib.sources.libgen import LibgenAdapter  # noqa: PLC0415
+
+    canary = "Pride and Prejudice"
     try:
-        # The li-family mirrors serve search at /index.php (search.php 404s).
-        resp = await client.get(
-            f"{LIBGEN_BASE_URL}/index.php", params={"req": "python"}
-        )
-        resp.raise_for_status()
-        return ProbeResult(
-            name="libgen:search",
-            ok=resp.status_code == 200 and len(resp.text) > 500,
-            detail=f"HTTP {resp.status_code}, {len(resp.text)} bytes",
-            required=False,
-        )
+        results = await LibgenAdapter(get_source_config()).search(canary)
     except Exception as exc:  # noqa: BLE001
         return ProbeResult(
             name="libgen:search",
             ok=False,
-            detail=f"{type(exc).__name__}: {exc}",
+            detail=f"adapter search failed: {type(exc).__name__}: {exc}",
             required=False,
         )
+    if results:
+        return ProbeResult(
+            name="libgen:search",
+            ok=True,
+            detail=(
+                f"{len(results)} result(s) parsed by the production adapter "
+                f"for canary {canary!r}"
+            ),
+            required=False,
+        )
+    return ProbeResult(
+        name="libgen:search",
+        ok=False,
+        detail=(
+            f"0 parsed results for canary {canary!r} — page had a results "
+            "table but nothing parsed from it (row-markup drift?)"
+        ),
+        required=False,
+    )
 
 
 def _extract_libgen_key(
@@ -348,7 +373,15 @@ async def _probe_libgen_download_mirror(
     base = f"https://libgen.{mirror}"
     ads_url = f"{base}/ads.php"
     try:
-        resp = await client.get(ads_url, params={"md5": LIBGEN_PROBE_MD5})
+        # Present the production adapter's UA, not this script's: the mirror
+        # UA-blocklists tool defaults (#124), so probing with a different
+        # identity than production is exactly the blindness this probe exists
+        # to avoid.
+        resp = await client.get(
+            ads_url,
+            params={"md5": LIBGEN_PROBE_MD5},
+            headers={"User-Agent": LIBGEN_PRODUCTION_UA},
+        )
         blocked = _libgen_block_detail(mirror, resp)
         if blocked:
             return False, blocked, True
@@ -373,7 +406,10 @@ async def _probe_libgen_download_mirror(
         # first 2 KiB is requested — enough to see the magic bytes.
         resp = await client.get(
             get_url,
-            headers={"Range": f"bytes=0-{LIBGEN_PROBE_RANGE_BYTES - 1}"},
+            headers={
+                "Range": f"bytes=0-{LIBGEN_PROBE_RANGE_BYTES - 1}",
+                "User-Agent": LIBGEN_PRODUCTION_UA,
+            },
         )
     except Exception as exc:  # noqa: BLE001
         # A dead CDN node lands here (cdn4.booksdl.lc failed TLS on


### PR DESCRIPTION
Fixes #124.

## What broke

`libgen.li` UA-blocklists known tool User-Agents — `python-requests/*`, `python-httpx/*`, `curl/*`, empty — serving them the default-nginx stub (HTTP 200, 639 bytes, `<title>Welcome to nginx!</title>`, no results table) while admitting any identifying UA, including this repo's own upstream-check UA (measurement matrix in the #124 diagnosis comment). Production sent blocklisted defaults at three sites; the daily canary sent an admitted UA and a `>500` byte threshold the stub satisfied, so it reported OK throughout.

## Changes

- **`lib/sources/libgen.py`** — `USER_AGENT` constant (honest self-identifying string, no browser spoofing); a `_RequestsWithUA` shim swapped in for the `requests` reference inside `libgen_api_enhanced.search_request` (the library has no headers hook); the download client gets the same UA. New `SourceParseError`: a genuinely-empty search still renders the (empty) results table — verified live — so zero results + no `tablelibgen` in the fetched page now raises with page details instead of reporting "no matches".
- **`lib/python_bridge.py::_download_url_to_file`** — same UA on the final CDN fetch. Without it the adapter verifies the URL with the right UA, then the actual download gets the stub and the HTML guard misdiagnoses it as an expired key (observed live before the fix).
- **`scripts/check_upstream.py`** — `libgen:search` probe goes through the production adapter and asserts ≥1 *parsed* result for a canary query ("Pride and Prejudice"); `ok` never again means a status code or byte count. The download probe's two requests present production's UA instead of the script's own, closing the canary-identity gap.
- Tests: shim installation + UA injection + caller-UA preservation; stub-page-raises vs empty-table-returns-empty vs no-fetch-recorded; probe ok/fail/exception paths via mocked adapter.

## Verification

- Full fast pytest suite: 1085 passed, coverage 67.91% (gate 60%).
- Live end-to-end through the running MCP server: `search_multi_source(source=libgen)` returns parsed results with `sources_used: ["libgen"]`; `download_book_to_file` on a LibGen result delivered a verified 238-page PDF (`file` confirms) via `ads.php` → key → `cdn5.booksdl.lc`.
- One pre-existing behavior noted, not changed: `search` is title-only (`search_title`), so author+title queries like "Deleuze Negotiations" legitimately return zero — that empty is now provably distinct from the parse-failure empty.

---

## Second commit: #129 — EAPI init decoupling

Fixes #129 in the same restoration theme: `main()` logged into Z-Library for every function except `process_document`/`search_multi_source`, so `download_book` with a `source: libgen` body — a path that never touches the EAPI client — died at login during the 2026-08-17 EAPI outage, taking the credential-free fallback down with the primary. `_requires_eapi_client()` now routes initialization by function AND (for downloads) by `bookDetails.source`.

**Verification:** routing-matrix unit tests + a pinning test that a `source: libgen` `download_book` succeeds with `initialize_eapi_client`/`get_eapi_client` monkeypatched to raise. Live falsifiable probe: bridge CLI `download_book` with deliberately broken `ZLIBRARY_EMAIL`/`PASSWORD` delivered a real epub, while `get_download_limits` under the same broken credentials still fails at login as it should. Full fast pytest suite: 1091 passed, 67.95% coverage.
