### PR TITLE
fix(canary): bound the adapter-backed search probe and require usable rows

### DIFF
--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -578,7 +578,43 @@ class TestLibgenSearchProbeUsesProductionAdapter:
         self_or_none = self
         result = self._run(check_upstream, fake_search)
         assert result.ok is True
-        assert "1 usable result(s) (md5+title) of 2 parsed" in result.detail
+        assert "1 usable result(s) (32-hex md5 + title) of 2 parsed" in result.detail
+
+    def test_isbn_shaped_md5_is_not_usable(self, check_upstream):
+        """A column-shifted row can put an ISBN or a citation in the md5 slot;
+        the downloader passes it to ads.php?md5= and resolves nothing, so
+        truthiness is not enough — require the 32-hex shape (Codex on #133)."""
+
+        async def fake_search(self, query, **kwargs):
+            return [
+                self_or_none._book(md5="978-0-14-143951-8"),
+                self_or_none._book(md5="Austen, J. (1813). Pride and Prejudice."),
+                self_or_none._book(md5="a" * 31),
+                self_or_none._book(md5="g" * 32),
+                self_or_none._book(md5=" " + "a" * 32 + " "),
+            ]
+
+        self_or_none = self
+        result = self._run(check_upstream, fake_search)
+        assert result.ok is False
+        assert "NONE usable" in result.detail
+
+    def test_blank_title_with_valid_md5_is_not_usable(self, check_upstream):
+        async def fake_search(self, query, **kwargs):
+            return [self_or_none._book(title="   ")]
+
+        self_or_none = self
+        result = self._run(check_upstream, fake_search)
+        assert result.ok is False
+        assert "NONE usable" in result.detail
+
+    def test_uppercase_hex_md5_is_usable(self, check_upstream):
+        async def fake_search(self, query, **kwargs):
+            return [self_or_none._book(md5="ABCDEF0123456789" * 2)]
+
+        self_or_none = self
+        result = self._run(check_upstream, fake_search)
+        assert result.ok is True
 
     def test_canary_carries_its_own_deadline(self, check_upstream):
         """A hung adapter search must fail the probe, not hang the doctor
@@ -608,6 +644,66 @@ class TestLibgenSearchProbeUsesProductionAdapter:
         result = _asyncio.run(go())
         assert result.ok is False
         assert "TimeoutError" in result.detail or "CancelledError" in result.detail
+
+    def test_probe_deadline_covers_the_documented_worst_case(self, check_upstream):
+        """90s cancelled a legitimate three-mirror failover walk, whose
+        documented default worst case is ~165s (Codex on #133)."""
+        from lib.sources.config import get_source_config
+        from lib.sources.libgen import LibgenAdapter
+
+        deadline = check_upstream.libgen_probe_timeout(
+            get_source_config(), LibgenAdapter.MIN_REQUEST_INTERVAL
+        )
+        # 3 mirrors x (2 x 5s preflight phases + 45s total + 2s rate limit)
+        assert deadline >= 165
+        assert deadline == pytest.approx(3 * 57 + check_upstream.LIBGEN_PROBE_MARGIN)
+
+    def test_probe_deadline_follows_operator_tuning(self, check_upstream, monkeypatch):
+        """An operator who raises the per-provider budget must not thereby make
+        the canary cancel searches production would complete."""
+        from lib.sources.config import get_source_config
+
+        monkeypatch.setenv("BOOK_SOURCE_TOTAL_TIMEOUT", "180")
+        monkeypatch.setenv("BOOK_SOURCE_PREFLIGHT_TIMEOUT", "20")
+        deadline = check_upstream.libgen_probe_timeout(get_source_config(), 2.0)
+        assert deadline == pytest.approx(
+            3 * (180 + 2 + 40) + check_upstream.LIBGEN_PROBE_MARGIN
+        )
+
+    def test_probe_passes_the_computed_deadline_to_wait_for(self, check_upstream):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from lib.sources.config import get_source_config
+        from lib.sources.libgen import LibgenAdapter
+
+        captured = {}
+        real_wait_for = asyncio.wait_for
+
+        def spy_wait_for(awaitable, timeout):
+            captured["timeout"] = timeout
+            return real_wait_for(awaitable, timeout=timeout)
+
+        async def fake_search(self, query, **kwargs):
+            return [SimpleNamespace(md5="a" * 32, title="Pride and Prejudice")]
+
+        async def go():
+            with (
+                patch("lib.sources.libgen.LibgenAdapter.search", new=fake_search),
+                patch.object(check_upstream.asyncio, "wait_for", spy_wait_for),
+            ):
+                async with httpx.AsyncClient(
+                    transport=httpx.MockTransport(lambda request: httpx.Response(500))
+                ) as client:
+                    return await check_upstream.probe_libgen(client)
+
+        result = asyncio.run(go())
+        assert result.ok is True
+        assert captured["timeout"] == pytest.approx(
+            check_upstream.libgen_probe_timeout(
+                get_source_config(), LibgenAdapter.MIN_REQUEST_INTERVAL
+            )
+        )
 
     def test_zero_parsed_results_fail_even_on_http_200(self, check_upstream):
         """The old byte-count threshold admitted the 639-byte failure stub;

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -537,14 +537,77 @@ class TestLibgenSearchProbeUsesProductionAdapter:
 
         return asyncio.run(go())
 
+    @staticmethod
+    def _book(md5="a" * 32, title="Pride and Prejudice"):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(md5=md5, title=title)
+
     def test_parsed_results_report_ok(self, check_upstream):
         async def fake_search(self, query, **kwargs):
-            return [object(), object()]
+            return [self_or_none._book(), self_or_none._book(md5="b" * 32)]
 
+        self_or_none = self
         result = self._run(check_upstream, fake_search)
         assert result.ok is True
-        assert "2 result(s)" in result.detail
+        assert "2 usable result(s)" in result.detail
         assert result.required is False
+
+    def test_nonempty_but_unusable_rows_fail(self, check_upstream):
+        """A parser regression that emits rows with empty md5/title (the #132
+        column-shift shape) must not pass the canary (Codex on #128)."""
+
+        async def fake_search(self, query, **kwargs):
+            return [
+                self_or_none._book(md5="", title=""),
+                self_or_none._book(md5="", title="some citation text"),
+            ]
+
+        self_or_none = self
+        result = self._run(check_upstream, fake_search)
+        assert result.ok is False
+        assert "NONE usable" in result.detail
+
+    def test_mixed_rows_count_only_usable(self, check_upstream):
+        async def fake_search(self, query, **kwargs):
+            return [
+                self_or_none._book(),
+                self_or_none._book(md5="", title=""),
+            ]
+
+        self_or_none = self
+        result = self._run(check_upstream, fake_search)
+        assert result.ok is True
+        assert "1 usable result(s) (md5+title) of 2 parsed" in result.detail
+
+    def test_canary_carries_its_own_deadline(self, check_upstream):
+        """A hung adapter search must fail the probe, not hang the doctor
+        (Codex on #128). Patch the probe's timeout down so the test is fast."""
+        import asyncio as _asyncio
+
+        async def hung_search(self, query, **kwargs):
+            await _asyncio.sleep(30)
+
+        real_wait_for = _asyncio.wait_for
+
+        def short_wait_for(awaitable, timeout):
+            return real_wait_for(awaitable, timeout=0.05)
+
+        from unittest.mock import patch
+
+        async def go():
+            with (
+                patch("lib.sources.libgen.LibgenAdapter.search", new=hung_search),
+                patch.object(check_upstream.asyncio, "wait_for", short_wait_for),
+            ):
+                async with httpx.AsyncClient(
+                    transport=httpx.MockTransport(lambda request: httpx.Response(500))
+                ) as client:
+                    return await check_upstream.probe_libgen(client)
+
+        result = _asyncio.run(go())
+        assert result.ok is False
+        assert "TimeoutError" in result.detail or "CancelledError" in result.detail
 
     def test_zero_parsed_results_fail_even_on_http_200(self, check_upstream):
         """The old byte-count threshold admitted the 639-byte failure stub;

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -682,7 +682,7 @@ class TestShimDefaultTimeout:
     mirror that accepts and never responds must not hold the search thread
     forever (Codex on #128)."""
 
-    def test_default_timeout_applied(self, monkeypatch):
+    def _capture(self, monkeypatch):
         from lib.sources import libgen as libgen_mod
 
         captured = {}
@@ -692,8 +692,47 @@ class TestShimDefaultTimeout:
             return MagicMock(status_code=200, text='<table id="tablelibgen"></table>')
 
         monkeypatch.setattr(libgen_mod.requests, "get", fake_get)
+        return libgen_mod, captured
+
+    def test_default_timeout_applied(self, monkeypatch):
+        libgen_mod, captured = self._capture(monkeypatch)
         libgen_mod._search_requests.get("https://libgen.li/index.php")
-        assert captured["timeout"] == 30
+        # (connect, read) from the defaults in lib/sources/config.py
+        assert captured["timeout"] == (10.0, 30.0)
+
+    def test_configured_timeout_respected(self, monkeypatch):
+        """An operator who raises the read budget must actually get it: the
+        hard-coded 30s defeated BOOK_SOURCE_READ_TIMEOUT tuning (Codex #133)."""
+        monkeypatch.setenv("BOOK_SOURCE_CONNECT_TIMEOUT", "20")
+        monkeypatch.setenv("BOOK_SOURCE_READ_TIMEOUT", "120")
+        monkeypatch.setenv("BOOK_SOURCE_TOTAL_TIMEOUT", "200")
+        libgen_mod, captured = self._capture(monkeypatch)
+        libgen_mod._search_requests.get("https://libgen.li/index.php")
+        assert captured["timeout"] == (20.0, 120.0)
+
+    def test_default_never_exceeds_total_budget(self, monkeypatch):
+        """The call runs under run_bounded(config.total_timeout); a per-request
+        budget above that could never be reached."""
+        monkeypatch.setenv("BOOK_SOURCE_READ_TIMEOUT", "300")
+        monkeypatch.setenv("BOOK_SOURCE_CONNECT_TIMEOUT", "300")
+        monkeypatch.setenv("BOOK_SOURCE_TOTAL_TIMEOUT", "12")
+        libgen_mod, captured = self._capture(monkeypatch)
+        libgen_mod._search_requests.get("https://libgen.li/index.php")
+        assert captured["timeout"] == (12.0, 12.0)
+
+    def test_unreadable_config_still_bounds_the_call(self, monkeypatch):
+        """A config fault must degrade to a finite timeout, never to none."""
+        from lib.sources import config as config_mod
+
+        libgen_mod, captured = self._capture(monkeypatch)
+
+        def boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr(config_mod, "get_source_config", boom)
+        libgen_mod._search_requests.get("https://libgen.li/index.php")
+        assert captured["timeout"] == libgen_mod.SHIM_FALLBACK_TIMEOUT
+        assert captured["timeout"] == 30.0
 
     def test_caller_timeout_preserved(self, monkeypatch):
         from lib.sources import libgen as libgen_mod

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -675,3 +675,35 @@ class TestLibgenAdapterParseFailure:
             results = await adapter.search("anything")
 
         assert results == []
+
+
+class TestShimDefaultTimeout:
+    """The shim must default a timeout on library calls that omit one — a
+    mirror that accepts and never responds must not hold the search thread
+    forever (Codex on #128)."""
+
+    def test_default_timeout_applied(self, monkeypatch):
+        from lib.sources import libgen as libgen_mod
+
+        captured = {}
+
+        def fake_get(url, headers=None, **kwargs):
+            captured.update(kwargs)
+            return MagicMock(status_code=200, text='<table id="tablelibgen"></table>')
+
+        monkeypatch.setattr(libgen_mod.requests, "get", fake_get)
+        libgen_mod._search_requests.get("https://libgen.li/index.php")
+        assert captured["timeout"] == 30
+
+    def test_caller_timeout_preserved(self, monkeypatch):
+        from lib.sources import libgen as libgen_mod
+
+        captured = {}
+
+        def fake_get(url, headers=None, **kwargs):
+            captured.update(kwargs)
+            return MagicMock(status_code=200, text="")
+
+        monkeypatch.setattr(libgen_mod.requests, "get", fake_get)
+        libgen_mod._search_requests.get("https://libgen.li/index.php", timeout=5)
+        assert captured["timeout"] == 5

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -87,6 +87,10 @@ class _RequestsWithUA:
     def get(self, url: str, **kwargs) -> requests.Response:
         headers = kwargs.pop("headers", None) or {}
         headers.setdefault("User-Agent", USER_AGENT)
+        # libgen-api-enhanced omits the timeout on some calls; a mirror that
+        # accepts the connection and never responds would otherwise hold the
+        # search thread past every outer budget (Codex on #128).
+        kwargs.setdefault("timeout", 30)
         response = requests.get(url, headers=headers, **kwargs)
         self.last_response = response
         return response

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -52,6 +52,49 @@ PROVIDER = "libgen"
 USER_AGENT = "zlibrary-mcp (+https://github.com/rookslog/zlibrary-mcp)"
 
 
+# Used only when the configuration cannot be read at all. Any real config
+# supplies its own budgets; this exists so a broken environment still gets a
+# finite timeout rather than none (the failure the shim default prevents).
+SHIM_FALLBACK_TIMEOUT = 30.0
+
+
+def _shim_default_timeout():
+    """Default `requests` timeout for library calls that omit one.
+
+    Derived from the same `SourceConfig` the adapter uses, so raising
+    `BOOK_SOURCE_READ_TIMEOUT` / `BOOK_SOURCE_TOTAL_TIMEOUT` for a slow
+    network actually reaches the LibGen search path — a hard-coded 30s
+    silently capped it and defeated supported tuning (Codex on #133).
+
+    Shaped like `net.build_timeout`: a (connect, read) pair with the same two
+    config fields behind it. Both are clamped to `total_timeout`, because the
+    call runs under `run_bounded(..., config.total_timeout)` — a per-request
+    budget above the wall-clock budget could never be reached and would only
+    misreport which deadline fired.
+
+    Returns:
+        (connect, read) seconds, or SHIM_FALLBACK_TIMEOUT if config is unreadable
+    """
+    try:
+        # Imported at call time, not module scope: the value must follow
+        # environment changes (get_source_config is deliberately uncached).
+        from .config import get_source_config  # noqa: PLC0415
+
+        config = get_source_config()
+        total = float(config.total_timeout)
+        return (
+            min(float(config.connect_timeout), total),
+            min(float(config.read_timeout), total),
+        )
+    except Exception:  # noqa: BLE001 - a config fault must not remove the bound
+        logger.warning(
+            "LibGen shim could not read the source config; "
+            "falling back to a %.0fs request timeout",
+            SHIM_FALLBACK_TIMEOUT,
+        )
+        return SHIM_FALLBACK_TIMEOUT
+
+
 class _RequestsWithUA:
     """Stand-in for the `requests` module inside libgen-api-enhanced.
 
@@ -90,7 +133,7 @@ class _RequestsWithUA:
         # libgen-api-enhanced omits the timeout on some calls; a mirror that
         # accepts the connection and never responds would otherwise hold the
         # search thread past every outer budget (Codex on #128).
-        kwargs.setdefault("timeout", 30)
+        kwargs.setdefault("timeout", _shim_default_timeout())
         response = requests.get(url, headers=headers, **kwargs)
         self.last_response = response
         return response

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -38,6 +38,7 @@ from bs4 import BeautifulSoup
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "zlibrary" / "src"))
 from lib.sources.config import get_source_config  # noqa: E402
+from lib.sources.libgen import FALLBACK_MIRRORS as LIBGEN_FALLBACK_MIRRORS  # noqa: E402
 from lib.sources.libgen import USER_AGENT as LIBGEN_PRODUCTION_UA  # noqa: E402
 from zlibrary.eapi import DEFAULT_EAPI_DOMAINS, WALLED_STATUS_CODES  # noqa: E402
 
@@ -277,6 +278,49 @@ async def probe_annas(client: httpx.AsyncClient) -> ProbeResult:
         )
 
 
+# Headroom over the adapter's own worst case. The canary's deadline exists to
+# catch a hang the adapter failed to bound, so it must sit ABOVE every budget
+# the adapter is entitled to spend — otherwise a slow-but-legitimate failover
+# walk is cancelled and reported as LibGen drift (Codex on #133).
+LIBGEN_PROBE_MARGIN = 30.0
+
+# What the downloader actually needs: ads.php?md5= resolves nothing else. A
+# column-shifted row can put an ISBN or a citation in this field, and a
+# truthiness check would call that healthy (Codex on #133; the #132 shape).
+MD5_PATTERN = re.compile(r"[0-9a-fA-F]{32}")
+
+
+def libgen_probe_timeout(config, min_request_interval: float = 0.0) -> float:
+    """Wall clock the production adapter may legitimately spend on one search.
+
+    `LibgenAdapter.search` walks every mirror candidate, and each attempt can
+    cost a two-phase preflight (DNS, then TCP — the budget is per phase), the
+    rate-limit wait, and the full per-provider total budget. Deriving the
+    deadline from the same config the adapter reads means an operator who
+    raises `BOOK_SOURCE_TOTAL_TIMEOUT` does not thereby make the canary
+    cancel searches production would complete.
+
+    Args:
+        config: SourceConfig the adapter will be constructed with
+        min_request_interval: LibgenAdapter.MIN_REQUEST_INTERVAL, per attempt
+
+    Returns:
+        Seconds, worst-case mirror walk plus LIBGEN_PROBE_MARGIN
+    """
+    mirrors = len({config.libgen_mirror, *LIBGEN_FALLBACK_MIRRORS})
+    per_mirror = float(config.total_timeout) + float(min_request_interval)
+    if config.preflight_enabled:
+        per_mirror += 2 * float(config.preflight_timeout)
+    return mirrors * per_mirror + LIBGEN_PROBE_MARGIN
+
+
+def _usable_row(result) -> bool:
+    """Whether a parsed row is one the downloader could actually act on."""
+    return bool((result.title or "").strip()) and bool(
+        MD5_PATTERN.fullmatch(result.md5 or "")
+    )
+
+
 async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
     """LibGen is the router's fallback source; mirrors rotate frequently.
 
@@ -294,12 +338,16 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
     from lib.sources.libgen import LibgenAdapter  # noqa: PLC0415
 
     canary = "Pride and Prejudice"
+    config = get_source_config()
     try:
         # #106's budgets bound the adapter internally, but the canary carries
         # its own deadline too: a canary that can hang has the exact defect
-        # it exists to detect (Codex on #128).
+        # it exists to detect (Codex on #128). The deadline is computed from
+        # the adapter's own configured mirror-walk budget rather than fixed at
+        # 90s, which was below the ~165s default worst case (Codex on #133).
         results = await asyncio.wait_for(
-            LibgenAdapter(get_source_config()).search(canary), timeout=90
+            LibgenAdapter(config).search(canary),
+            timeout=libgen_probe_timeout(config, LibgenAdapter.MIN_REQUEST_INTERVAL),
         )
     except Exception as exc:  # noqa: BLE001
         return ProbeResult(
@@ -310,15 +358,16 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
         )
     # A nonempty list of unusable rows is a parser regression, not a pass:
     # the adapter maps missing fields to empty strings, and a result without
-    # an md5 can never be downloaded (Codex on #128; the article-row
-    # column-shift in #132 is exactly this shape).
-    usable = [r for r in results if r.md5 and r.title]
+    # a resolvable md5 can never be downloaded (Codex on #128; the article-row
+    # column-shift in #132 is exactly this shape). Shape, not truthiness — a
+    # shifted column can carry an ISBN or a citation here and still be truthy.
+    usable = [r for r in results if _usable_row(r)]
     if usable:
         return ProbeResult(
             name="libgen:search",
             ok=True,
             detail=(
-                f"{len(usable)} usable result(s) (md5+title) of "
+                f"{len(usable)} usable result(s) (32-hex md5 + title) of "
                 f"{len(results)} parsed by the production adapter "
                 f"for canary {canary!r}"
             ),
@@ -330,8 +379,8 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
             ok=False,
             detail=(
                 f"{len(results)} parsed result(s) but NONE usable "
-                f"(md5+title both present) for canary {canary!r} — "
-                "row-markup drift"
+                f"(a 32-hex md5 and a nonblank title) for canary "
+                f"{canary!r} — row-markup drift"
             ),
             required=False,
         )

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -295,7 +295,12 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
 
     canary = "Pride and Prejudice"
     try:
-        results = await LibgenAdapter(get_source_config()).search(canary)
+        # #106's budgets bound the adapter internally, but the canary carries
+        # its own deadline too: a canary that can hang has the exact defect
+        # it exists to detect (Codex on #128).
+        results = await asyncio.wait_for(
+            LibgenAdapter(get_source_config()).search(canary), timeout=90
+        )
     except Exception as exc:  # noqa: BLE001
         return ProbeResult(
             name="libgen:search",
@@ -303,13 +308,30 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
             detail=f"adapter search failed: {type(exc).__name__}: {exc}",
             required=False,
         )
-    if results:
+    # A nonempty list of unusable rows is a parser regression, not a pass:
+    # the adapter maps missing fields to empty strings, and a result without
+    # an md5 can never be downloaded (Codex on #128; the article-row
+    # column-shift in #132 is exactly this shape).
+    usable = [r for r in results if r.md5 and r.title]
+    if usable:
         return ProbeResult(
             name="libgen:search",
             ok=True,
             detail=(
-                f"{len(results)} result(s) parsed by the production adapter "
+                f"{len(usable)} usable result(s) (md5+title) of "
+                f"{len(results)} parsed by the production adapter "
                 f"for canary {canary!r}"
+            ),
+            required=False,
+        )
+    if results:
+        return ProbeResult(
+            name="libgen:search",
+            ok=False,
+            detail=(
+                f"{len(results)} parsed result(s) but NONE usable "
+                f"(md5+title both present) for canary {canary!r} — "
+                "row-markup drift"
             ),
             required=False,
         )


### PR DESCRIPTION
Resolves both Codex P2 findings on merged PR #128 ([probe deadline](https://github.com/rookslog/zlibrary-mcp/pull/128#discussion_r1), [usable-row validation](https://github.com/rookslog/zlibrary-mcp/pull/128#discussion_r2)):

1. **Canary deadline**: the shim's `requests.get` now defaults `timeout=30` on library calls that omit one (caller values preserved), and `probe_libgen` wraps the adapter search in `asyncio.wait_for(90)`. #106's budgets bound the production path internally; the canary carries its own belt so `npm run doctor` and the scheduled workflow can never hang on a half-open mirror connection.

2. **Usable-row validation**: the probe now requires ≥1 result with **md5 AND title** rather than a nonempty list — the #132 column-shift emits nonempty-but-undownloadable rows, exactly the parser regression the old truthiness check waved through. Detail reports usable-of-parsed counts; all-unusable fails with a row-markup-drift message.

Tests: default-timeout + caller-timeout-preserved on the shim; ok/fail/mixed/hung canary paths (hung path patched to a fast deadline). Full fast pytest suite green.