### PR TITLE
fix(sources): LibGen search uses search_default; md5-less rows dropped

### DIFF
--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -54,7 +54,7 @@ class TestLibgenAdapterSearch:
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
             mock_instance = MagicMock()
-            mock_instance.search_title.return_value = [mock_book]
+            mock_instance.search_default.return_value = [mock_book]
             mock_search_class.return_value = mock_instance
 
             results = await adapter.search("python")
@@ -78,7 +78,7 @@ class TestLibgenAdapterSearch:
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
             mock_instance = MagicMock()
-            mock_instance.search_title.return_value = []
+            mock_instance.search_default.return_value = []
             mock_search_class.return_value = mock_instance
 
             results = await adapter.search("nonexistent_book_xyz123")
@@ -100,7 +100,7 @@ class TestLibgenAdapterSearch:
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
             mock_instance = MagicMock()
-            mock_instance.search_title.return_value = [mock_book]
+            mock_instance.search_default.return_value = [mock_book]
             mock_search_class.return_value = mock_instance
 
             with patch("lib.sources.libgen.run_bounded") as mock_run_bounded:
@@ -129,7 +129,7 @@ class TestLibgenAdapterSearch:
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
             mock_instance = MagicMock()
-            mock_instance.search_title.return_value = [mock_book]
+            mock_instance.search_default.return_value = [mock_book]
             mock_search_class.return_value = mock_instance
 
             with patch("asyncio.to_thread") as mock_to_thread:
@@ -144,20 +144,22 @@ class TestLibgenAdapterSearch:
 
         adapter = LibgenAdapter(config)
 
-        # Book with minimal attributes
-        minimal_book = MagicMock(spec=[])  # Empty spec means no attributes
-        minimal_book.configure_mock(**{})
+        # Book with only an md5 (an md5-less book is dropped, not defaulted —
+        # see TestMd5lessRowsFiltered); every OTHER missing attribute still
+        # maps to an empty default rather than raising.
+        minimal_book = MagicMock(spec=["md5"])
+        minimal_book.md5 = "a" * 32
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
             mock_instance = MagicMock()
-            mock_instance.search_title.return_value = [minimal_book]
+            mock_instance.search_default.return_value = [minimal_book]
             mock_search_class.return_value = mock_instance
 
             results = await adapter.search("python")
 
             # Should not raise, should use empty defaults
             assert len(results) == 1
-            assert results[0].md5 == ""
+            assert results[0].md5 == "a" * 32
             assert results[0].title == ""
             assert results[0].source == SourceType.LIBGEN
 
@@ -568,7 +570,7 @@ class TestLibgenAdapterRateLimiting:
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
             mock_instance = MagicMock()
-            mock_instance.search_title.return_value = []
+            mock_instance.search_default.return_value = []
             mock_search_class.return_value = mock_instance
 
             with patch("lib.sources.libgen.asyncio.sleep") as mock_sleep:
@@ -712,14 +714,16 @@ class TestLibgenAdapterParseFailure:
         adapter.MIN_REQUEST_INTERVAL = 0
         stub_page = self._stub_page()
 
-        def fake_search_title(query):
+        def fake_search_default(query):
             # Mirror reality: the library fetches through the shim (setting
             # last_response) and parses no table from the stub.
             libgen_mod._search_requests.last_response = stub_page
             return []
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
-            mock_search_class.return_value.search_title.side_effect = fake_search_title
+            mock_search_class.return_value.search_default.side_effect = (
+                fake_search_default
+            )
             with pytest.raises(AllSourcesFailedError) as excinfo:
                 await adapter.search("anything")
 
@@ -755,7 +759,7 @@ class TestLibgenAdapterParseFailure:
         book.title = "Found On The Second Mirror"
 
         def search_for(mirror):
-            def _search_title(query):
+            def _search_default(query):
                 if mirror == "li":
                     libgen_mod._search_requests.last_response = stub_page
                     return []
@@ -763,7 +767,7 @@ class TestLibgenAdapterParseFailure:
                 return [book]
 
             instance = MagicMock()
-            instance.search_title.side_effect = _search_title
+            instance.search_default.side_effect = _search_default
             return instance
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
@@ -784,12 +788,14 @@ class TestLibgenAdapterParseFailure:
         empty_results_page.status_code = 200
         empty_results_page.text = '<html><table id="tablelibgen"></table></html>'
 
-        def fake_search_title(query):
+        def fake_search_default(query):
             libgen_mod._search_requests.last_response = empty_results_page
             return []
 
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
-            mock_search_class.return_value.search_title.side_effect = fake_search_title
+            mock_search_class.return_value.search_default.side_effect = (
+                fake_search_default
+            )
             results = await adapter.search("xqzv nonexistent qqqzzz")
 
         assert results == []
@@ -801,7 +807,7 @@ class TestLibgenAdapterParseFailure:
 
         adapter = LibgenAdapter(config)
         with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
-            mock_search_class.return_value.search_title.return_value = []
+            mock_search_class.return_value.search_default.return_value = []
             results = await adapter.search("anything")
 
         assert results == []
@@ -876,3 +882,51 @@ class TestShimDefaultTimeout:
         monkeypatch.setattr(libgen_mod.requests, "get", fake_get)
         libgen_mod._search_requests.get("https://libgen.li/index.php", timeout=5)
         assert captured["timeout"] == 5
+
+
+class TestMd5lessRowsFiltered:
+    """Column-shifted journal-article rows (#132) arrive with an empty md5
+    and can never be downloaded; _to_unified drops them so #134's wider
+    search_default results stay usable."""
+
+    @pytest.fixture
+    def config(self):
+        return SourceConfig(
+            libgen_mirror="li",
+            default_source="libgen",
+            fallback_enabled=False,
+        )
+
+    @pytest.fixture
+    def mock_book(self):
+        book = MagicMock()
+        book.md5 = "abc123def456"
+        book.title = "Python Programming"
+        book.author = "John Doe"
+        book.year = "2023"
+        book.extension = "pdf"
+        book.size = "5 MB"
+        book.id = "12345"
+        book.language = "English"
+        book.pages = "500"
+        return book
+
+    def test_md5less_rows_dropped_books_kept(self, config, mock_book):
+        from lib.sources.libgen import LibgenAdapter
+
+        shifted = MagicMock()
+        shifted.md5 = ""
+        shifted.title = ""
+        shifted.author = "Journal of X pp.193-224 Some citation aa 62395571"
+        shifted.year = ""
+        shifted.extension = "389 kB"
+        shifted.size = "0"
+        shifted.id = "68653542"
+        shifted.language = "2003"
+        shifted.pages = "English"
+
+        adapter = LibgenAdapter(config)
+        unified = adapter._to_unified([mock_book, shifted])
+
+        assert len(unified) == 1
+        assert unified[0].md5 == mock_book.md5

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -33,7 +33,7 @@ class TestLibgenAdapterSearch:
     def mock_book(self):
         """Create a mock book result from LibgenSearch."""
         book = MagicMock()
-        book.md5 = "abc123def456"
+        book.md5 = "abc123def45600000000000000000000"
         book.title = "Python Programming"
         book.author = "John Doe"
         book.year = "2023"
@@ -60,7 +60,7 @@ class TestLibgenAdapterSearch:
             results = await adapter.search("python")
 
             assert len(results) == 1
-            assert results[0].md5 == "abc123def456"
+            assert results[0].md5 == "abc123def45600000000000000000000"
             assert results[0].title == "Python Programming"
             assert results[0].author == "John Doe"
             assert results[0].source == SourceType.LIBGEN
@@ -755,7 +755,7 @@ class TestLibgenAdapterParseFailure:
         good_page.text = '<html><table id="tablelibgen">...</table></html>'
 
         book = MagicMock()
-        book.md5 = "abc123def456"
+        book.md5 = "abc123def45600000000000000000000"
         book.title = "Found On The Second Mirror"
 
         def search_for(mirror):
@@ -900,7 +900,7 @@ class TestMd5lessRowsFiltered:
     @pytest.fixture
     def mock_book(self):
         book = MagicMock()
-        book.md5 = "abc123def456"
+        book.md5 = "abc123def45600000000000000000000"
         book.title = "Python Programming"
         book.author = "John Doe"
         book.year = "2023"

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -154,7 +154,7 @@ class TestLibgenSearchIsBounded:
             if host == "libgen.li":
                 raise ProviderUnreachableError(provider, host, reason="connect_timeout")
 
-        book = MagicMock(md5="abc", title="Phenomenology", author="Hegel")
+        book = MagicMock(md5="a" * 32, title="Phenomenology", author="Hegel")
 
         with (
             patch("lib.sources.libgen.probe_host", side_effect=_first_mirror_dead),

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -160,7 +160,7 @@ class TestLibgenSearchIsBounded:
             patch("lib.sources.libgen.probe_host", side_effect=_first_mirror_dead),
             patch("lib.sources.libgen.LibgenSearch") as mock_search_class,
         ):
-            mock_search_class.return_value.search_title.return_value = [book]
+            mock_search_class.return_value.search_default.return_value = [book]
             results = await adapter.search("hegel")
 
         assert len(results) == 1
@@ -179,7 +179,7 @@ class TestLibgenSearchIsBounded:
             patch("lib.sources.libgen.probe_host", new=AsyncMock(return_value=None)),
             patch("lib.sources.libgen.LibgenSearch") as mock_search_class,
         ):
-            mock_search_class.return_value.search_title.side_effect = _hang
+            mock_search_class.return_value.search_default.side_effect = _hang
 
             began = time.monotonic()
             with pytest.raises(AllSourcesFailedError) as excinfo:
@@ -198,7 +198,7 @@ class TestLibgenSearchIsBounded:
             patch("lib.sources.libgen.probe_host", new=AsyncMock(return_value=None)),
             patch("lib.sources.libgen.LibgenSearch") as mock_search_class,
         ):
-            mock_search_class.return_value.search_title.return_value = []
+            mock_search_class.return_value.search_default.return_value = []
             assert await adapter.search("nothing matches this") == []
 
 

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -272,7 +272,10 @@ class LibgenAdapter(SourceAdapter):
                 # thread-local precisely so an abandoned earlier attempt
                 # cannot supply it.
                 _search_requests.last_response = None
-                results = LibgenSearch(mirror=mirror).search_title(query)
+                # search_default covers title+author+series+publisher —
+                # search_title made author-bearing queries return nothing
+                # and got swamped on generic titles (#134).
+                results = LibgenSearch(mirror=mirror).search_default(query)
                 return results, _search_requests.last_response
 
             try:
@@ -304,7 +307,17 @@ class LibgenAdapter(SourceAdapter):
         raise AllSourcesFailedError(f"LibGen search for {query!r}", failures)
 
     def _to_unified(self, results) -> List[UnifiedBookResult]:
-        """Convert libgen-api-enhanced books into UnifiedBookResult."""
+        """Convert libgen-api-enhanced books into UnifiedBookResult.
+
+        Rows without an md5 are dropped: journal-article rows come back
+        column-shifted from the parser (empty md5/title, citation text in
+        author — #132) and an md5-less row can never be downloaded. The
+        full per-object-type parse is #132's job; this filter is the
+        minimal slice that keeps #134's wider search results usable.
+        """
+        dropped = sum(1 for book in results if not (getattr(book, "md5", "") or ""))
+        if dropped:
+            logger.debug("LibGen search: dropped %d md5-less row(s)", dropped)
         return [
             UnifiedBookResult(
                 md5=getattr(book, "md5", "") or "",
@@ -327,6 +340,7 @@ class LibgenAdapter(SourceAdapter):
                 },
             )
             for book in results
+            if getattr(book, "md5", "") or ""
         ]
 
     def _mirror_candidates(self) -> List[str]:

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -149,6 +149,10 @@ _lge_search_request.requests = _search_requests
 # a dead CDN node, which is why this list exists rather than a single default.
 FALLBACK_MIRRORS = ("li", "vg", "la")
 
+# A usable search row carries a real md5; anything else (empty, ISBN,
+# citation text from a column-shifted article row) cannot be downloaded.
+_MD5_HEX_RE = re.compile(r"[0-9a-fA-F]{32}")
+
 
 def mirror_host(mirror: str) -> str:
     """Hostname for a mirror suffix, matching what LibgenSearch builds."""
@@ -309,15 +313,25 @@ class LibgenAdapter(SourceAdapter):
     def _to_unified(self, results) -> List[UnifiedBookResult]:
         """Convert libgen-api-enhanced books into UnifiedBookResult.
 
-        Rows without an md5 are dropped: journal-article rows come back
-        column-shifted from the parser (empty md5/title, citation text in
-        author — #132) and an md5-less row can never be downloaded. The
-        full per-object-type parse is #132's job; this filter is the
-        minimal slice that keeps #134's wider search results usable.
+        Rows whose md5 is not a full 32-hex digest are dropped:
+        journal-article rows come back column-shifted from the parser
+        (empty md5, or another column's value — an ISBN, a citation — in
+        the md5 field, #132), and anything short of a real md5 cannot be
+        resolved by ads.php. Same rule as the production canary's
+        usable-row check. The full per-object-type parse is #132's job;
+        this filter is the minimal slice that keeps #134's wider search
+        results usable.
         """
-        dropped = sum(1 for book in results if not (getattr(book, "md5", "") or ""))
+        dropped = sum(
+            1
+            for book in results
+            if not _MD5_HEX_RE.fullmatch(getattr(book, "md5", "") or "")
+        )
         if dropped:
-            logger.debug("LibGen search: dropped %d md5-less row(s)", dropped)
+            logger.debug(
+                "LibGen search: dropped %d row(s) without a valid 32-hex md5",
+                dropped,
+            )
         return [
             UnifiedBookResult(
                 md5=getattr(book, "md5", "") or "",
@@ -340,7 +354,7 @@ class LibgenAdapter(SourceAdapter):
                 },
             )
             for book in results
-            if getattr(book, "md5", "") or ""
+            if _MD5_HEX_RE.fullmatch(getattr(book, "md5", "") or "")
         ]
 
     def _mirror_candidates(self) -> List[str]:


### PR DESCRIPTION
Fixes #134; carries the minimal slice of #132 (md5-less row filter) needed to keep the wider results usable — the full per-object-type parse stays #132.

**Live verification** (bridge CLI, post-fix): "Derrida Paper Machine" → *Paper Machine* (pdf) as first hit; "Deleuze Difference and Repetition" → the Patton translation; "Wittgenstein Philosophical Investigations" → usable rows. All three were dead ends under search_title in tonight's acquisition sweep.

**Tests**: all search mocks moved to search_default; md5-less-row filter pinned (column-shifted article row dropped, real book kept); the missing-attributes test updated to carry an md5 (an md5-less book is now dropped by design, every other missing attribute still defaults). Full fast suite: 1293 passed.