### PR TITLE
fix(sources): browser UA by default for LibGen, and name the block when it happens (#141)

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -91,7 +91,7 @@ keep working. See `docs/api.md` for the full response shapes.
 |--------|---------------|
 | `base.py` | `SourceAdapter` ABC: `search()`, `get_download_url(md5)`, `close()` |
 | `models.py` | `UnifiedBookResult`, `DownloadResult` (shared result shapes) |
-| `config.py` | `SourceConfig` from env (`ANNAS_SECRET_KEY`, `ANNAS_BASE_URL`, `LIBGEN_MIRROR`, `BOOK_SOURCE_DEFAULT`, `BOOK_SOURCE_FALLBACK_ENABLED`) |
+| `config.py` | `SourceConfig` from env (`ANNAS_SECRET_KEY`, `ANNAS_BASE_URL`, `LIBGEN_MIRROR`, `LIBGEN_USER_AGENT`, `BOOK_SOURCE_DEFAULT`, `BOOK_SOURCE_FALLBACK_ENABLED`) |
 | `annas.py` | Anna's Archive adapter — HTML scraping (BeautifulSoup); DOM-fragile surface |
 | `libgen.py` | LibGen adapter (fallback source) |
 | `router.py` | `SourceRouter`: Anna's primary when key configured, LibGen fallback on error/quota exhaustion; source selection `auto`/`annas`/`libgen` |

--- a/.claude/PROJECT_CONTEXT.md
+++ b/.claude/PROJECT_CONTEXT.md
@@ -185,6 +185,10 @@ LOG_LEVEL=silent|error|warn|info|debug   # stderr logging via src/lib/logger.ts
 ANNAS_SECRET_KEY=                # Enables Anna's Archive fast downloads (primary source)
 ANNAS_BASE_URL=                  # Default: https://annas-archive.li
 LIBGEN_MIRROR=                   # Default: li
+LIBGEN_USER_AGENT=               # Default: a desktop Firefox string. LibGen blocklists
+                                 # tool UAs and answers with nginx's ~640-byte default
+                                 # page at HTTP 200 — search and ads.php alike. Override
+                                 # when the blocklist widens again (#141).
 BOOK_SOURCE_DEFAULT=auto         # auto | annas | libgen
 BOOK_SOURCE_FALLBACK_ENABLED=true
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,32 +71,10 @@ because the route is planned. Guardrails for it (#97) are moot rather than defer
 sanctioned rate-limited route ever appears, reopen those rather than restarting.
 _Avoid_: Keyless download (ambiguous — say this instead)
 
-**Browser-resident session**:
-A route where a *real browser on the operator's machine* holds the DDoS-Guard clearance and
-search and download requests are issued from inside it, rate-limited. Nothing is exported to
-a different client, so the binding that defeated the operator-cookie route above does not
-apply. Whether clearance can be held at all is what #142 measures; #143 and #144 are gated
-on its answer.
-
 **Machine-solved challenge**:
 Any route where the *server* defeats the browser verification itself — headless browser,
-fingerprint spoofing.
-
-**Scope reversed 2026-08-23** (operator ruling, recorded in `DECISION_LOG.md`). This entry
-read "permanently out of scope" from 2026-08-11 until then, and #95 carried the same clause
-forward to every successor map. Both are retired for the purpose of reaching Anna's search
-and download. The stated reason is that non-API Anna's access is the project's hardest
-requirement: Anna's aggregates LibGen, Z-Library and IA, and the scholarly editions it
-uniquely carries are the whole reason it is a source.
-
-Read this honestly rather than as a re-scoping: it does defeat an anti-abuse control Anna's
-operates deliberately, and Anna's states its reason plainly — *"browser verification for our
-slow downloads, because otherwise bots and scrapers will abuse them."* What keeps this on the
-right side of that claim is #144's rate limiting, which ships **in the same pass** as any
-bypass rather than after it, bounded to the personal-use scale #95 fixed: 10-15 books
-typical, 30 maximum, per roughly a four-hour reading session. A bypass that shipped without
-those limits would make the politeness claim rhetorical, which is the one outcome this entry
-exists to prevent.
+fingerprint spoofing. Permanently out of scope: it defeats an anti-abuse control Anna's
+operates deliberately.
 _Avoid_: Keyless download, automated download
 
 Note that "keyless" alone should not be used. It has meant both *no API key* (a live

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,10 +71,32 @@ because the route is planned. Guardrails for it (#97) are moot rather than defer
 sanctioned rate-limited route ever appears, reopen those rather than restarting.
 _Avoid_: Keyless download (ambiguous — say this instead)
 
+**Browser-resident session**:
+A route where a *real browser on the operator's machine* holds the DDoS-Guard clearance and
+search and download requests are issued from inside it, rate-limited. Nothing is exported to
+a different client, so the binding that defeated the operator-cookie route above does not
+apply. Whether clearance can be held at all is what #142 measures; #143 and #144 are gated
+on its answer.
+
 **Machine-solved challenge**:
 Any route where the *server* defeats the browser verification itself — headless browser,
-fingerprint spoofing. Permanently out of scope: it defeats an anti-abuse control Anna's
-operates deliberately.
+fingerprint spoofing.
+
+**Scope reversed 2026-08-23** (operator ruling, recorded in `DECISION_LOG.md`). This entry
+read "permanently out of scope" from 2026-08-11 until then, and #95 carried the same clause
+forward to every successor map. Both are retired for the purpose of reaching Anna's search
+and download. The stated reason is that non-API Anna's access is the project's hardest
+requirement: Anna's aggregates LibGen, Z-Library and IA, and the scholarly editions it
+uniquely carries are the whole reason it is a source.
+
+Read this honestly rather than as a re-scoping: it does defeat an anti-abuse control Anna's
+operates deliberately, and Anna's states its reason plainly — *"browser verification for our
+slow downloads, because otherwise bots and scrapers will abuse them."* What keeps this on the
+right side of that claim is #144's rate limiting, which ships **in the same pass** as any
+bypass rather than after it, bounded to the personal-use scale #95 fixed: 10-15 books
+typical, 30 maximum, per roughly a four-hour reading session. A bypass that shipped without
+those limits would make the politeness claim rhetorical, which is the one outcome this entry
+exists to prevent.
 _Avoid_: Keyless download, automated download
 
 Note that "keyless" alone should not be used. It has meant both *no API key* (a live

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -764,3 +764,92 @@ def test_annas_block_does_not_set_the_zlibrary_flag_either(check_upstream):
         ),
     ]
     assert check_upstream.zlibrary_blocked(results) is False
+
+
+class TestLibgenSearchProbeReportsUserAgentBlocks:
+    """A UA-blocked search must read as BLOCK, not as upstream drift.
+
+    Codex on #146: `probe_libgen` caught the adapter's failure as an ordinary
+    optional failure, so one doctor run reported `libgen:search` WARN and
+    `libgen:download` BLOCK for the identical refusal — and the summary counted
+    an optional failure while the message said it was not drift. The two probes
+    have to agree, or the operator has to guess which one is lying.
+    """
+
+    def _run(self, check_upstream, search_impl):
+        import asyncio
+        from unittest.mock import patch
+
+        async def go():
+            with patch("lib.sources.libgen.LibgenAdapter.search", new=search_impl):
+                async with httpx.AsyncClient(
+                    transport=httpx.MockTransport(lambda request: httpx.Response(500))
+                ) as client:
+                    return await check_upstream.probe_libgen(client)
+
+        return asyncio.run(go())
+
+    def test_blocked_failure_sets_blocked_and_reads_as_block(self, check_upstream):
+        from lib.sources.errors import AllSourcesFailedError
+        from lib.sources.libgen import LibgenUserAgentBlocked
+
+        async def blocked(_self, _query, **_kwargs):
+            raise AllSourcesFailedError(
+                "LibGen search",
+                [
+                    LibgenUserAgentBlocked(
+                        "libgen",
+                        "libgen.li",
+                        "search page served nginx's default stub",
+                        reason="protocol_error",
+                    )
+                ],
+            )
+
+        result = self._run(check_upstream, blocked)
+
+        assert result.ok is False
+        assert result.blocked is True
+        assert result.symbol == "BLOCK"
+
+    def test_ordinary_upstream_failure_is_not_reported_as_blocked(self, check_upstream):
+        """The classification must stay narrow or it hides real drift.
+
+        A timeout or a DOM change reported as BLOCK would suppress the drift
+        issue the doctor exists to raise.
+        """
+        from lib.sources.errors import AllSourcesFailedError, ProviderResponseError
+
+        async def drifted(_self, _query, **_kwargs):
+            raise AllSourcesFailedError(
+                "LibGen search",
+                [
+                    ProviderResponseError(
+                        "libgen",
+                        "libgen.li",
+                        "search page had no results table — parse failure",
+                        reason="protocol_error",
+                    )
+                ],
+            )
+
+        result = self._run(check_upstream, drifted)
+
+        assert result.ok is False
+        assert result.blocked is False
+        assert result.symbol == "WARN"
+
+    def test_a_libgen_block_does_not_imply_a_zlibrary_block(self, check_upstream):
+        """`zlibrary_blocked` must stay source-scoped (#141).
+
+        The new `blocked=True` on a LibGen probe would otherwise start
+        triggering the Z-Library block path, which is the exact conflation the
+        scoping fix on this branch removed.
+        """
+        results = [
+            check_upstream.ProbeResult(
+                name="libgen:search", ok=False, detail="UA blocked", blocked=True
+            )
+        ]
+
+        assert check_upstream.zlibrary_blocked(results) is False

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -723,3 +723,44 @@ class TestLibgenSearchProbeUsesProductionAdapter:
         result = self._run(check_upstream, fake_search)
         assert result.ok is False
         assert "Welcome to nginx!" in result.detail
+
+
+def test_libgen_block_does_not_set_the_zlibrary_blocked_flag(check_upstream):
+    """A walled LibGen must not suppress the Z-Library drift report.
+
+    `zlib_blocked` gates whether upstream-check.yml files the Z-Library drift
+    issue. #141 made a LibGen UA block set `blocked=True` too, so an unscoped
+    `any(...)` would silence a genuine Z-Library drift report because a
+    different source was walled (Codex on #146).
+    """
+    results = [
+        check_upstream.ProbeResult(
+            name="libgen:download", ok=False, detail="nginx stub", blocked=True
+        ),
+        check_upstream.ProbeResult(
+            name="zlibrary:eapi/book/search", ok=False, detail="drift", blocked=False
+        ),
+    ]
+    assert check_upstream.zlibrary_blocked(results) is False
+
+
+def test_zlibrary_block_still_sets_the_flag(check_upstream):
+    results = [
+        check_upstream.ProbeResult(
+            name="libgen:search", ok=True, detail="fine", blocked=False
+        ),
+        check_upstream.ProbeResult(
+            name="zlibrary:eapi/info/domains", ok=False, detail="403", blocked=True
+        ),
+    ]
+    assert check_upstream.zlibrary_blocked(results) is True
+
+
+def test_annas_block_does_not_set_the_zlibrary_flag_either(check_upstream):
+    """The scope is Z-Library specifically, not 'any source but LibGen'."""
+    results = [
+        check_upstream.ProbeResult(
+            name="annas-archive:search", ok=False, detail="DDoS-Guard", blocked=True
+        ),
+    ]
+    assert check_upstream.zlibrary_blocked(results) is False

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -853,3 +853,45 @@ class TestLibgenSearchProbeReportsUserAgentBlocks:
         ]
 
         assert check_upstream.zlibrary_blocked(results) is False
+
+    def test_a_mixed_failure_set_is_not_reported_as_blocked(self, check_upstream):
+        """One stubbed mirror plus one real failure is not a wall.
+
+        Codex round 4 on #146: `any()` would have marked the whole probe BLOCK,
+        dropping the genuine transport failure out of the optional-failure
+        count and describing drift as network-level. `probe_libgen_download`
+        requires every mirror to be blocked; the search probe must match, or
+        the doctor contradicts itself in the other direction.
+        """
+        from lib.sources.errors import AllSourcesFailedError, ProviderUnreachableError
+        from lib.sources.libgen import LibgenUserAgentBlocked
+
+        async def mixed(_self, _query, **_kwargs):
+            raise AllSourcesFailedError(
+                "LibGen search",
+                [
+                    LibgenUserAgentBlocked(
+                        "libgen", "libgen.li", "nginx stub", reason="protocol_error"
+                    ),
+                    ProviderUnreachableError(
+                        "libgen", "libgen.vg", "no route", reason="connect_timeout"
+                    ),
+                ],
+            )
+
+        result = self._run(check_upstream, mixed)
+
+        assert result.ok is False
+        assert result.blocked is False
+        assert result.symbol == "WARN"
+
+    def test_an_empty_failure_list_is_not_reported_as_blocked(self, check_upstream):
+        """`all()` over an empty list is True, which would invent a wall."""
+        from lib.sources.errors import AllSourcesFailedError
+
+        async def empty(_self, _query, **_kwargs):
+            raise AllSourcesFailedError("LibGen search", [])
+
+        result = self._run(check_upstream, empty)
+
+        assert result.blocked is False

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -1049,8 +1049,24 @@ class TestLibgenBlockedUserAgent:
         assert _unparseable_search_page(page) is None
 
     @pytest.mark.asyncio
-    async def test_ads_php_stub_is_reported_as_a_blocked_ua(self, adapter, monkeypatch):
-        monkeypatch.setenv("LIBGEN_USER_AGENT", "blocked-agent/1.0")
+    async def test_ads_php_stub_is_reported_as_a_blocked_ua(self, monkeypatch):
+        """The detail names the UA the adapter actually sent.
+
+        Supplied through the adapter's own `SourceConfig` rather than the
+        environment: since #146 an adapter honours the config it was
+        constructed with, so a later env change is deliberately NOT what this
+        request used, and naming the env value would misreport the wire.
+        """
+        from lib.sources.libgen import LibgenAdapter
+
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "not-what-this-adapter-uses/1.0")
+        adapter = LibgenAdapter(
+            SourceConfig(
+                libgen_mirror="li",
+                default_source="libgen",
+                libgen_user_agent="blocked-agent/1.0",
+            )
+        )
         client = MagicMock()
         client.get = AsyncMock(
             return_value=MagicMock(text=self.STUB, raise_for_status=MagicMock())
@@ -1058,6 +1074,7 @@ class TestLibgenBlockedUserAgent:
         key, detail = await adapter._resolve_key(client, "li", MD5)
         assert key is None
         assert "blocked-agent/1.0" in detail
+        assert "not-what-this-adapter-uses/1.0" not in detail
         assert "blocklisted" in detail
         assert "DOM drift" not in detail
 
@@ -1091,3 +1108,129 @@ class TestLibgenBlockedUserAgent:
         key, detail = await adapter._resolve_key(client, "li", MD5)
         assert key == "ABC123"
         assert detail == ""
+
+
+class TestUserAgentReachesEveryRequest:
+    """The override must apply to every LibGen request, not most of them.
+
+    Codex on #146 found the first cut honoured `LIBGEN_USER_AGENT` on search
+    and key resolution while the actual file transfer still sent the
+    compiled-in default. An override that covers every request except the one
+    that moves the file is worse than none: the operator sets it, search
+    starts working, and downloads keep failing for a reason the config appears
+    to have addressed.
+    """
+
+    CUSTOM = "custom-agent/9.9"
+
+    def test_supplied_config_wins_over_the_environment(self, monkeypatch):
+        """An adapter's own SourceConfig is not overridden by ambient env."""
+        from lib.sources.libgen import get_user_agent
+
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "env-agent/1.0")
+        assert (
+            get_user_agent(SourceConfig(libgen_user_agent=self.CUSTOM)) == self.CUSTOM
+        )
+
+    def test_blank_config_value_falls_back_rather_than_sending_nothing(self):
+        from lib.sources.config import DEFAULT_LIBGEN_USER_AGENT
+        from lib.sources.libgen import get_user_agent
+
+        assert (
+            get_user_agent(SourceConfig(libgen_user_agent=""))
+            == DEFAULT_LIBGEN_USER_AGENT
+        )
+
+    def test_no_config_still_reads_the_environment(self, monkeypatch):
+        """The module-level search shim has no config and must keep working."""
+        from lib.sources.libgen import get_user_agent
+
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "env-agent/1.0")
+        assert get_user_agent() == "env-agent/1.0"
+
+    def test_search_sends_the_adapters_own_configured_agent(self, monkeypatch):
+        """The shim is a module singleton; the adapter's UA must still reach it."""
+        import lib.sources.libgen as libgen_mod
+
+        seen = {}
+
+        def fake_get(url, headers=None, **kwargs):
+            seen["ua"] = (headers or {}).get("User-Agent")
+
+            class _Resp:
+                status_code = 200
+                text = "<html><table class='tablelibgen'></table></html>"
+
+            return _Resp()
+
+        monkeypatch.setattr(libgen_mod.requests, "get", fake_get)
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "env-agent/1.0")
+
+        adapter = libgen_mod.LibgenAdapter(
+            SourceConfig(libgen_mirror="li", libgen_user_agent=self.CUSTOM)
+        )
+        libgen_mod._search_requests.user_agent = libgen_mod.get_user_agent(
+            adapter.config
+        )
+        libgen_mod._search_requests.get("https://libgen.li/index.php")
+
+        assert seen["ua"] == self.CUSTOM, (
+            "the adapter's configured UA must reach the search shim, "
+            "not the ambient environment"
+        )
+
+    def test_shim_falls_back_to_env_when_no_agent_was_set(self, monkeypatch):
+        import lib.sources.libgen as libgen_mod
+
+        seen = {}
+
+        def fake_get(url, headers=None, **kwargs):
+            seen["ua"] = (headers or {}).get("User-Agent")
+
+            class _Resp:
+                status_code = 200
+                text = ""
+
+            return _Resp()
+
+        monkeypatch.setattr(libgen_mod.requests, "get", fake_get)
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "env-agent/1.0")
+        libgen_mod._search_requests.user_agent = None
+        libgen_mod._search_requests.get("https://libgen.li/index.php")
+
+        assert seen["ua"] == "env-agent/1.0"
+
+
+class TestNginxStubMatchesTitleOnly:
+    """A real record mentioning nginx is not a block.
+
+    The classifier's own docstring said "matched on the title"; the first cut
+    matched the whole body. A LibGen record whose title or description carries
+    the phrase would have had its perfectly good GET anchor discarded and been
+    reported to the operator as a blocked UA (Codex on #146).
+    """
+
+    def test_real_page_mentioning_nginx_in_content_is_not_a_stub(self):
+        from lib.sources.libgen import _nginx_stub
+
+        page = (
+            "<html><head><title>Nginx HTTP Server - Third Edition</title></head>"
+            "<body><p>Welcome to nginx! and other greetings, chapter 2</p>"
+            "<a href='/get.php?md5=abc&key=K'>GET</a></body></html>"
+        )
+        assert _nginx_stub(page) is False
+
+    def test_actual_stub_is_still_recognised(self):
+        from lib.sources.libgen import _nginx_stub
+
+        assert (
+            _nginx_stub(
+                "<html><head><title>Welcome to nginx!</title></head><body></body></html>"
+            )
+            is True
+        )
+
+    def test_title_match_is_case_insensitive_and_length_independent(self):
+        from lib.sources.libgen import _nginx_stub
+
+        assert _nginx_stub("<TITLE>WELCOME TO NGINX!</TITLE>" + "x" * 50_000) is True

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -1234,3 +1234,129 @@ class TestNginxStubMatchesTitleOnly:
         from lib.sources.libgen import _nginx_stub
 
         assert _nginx_stub("<TITLE>WELCOME TO NGINX!</TITLE>" + "x" * 50_000) is True
+
+
+class TestBlankConfiguredUserAgentFallsBack:
+    """A whitespace-only injected UA must not reach the wire.
+
+    Codex on #146: `get_source_config()` strips `LIBGEN_USER_AGENT` before
+    storing it, so the environment path already treated "   " as absent. A
+    caller constructing `SourceConfig` directly bypassed that strip, and the
+    truthiness test then let whitespace through as a valid header — earning the
+    nginx stub, which is the exact failure the override exists to escape, while
+    the configuration looked like it had addressed it.
+    """
+
+    def test_whitespace_only_config_value_yields_the_default(self):
+        from lib.sources.config import DEFAULT_LIBGEN_USER_AGENT, SourceConfig
+        from lib.sources.libgen import get_user_agent
+
+        blank = SourceConfig(libgen_user_agent="   ")
+
+        assert get_user_agent(blank) == DEFAULT_LIBGEN_USER_AGENT
+
+    def test_a_real_value_is_still_stripped_not_discarded(self):
+        from lib.sources.config import SourceConfig
+        from lib.sources.libgen import get_user_agent
+
+        padded = SourceConfig(libgen_user_agent="  operator/9.9  ")
+
+        assert get_user_agent(padded) == "operator/9.9"
+
+    def test_whitespace_only_environment_value_yields_the_default(self, monkeypatch):
+        from lib.sources.config import DEFAULT_LIBGEN_USER_AGENT
+        from lib.sources.libgen import get_user_agent
+
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "   ")
+
+        assert get_user_agent() == DEFAULT_LIBGEN_USER_AGENT
+
+
+class TestSearchUserAgentBlockIsTyped:
+    """A UA-blocked search must be distinguishable by type, not by message.
+
+    Codex on #146: the doctor catches the search adapter's failure as an
+    ordinary optional failure, so a refusal every mirror served came back as
+    WARN from `libgen:search` while `libgen:download` reported BLOCK on the
+    identical refusal in the same run. Sniffing the message across that
+    boundary is not a contract; a type is.
+    """
+
+    @pytest.fixture
+    def config(self):
+        return SourceConfig(
+            libgen_mirror="li", default_source="libgen", fallback_enabled=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_nginx_stub_raises_the_blocked_subclass(self, config):
+        from lib.sources import libgen as libgen_mod
+        from lib.sources.libgen import LibgenAdapter
+
+        adapter = LibgenAdapter(config)
+        adapter.MIN_REQUEST_INTERVAL = 0
+        stub_page = MagicMock()
+        stub_page.status_code = 200
+        stub_page.text = STUB_PAGE_HTML
+
+        def fake_search_default(query):
+            libgen_mod._search_requests.last_response = stub_page
+            return []
+
+        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
+            mock_search_class.return_value.search_default.side_effect = (
+                fake_search_default
+            )
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await adapter.search("anything")
+
+        assert excinfo.value.failures, "the stub must be recorded as a failure"
+        assert all(
+            isinstance(f, libgen_mod.LibgenUserAgentBlocked)
+            for f in excinfo.value.failures
+        ), (
+            "a stub-serving mirror must produce LibgenUserAgentBlocked; the "
+            "doctor has no other way to tell a UA block from upstream drift"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_layout_change_does_not_claim_a_ua_block(self, config):
+        """The subclass must be narrow, or it becomes a second false diagnosis.
+
+        A page that simply lost its results table is DOM drift, and calling it
+        a UA block would send an operator to change LIBGEN_USER_AGENT for a
+        problem no header can fix.
+        """
+        from lib.sources import libgen as libgen_mod
+        from lib.sources.libgen import LibgenAdapter
+
+        adapter = LibgenAdapter(config)
+        adapter.MIN_REQUEST_INTERVAL = 0
+        redesigned = MagicMock()
+        redesigned.status_code = 200
+        redesigned.text = "<html><title>Library Genesis</title><main></main></html>"
+
+        def fake_search_default(query):
+            libgen_mod._search_requests.last_response = redesigned
+            return []
+
+        with patch("lib.sources.libgen.LibgenSearch") as mock_search_class:
+            mock_search_class.return_value.search_default.side_effect = (
+                fake_search_default
+            )
+            with pytest.raises(AllSourcesFailedError) as excinfo:
+                await adapter.search("anything")
+
+        assert not any(
+            isinstance(f, libgen_mod.LibgenUserAgentBlocked)
+            for f in excinfo.value.failures
+        )
+
+    def test_the_blocked_subclass_is_still_a_provider_response_error(self):
+        from lib.sources.errors import ProviderResponseError
+        from lib.sources.libgen import LibgenUserAgentBlocked
+
+        assert issubclass(LibgenUserAgentBlocked, ProviderResponseError), (
+            "existing handlers catch ProviderResponseError; narrowing the "
+            "hierarchy here would silently change failover behaviour"
+        )

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -542,7 +542,9 @@ class TestLibgenAdapterDownload:
         with (
             patch.object(adapter, "_preflight", new=AsyncMock(return_value=None)),
             patch.object(adapter, "_rate_limit", new=AsyncMock(return_value=None)),
-            patch.object(adapter, "_resolve_key", new=AsyncMock(return_value="KEY")),
+            patch.object(
+                adapter, "_resolve_key", new=AsyncMock(return_value=("KEY", ""))
+            ),
             patch.object(adapter, "_serves_bytes", side_effect=trickle),
         ):
             with pytest.raises(AllSourcesFailedError, match="every source"):
@@ -708,7 +710,7 @@ class TestLibgenAdapterParseFailure:
         """Zero results + no results table anywhere must raise, not return []."""
         from lib.sources import libgen as libgen_mod
         from lib.sources.errors import ProviderResponseError
-        from lib.sources.libgen import LibgenAdapter
+        from lib.sources.libgen import LibgenAdapter, get_user_agent
 
         adapter = LibgenAdapter(config)
         adapter.MIN_REQUEST_INTERVAL = 0
@@ -729,9 +731,17 @@ class TestLibgenAdapterParseFailure:
 
         # #124's message content survives the fold: title, status, byte count.
         assert "Welcome to nginx!" in str(excinfo.value)
-        assert "no results table" in str(excinfo.value)
         assert f"{len(STUB_PAGE_HTML)} bytes" in str(excinfo.value)
         assert "HTTP 200" in str(excinfo.value)
+
+        # #141 sharpened the diagnosis rather than restating it. "no results
+        # table" was true of the stub but described the symptom; the message
+        # must now name the blocklisted UA and rule out the two wrong readings
+        # a sweep actually made — that LibGen was down, or lacked the books.
+        assert "blocklisted" in str(excinfo.value)
+        assert "NOT an outage" in str(excinfo.value)
+        assert "LIBGEN_USER_AGENT" in str(excinfo.value)
+        assert get_user_agent() in str(excinfo.value)
 
         failures = excinfo.value.failures
         assert failures, "the stub must be recorded as a typed failure"
@@ -930,3 +940,154 @@ class TestMd5lessRowsFiltered:
 
         assert len(unified) == 1
         assert unified[0].md5 == mock_book.md5
+
+
+class TestLibgenBlockedUserAgent:
+    """A blocklisted UA must be named, never reported as drift or emptiness.
+
+    LibGen refuses a blocklisted User-Agent with HTTP 200 and nginx's default
+    page. That is the same shape as an empty catalogue on the search path and
+    the same shape as markup drift on the download path, so without explicit
+    classification the operator is told the wrong thing twice. #141 records
+    what that cost: a sweep read "no results table" as LibGen being down and
+    concluded the catalogue lacked books it in fact had.
+    """
+
+    STUB = (
+        "<html><head><title>Welcome to nginx!</title></head>"
+        "<body><h1>Welcome to nginx!</h1></body></html>"
+    )
+
+    @pytest.fixture
+    def adapter(self):
+        from lib.sources.libgen import LibgenAdapter
+
+        return LibgenAdapter(SourceConfig(libgen_mirror="li", default_source="libgen"))
+
+    def test_user_agent_defaults_to_the_admitted_browser_string(self, monkeypatch):
+        from lib.sources.config import DEFAULT_LIBGEN_USER_AGENT
+        from lib.sources.libgen import (
+            get_user_agent,
+        )
+
+        monkeypatch.delenv("LIBGEN_USER_AGENT", raising=False)
+        assert get_user_agent() == DEFAULT_LIBGEN_USER_AGENT
+
+    def test_user_agent_honours_the_operator_override(self, monkeypatch):
+        from lib.sources.libgen import (
+            get_user_agent,
+        )
+
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "my-crawler/2.0")
+        assert get_user_agent() == "my-crawler/2.0"
+
+    def test_blank_override_falls_back_rather_than_sending_nothing(self, monkeypatch):
+        """An empty env var must not become an empty UA header."""
+        from lib.sources.config import DEFAULT_LIBGEN_USER_AGENT
+        from lib.sources.libgen import (
+            get_user_agent,
+        )
+
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "   ")
+        assert get_user_agent() == DEFAULT_LIBGEN_USER_AGENT
+
+    def test_override_is_read_per_request_not_pinned_at_import(self, monkeypatch):
+        """The override exists to answer the next widening without a release."""
+        from lib.sources.libgen import (
+            get_user_agent,
+        )
+
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "first/1.0")
+        assert get_user_agent() == "first/1.0"
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "second/2.0")
+        assert get_user_agent() == "second/2.0"
+
+    def test_nginx_stub_recognised_regardless_of_length(self):
+        """Matched on the title: byte count is incidental and vhost-specific."""
+        from lib.sources.libgen import (
+            _nginx_stub,
+        )
+
+        assert _nginx_stub(self.STUB)
+        assert _nginx_stub(self.STUB + "x" * 5000)
+        assert not _nginx_stub("<html><title>Library Genesis</title></html>")
+
+    def test_search_stub_is_reported_as_a_blocked_ua(self, monkeypatch):
+        from lib.sources.libgen import (
+            _unparseable_search_page,
+        )
+
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "blocked-agent/1.0")
+        page = MagicMock(text=self.STUB, status_code=200)
+        detail = _unparseable_search_page(page)
+        assert "blocked-agent/1.0" in detail
+        assert "blocklisted" in detail
+        assert "NOT an outage" in detail
+        assert "LIBGEN_USER_AGENT" in detail
+
+    def test_search_non_stub_parse_failure_keeps_its_own_wording(self):
+        """A redesign is not a block; the two must stay distinguishable."""
+        from lib.sources.libgen import (
+            _unparseable_search_page,
+        )
+
+        page = MagicMock(
+            text="<html><title>Library Genesis</title><body>redesigned</body></html>",
+            status_code=200,
+        )
+        detail = _unparseable_search_page(page)
+        assert "parse failure, not an empty result" in detail
+        assert "blocklisted" not in detail
+
+    def test_genuinely_empty_search_is_not_a_failure(self):
+        """An empty catalogue hit still renders the table, and must pass through."""
+        from lib.sources.libgen import (
+            _unparseable_search_page,
+        )
+
+        page = MagicMock(text="<table id='tablelibgen'></table>", status_code=200)
+        assert _unparseable_search_page(page) is None
+
+    @pytest.mark.asyncio
+    async def test_ads_php_stub_is_reported_as_a_blocked_ua(self, adapter, monkeypatch):
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "blocked-agent/1.0")
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=MagicMock(text=self.STUB, raise_for_status=MagicMock())
+        )
+        key, detail = await adapter._resolve_key(client, "li", MD5)
+        assert key is None
+        assert "blocked-agent/1.0" in detail
+        assert "blocklisted" in detail
+        assert "DOM drift" not in detail
+
+    @pytest.mark.asyncio
+    async def test_ads_php_without_anchor_still_reports_dom_drift(self, adapter):
+        """Real markup drift must not be relabelled as a UA block."""
+
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=MagicMock(
+                text="<html><title>Library Genesis</title><a href='/x'>Other</a></html>",
+                raise_for_status=MagicMock(),
+            )
+        )
+        key, detail = await adapter._resolve_key(client, "li", MD5)
+        assert key is None
+        assert "DOM drift" in detail
+        assert "blocklisted" not in detail
+
+    @pytest.mark.asyncio
+    async def test_ads_php_with_key_returns_it(self, adapter):
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=MagicMock(
+                text=(
+                    "<html><a href='get.php?md5=" + MD5 + "&key=ABC123'>GET</a></html>"
+                ),
+                raise_for_status=MagicMock(),
+            )
+        )
+        key, detail = await adapter._resolve_key(client, "li", MD5)
+        assert key == "ABC123"
+        assert detail == ""

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -1,6 +1,7 @@
 # Tests for lib/python_bridge.py (EAPI-based)
 
 import json
+import dataclasses
 import hashlib
 import pytest
 import os
@@ -2585,3 +2586,70 @@ class TestDownloadHonoursTheLibgenUserAgentOverride:
             "the transfer must use the operator's override; sending the "
             "compiled-in default here is the failure #146 caught"
         )
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_config_wins_over_the_ambient_one(
+        self, tmp_path, mocker, monkeypatch
+    ):
+        """A router built with an injected config must not be second-guessed.
+
+        Codex round 2 on #146: the caller resolves a router (which carries its
+        own `config`, possibly injected or cached) and this function then
+        called `get_source_config()` again. Two config objects, one of which
+        moves the file — the same split the UA fix was meant to close.
+        """
+        import httpx
+
+        from lib import python_bridge
+        from lib.sources.config import get_source_config
+
+        body = b"%PDF-1.6" + b"\x00" * 2040
+        digest = hashlib.md5(body).hexdigest()
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "ambient-should-lose/1.0")
+
+        injected = dataclasses.replace(
+            get_source_config(), libgen_user_agent="injected-should-win/3.0"
+        )
+        seen = {}
+
+        class Response:
+            url = httpx.URL("https://mirror.example/get")
+            headers = {}
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self, _chunk_size):
+                yield body
+
+        class Stream:
+            async def __aenter__(self):
+                return Response()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class Client:
+            def __init__(self, **kwargs):
+                seen["headers"] = kwargs.get("headers") or {}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def stream(self, *_args):
+                return Stream()
+
+        mocker.patch("httpx.AsyncClient", Client)
+
+        await python_bridge._download_url_to_file(
+            "https://mirror.example/get",
+            str(tmp_path),
+            digest,
+            "libgen",
+            config=injected,
+        )
+
+        assert seen["headers"].get("User-Agent") == "injected-should-win/3.0"

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -2653,3 +2653,69 @@ class TestDownloadHonoursTheLibgenUserAgentOverride:
         )
 
         assert seen["headers"].get("User-Agent") == "injected-should-win/3.0"
+
+    @pytest.mark.asyncio
+    async def test_the_libgen_override_does_not_leak_to_other_providers(
+        self, tmp_path, mocker, monkeypatch
+    ):
+        """`LIBGEN_USER_AGENT` is scoped to LibGen, and this function is not.
+
+        Codex round 3 on #146: an operator sets this variable to satisfy one
+        provider's blocklist. Sending that string to Anna's host changes an
+        unrelated transfer's behaviour and hands a custom identifying value to
+        a provider that never asked for it — and `auto` routing means the
+        operator does not choose which host receives it.
+        """
+        import httpx
+
+        from lib import python_bridge
+        from lib.sources.config import DEFAULT_BROWSER_USER_AGENT
+
+        body = b"%PDF-1.6" + b"\x00" * 2040
+        digest = hashlib.md5(body).hexdigest()
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "libgen-only/4.0")
+
+        seen = {}
+
+        class Response:
+            url = httpx.URL("https://annas.example/get")
+            headers = {}
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self, _chunk_size):
+                yield body
+
+        class Stream:
+            async def __aenter__(self):
+                return Response()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class Client:
+            def __init__(self, **kwargs):
+                seen["headers"] = kwargs.get("headers") or {}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def stream(self, *_args):
+                return Stream()
+
+        mocker.patch("httpx.AsyncClient", Client)
+
+        await python_bridge._download_url_to_file(
+            "https://annas.example/get", str(tmp_path), digest, "annas"
+        )
+
+        sent = seen["headers"].get("User-Agent")
+        assert sent == DEFAULT_BROWSER_USER_AGENT
+        assert sent != "libgen-only/4.0", (
+            "a LibGen-scoped override reaching Anna's is both a behaviour "
+            "change on an unrelated transfer and an identifier leak"
+        )

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -1453,9 +1453,7 @@ class TestDownloadBook:
         file_path.write_bytes(content)
 
         mock_eapi_download.download_file.return_value = str(file_path)
-        mocker.patch(
-            "python_bridge.create_unified_filename", return_value=filename
-        )
+        mocker.patch("python_bridge.create_unified_filename", return_value=filename)
 
         result = await download_book(
             book_details={
@@ -2520,3 +2518,70 @@ class TestLibgenDownloadNeedsNoZlibraryLogin:
         from pathlib import Path as _P
 
         assert _P(result["file_path"]).exists()
+
+
+class TestDownloadHonoursTheLibgenUserAgentOverride:
+    """The file transfer must send the configured UA, not the compiled default.
+
+    Codex on #146: search and key resolution honoured `LIBGEN_USER_AGENT`
+    while this function imported the module-level constant, so an operator who
+    set the override to escape a widened blocklist would see search recover and
+    downloads keep failing — with the config appearing to have addressed it.
+    LibGen serves blocked UAs an HTML stub at HTTP 200, which the guard here
+    then misreads as an expired key, so the symptom points away from the cause.
+    """
+
+    @pytest.mark.asyncio
+    async def test_configured_user_agent_reaches_the_transfer(
+        self, tmp_path, mocker, monkeypatch
+    ):
+        import httpx
+
+        from lib import python_bridge
+
+        body = b"%PDF-1.6" + b"\x00" * 2040
+        digest = hashlib.md5(body).hexdigest()
+        monkeypatch.setenv("LIBGEN_USER_AGENT", "operator-chosen/2.0")
+
+        seen = {}
+
+        class Response:
+            url = httpx.URL("https://mirror.example/get")
+            headers = {}
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self, _chunk_size):
+                yield body
+
+        class Stream:
+            async def __aenter__(self):
+                return Response()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class Client:
+            def __init__(self, **kwargs):
+                seen["headers"] = kwargs.get("headers") or {}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def stream(self, *_args):
+                return Stream()
+
+        mocker.patch("httpx.AsyncClient", Client)
+
+        await python_bridge._download_url_to_file(
+            "https://mirror.example/get", str(tmp_path), digest, "libgen"
+        )
+
+        assert seen["headers"].get("User-Agent") == "operator-chosen/2.0", (
+            "the transfer must use the operator's override; sending the "
+            "compiled-in default here is the failure #146 caught"
+        )

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -923,6 +923,7 @@ async def _download_url_to_file(
     """
     import httpx
 
+    from lib.sources.config import DEFAULT_BROWSER_USER_AGENT
     from lib.sources.libgen import get_user_agent
 
     expected_md5 = md5.strip().lower()
@@ -936,6 +937,18 @@ async def _download_url_to_file(
     )
     os.close(descriptor)
     attempt_path = Path(attempt_name)
+
+    # LIBGEN_USER_AGENT is scoped to LibGen. This function is source-agnostic,
+    # so sending an operator's LibGen-specific string to Anna's host would both
+    # change an unrelated transfer's behaviour and hand a custom identifying
+    # string to a provider that never asked for it (Codex on #146). Other
+    # sources get the neutral browser default, which is what they sent before
+    # the override existed.
+    user_agent = (
+        get_user_agent(config)
+        if str(provider).lower() == "libgen"
+        else DEFAULT_BROWSER_USER_AGENT
+    )
 
     original_host = (urlsplit(url).hostname or "").lower()
     active_host = original_host
@@ -961,7 +974,7 @@ async def _download_url_to_file(
             async with httpx.AsyncClient(
                 timeout=build_timeout(config),
                 follow_redirects=True,
-                headers={"User-Agent": get_user_agent(config)},
+                headers={"User-Agent": user_agent},
             ) as client:
                 async with client.stream("GET", url) as response:
                     response_url = getattr(response, "url", None)

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -6,6 +6,7 @@ import hashlib
 import re
 import tempfile
 import traceback
+from typing import Optional
 from email.message import Message
 from urllib.parse import unquote, urlsplit
 
@@ -28,7 +29,7 @@ from lib import enhanced_metadata
 
 # Import multi-source router
 from lib.sources.router import SourceRouter
-from lib.sources.config import get_source_config
+from lib.sources.config import SourceConfig, get_source_config
 from lib.sources.errors import (
     AllSourcesFailedError,
     ProviderResponseError,
@@ -908,6 +909,7 @@ async def _download_url_to_file(
     *,
     enforce_timeout: bool = True,
     host_observer=None,
+    config: Optional[SourceConfig] = None,
 ) -> str:
     """Stream a resolved source URL to disk and return the raw path.
 
@@ -937,7 +939,10 @@ async def _download_url_to_file(
 
     original_host = (urlsplit(url).hostname or "").lower()
     active_host = original_host
-    config = get_source_config()
+    # The caller's config wins when it has one. A router built with an
+    # injected or cached config would otherwise resolve its UA and timeouts
+    # from one object and move the file with another (Codex on #146).
+    config = config or get_source_config()
 
     async def stream_to_disk() -> tuple[int, str]:
         nonlocal active_host
@@ -1096,7 +1101,7 @@ async def _fetch_from_source(book_details: dict, output_dir: str) -> str:
     if not _MD5_RE.fullmatch(md5):
         raise ValueError("Source downloads require a normalized 32-hex MD5")
 
-    config = get_source_config()
+    config = getattr(router, "config", None) or get_source_config()
     active_host = ""
     failures = []
     seen_failure_ids = set()
@@ -1125,6 +1130,7 @@ async def _fetch_from_source(book_details: dict, output_dir: str) -> str:
                         str(provider),
                         enforce_timeout=False,
                         host_observer=lambda host: _set_active_host(host),
+                        config=config,
                     )
                 except AllSourcesFailedError as exc:
                     for failure in exc.failures:

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -921,7 +921,7 @@ async def _download_url_to_file(
     """
     import httpx
 
-    from lib.sources.libgen import USER_AGENT
+    from lib.sources.libgen import get_user_agent
 
     expected_md5 = md5.strip().lower()
     if not _MD5_RE.fullmatch(expected_md5):
@@ -942,15 +942,21 @@ async def _download_url_to_file(
     async def stream_to_disk() -> tuple[int, str]:
         nonlocal active_host
         try:
-            # The identifying UA is load-bearing: libgen's hosts serve an HTML
+            # The admitted UA is load-bearing: libgen's hosts serve an HTML
             # stub to blocklisted tool UAs including python-httpx's default
             # (#124), which the HTML guard below then misreads as an expired
             # key — the adapter verifies the URL with the right UA and the
             # transfer dies here with the wrong one.
+            #
+            # Resolved from `config`, not the module constant: an operator who
+            # sets LIBGEN_USER_AGENT because the default went onto the
+            # blocklist would otherwise have search and key resolution honour
+            # the override while this transfer — the one request that moves the
+            # file — kept sending the blocked default (Codex on #146).
             async with httpx.AsyncClient(
                 timeout=build_timeout(config),
                 follow_redirects=True,
-                headers={"User-Agent": USER_AGENT},
+                headers={"User-Agent": get_user_agent(config)},
             ) as client:
                 async with client.stream("GET", url) as response:
                     response_url = getattr(response, "url", None)

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -79,6 +79,25 @@ DEFAULT_ANNAS_BASE_URL = "https://annas-archive.gl"
 # host from here so the probe cannot drift from the runtime again.
 DEFAULT_LIBGEN_MIRROR = "li"
 
+# LibGen's blocklist is a moving target and it fails SILENTLY: a blocked UA
+# gets HTTP 200 with nginx's ~640-byte default page, which is indistinguishable
+# from an outage or an empty catalogue unless something classifies it (#141).
+#
+# #124 (2026-08-17) found an honest self-identifying UA was admitted where
+# python-requests' default was not, and this default was set to that honest
+# string. By 2026-08-23 the blocklist had widened to include it: measured
+# against libgen.li, libgen.vg and libgen.la, the self-identifying UA returned
+# the 641-byte stub for search AND the 637-byte stub for ads.php, while a
+# desktop Firefox string returned 265 KB and a key-bearing download page.
+#
+# The honest string therefore now costs total failure and buys nothing, so the
+# default is a browser string. `LIBGEN_USER_AGENT` exists so operators can set
+# their own policy — including going back to an identifying string — without
+# forking, and so the next widening is a config change rather than a release.
+DEFAULT_LIBGEN_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
+)
+
 
 @dataclass
 class SourceConfig:
@@ -101,6 +120,7 @@ class SourceConfig:
     annas_secret_key: str = ""
     annas_base_url: str = DEFAULT_ANNAS_BASE_URL
     libgen_mirror: str = DEFAULT_LIBGEN_MIRROR
+    libgen_user_agent: str = DEFAULT_LIBGEN_USER_AGENT
     default_source: str = "auto"  # 'auto' | 'annas' | 'libgen'
     fallback_enabled: bool = True
     connect_timeout: float = DEFAULT_CONNECT_TIMEOUT
@@ -143,6 +163,9 @@ def get_source_config() -> SourceConfig:
         annas_secret_key=os.environ.get("ANNAS_SECRET_KEY", ""),
         annas_base_url=os.environ.get("ANNAS_BASE_URL", DEFAULT_ANNAS_BASE_URL),
         libgen_mirror=os.environ.get("LIBGEN_MIRROR", DEFAULT_LIBGEN_MIRROR),
+        libgen_user_agent=(
+            os.environ.get("LIBGEN_USER_AGENT", "").strip() or DEFAULT_LIBGEN_USER_AGENT
+        ),
         default_source=os.environ.get("BOOK_SOURCE_DEFAULT", "auto"),
         fallback_enabled=os.environ.get("BOOK_SOURCE_FALLBACK_ENABLED", "true").lower()
         == "true",

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -94,9 +94,17 @@ DEFAULT_LIBGEN_MIRROR = "li"
 # default is a browser string. `LIBGEN_USER_AGENT` exists so operators can set
 # their own policy — including going back to an identifying string — without
 # forking, and so the next widening is a config change rather than a release.
-DEFAULT_LIBGEN_USER_AGENT = (
+# The header every source sends unless something source-specific overrides it.
+# Not LibGen-specific: httpx's and requests' default UAs are on more than one
+# provider's blocklist, so "a browser string" is the neutral choice, not a
+# LibGen accommodation.
+DEFAULT_BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
 )
+
+# LibGen starts from the neutral default and diverges only when an operator
+# sets LIBGEN_USER_AGENT, which is scoped to LibGen requests alone.
+DEFAULT_LIBGEN_USER_AGENT = DEFAULT_BROWSER_USER_AGENT
 
 
 @dataclass

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -18,7 +18,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from .base import SourceAdapter
-from .config import SourceConfig
+from .config import DEFAULT_LIBGEN_USER_AGENT, SourceConfig
 from .errors import (
     AllSourcesFailedError,
     ProviderResponseError,
@@ -44,12 +44,36 @@ logger = logging.getLogger("zlibrary.sources")
 PROVIDER = "libgen"
 
 # libgen.li serves its default-nginx stub (HTTP 200, ~640 bytes, no results
-# table) to blocklisted tool User-Agents — python-requests' default, python-httpx's
-# default, and curl among them — while any identifying UA gets the real page
-# (measured 2026-08-17, issue #124). An honest self-identifying UA is admitted,
-# so no browser string is needed. Used by BOTH the search path (via the shim
-# below) and the download path (ads.php serves the same stub to blocked UAs).
-USER_AGENT = "zlibrary-mcp (+https://github.com/rookslog/zlibrary-mcp)"
+# table) to blocklisted tool User-Agents while an admitted UA gets the real
+# page. Used by BOTH the search path (via the shim below) and the download path
+# (ads.php serves the same stub to blocked UAs).
+#
+# The blocklist widened on 2026-08-23 to include the honest self-identifying
+# string that #124 had established as admitted, taking search AND ads.php down
+# together (#141). The policy, its default and the measurements now live on
+# `SourceConfig.libgen_user_agent` so a further widening is an env change
+# rather than a release; see lib/sources/config.py.
+#
+# Kept as a module constant for backwards compatibility — scripts/check_upstream.py
+# imports it — but every request reads the config so `LIBGEN_USER_AGENT` takes
+# effect without a reimport.
+USER_AGENT = DEFAULT_LIBGEN_USER_AGENT
+
+
+def get_user_agent() -> str:
+    """UA for every LibGen request, honouring `LIBGEN_USER_AGENT`.
+
+    Read per request rather than captured at import: `get_source_config` is
+    deliberately uncached so the environment can change under a running
+    process, and a UA pinned at import would silently ignore the override
+    that exists to answer the next blocklist widening.
+    """
+    try:
+        from .config import get_source_config  # noqa: PLC0415
+
+        return get_source_config().libgen_user_agent or DEFAULT_LIBGEN_USER_AGENT
+    except Exception:  # noqa: BLE001 - a config fault must not remove the UA
+        return DEFAULT_LIBGEN_USER_AGENT
 
 
 # Used only when the configuration cannot be read at all. Any real config
@@ -129,7 +153,7 @@ class _RequestsWithUA:
 
     def get(self, url: str, **kwargs) -> requests.Response:
         headers = kwargs.pop("headers", None) or {}
-        headers.setdefault("User-Agent", USER_AGENT)
+        headers.setdefault("User-Agent", get_user_agent())
         # libgen-api-enhanced omits the timeout on some calls; a mirror that
         # accepts the connection and never responds would otherwise hold the
         # search thread past every outer budget (Codex on #128).
@@ -159,6 +183,31 @@ def mirror_host(mirror: str) -> str:
     return f"libgen.{mirror}"
 
 
+def _nginx_stub(text: str) -> bool:
+    """True when a body is nginx's default page rather than LibGen's.
+
+    This is what a blocklisted User-Agent receives: HTTP 200, ~640 bytes,
+    `<title>Welcome to nginx!</title>`. It is not an error status and not an
+    empty result, so nothing upstream distinguishes it from a real outage or a
+    catalogue miss unless it is classified here (#141).
+
+    Matched on the title rather than the byte count: the length is incidental
+    and the same block on a different vhost may pad differently, while the
+    default-page title is the thing that identifies it.
+    """
+    return "welcome to nginx" in text.lower()
+
+
+def _blocked_ua_detail(context: str) -> str:
+    """Detail text naming the UA a mirror refused, and how to change it."""
+    return (
+        f"{context} served nginx's default stub for User-Agent "
+        f"{get_user_agent()!r} — this UA is blocklisted, which is NOT an "
+        f"outage and NOT an empty catalogue. Set LIBGEN_USER_AGENT to a "
+        f"string the mirror admits (#141)."
+    )
+
+
 def _unparseable_search_page(page) -> Optional[str]:
     """Detail text when a zero-result page is a parse failure, else None.
 
@@ -186,11 +235,20 @@ def _unparseable_search_page(page) -> Optional[str]:
     text = getattr(page, "text", "") or ""
     if "tablelibgen" in text:
         return None
+    status = getattr(page, "status_code", "?")
     title_match = re.search(r"<title>([^<]*)</title>", text, re.I)
     page_title = title_match.group(1).strip() if title_match else ""
+    if _nginx_stub(text):
+        # #124's diagnostics are retained verbatim alongside the new naming:
+        # title, status and byte count are what distinguish a stub from a
+        # redesign, and dropping them would trade one diagnosis for another.
+        return (
+            f"{_blocked_ua_detail('search page')} "
+            f"[HTTP {status}, {len(text)} bytes, title {page_title!r}]"
+        )
     return (
         f"search page had no results table (HTTP "
-        f"{getattr(page, 'status_code', '?')}, {len(text)} bytes, title "
+        f"{status}, {len(text)} bytes, title "
         f"{page_title!r}) — parse failure, not an empty result"
     )
 
@@ -416,16 +474,26 @@ class LibgenAdapter(SourceAdapter):
 
     async def _resolve_key(
         self, client: httpx.AsyncClient, mirror: str, md5: str
-    ) -> Optional[str]:
+    ) -> tuple[Optional[str], str]:
         """Scrape the one-time CDN key out of a mirror's ads.php page.
 
         `ads.php?md5=<md5>` is addressable directly from the hash — no search
         is involved — and carries a single `GET` anchor whose href holds the
-        key. Returns None if the page has no usable key.
+        key.
+
+        Returns:
+            (key, detail). `key` is None when the page carries no usable key;
+            `detail` says why, distinguishing a blocklisted UA from real
+            markup drift. Those two produce identical symptoms — HTTP 200 with
+            no `GET` anchor — and reporting the block as "DOM drift" sent an
+            operator looking for a parser bug that did not exist (#141).
         """
         url = f"https://libgen.{mirror}/ads.php?md5={md5}"
         response = await client.get(url)
         response.raise_for_status()
+
+        if _nginx_stub(response.text):
+            return None, _blocked_ua_detail("ads.php")
 
         soup = BeautifulSoup(response.text, "html.parser")
         for anchor in soup.find_all("a"):
@@ -437,8 +505,11 @@ class LibgenAdapter(SourceAdapter):
             params = parse_qs(urlparse(urljoin(url, href)).query)
             key = (params.get("key") or [None])[0]
             if key:
-                return key
-        return None
+                return key, ""
+        return None, (
+            "ads.php returned HTTP 200 with no key-bearing GET link "
+            "(DOM drift — the resolver scrapes this anchor for the CDN key)"
+        )
 
     async def _serves_bytes(
         self, client: httpx.AsyncClient, url: str
@@ -513,7 +584,7 @@ class LibgenAdapter(SourceAdapter):
         async with httpx.AsyncClient(
             timeout=build_timeout(self.config),
             follow_redirects=True,
-            headers={"User-Agent": USER_AGENT},
+            headers={"User-Agent": get_user_agent()},
         ) as client:
             for mirror in self._mirror_candidates():
                 try:
@@ -527,9 +598,9 @@ class LibgenAdapter(SourceAdapter):
 
                 async def resolve_attempt() -> tuple[Optional[str], str]:
                     """Resolve and validate one mirror under one total budget."""
-                    key = await self._resolve_key(client, mirror, md5)
+                    key, key_detail = await self._resolve_key(client, mirror, md5)
                     if not key:
-                        return None, "no GET link"
+                        return None, key_detail
 
                     candidate = f"https://libgen.{mirror}/get.php?md5={md5}&key={key}"
                     ok, detail = await self._serves_bytes(client, candidate)

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -60,14 +60,22 @@ PROVIDER = "libgen"
 USER_AGENT = DEFAULT_LIBGEN_USER_AGENT
 
 
-def get_user_agent() -> str:
+def get_user_agent(config: Optional[SourceConfig] = None) -> str:
     """UA for every LibGen request, honouring `LIBGEN_USER_AGENT`.
+
+    Pass `config` wherever the caller holds one — an adapter constructed as
+    `LibgenAdapter(SourceConfig(libgen_user_agent=...))` must send that UA, not
+    re-read the environment behind its caller's back (Codex on #146). Only the
+    module-level search shim, which has no config to hold, falls through to the
+    environment.
 
     Read per request rather than captured at import: `get_source_config` is
     deliberately uncached so the environment can change under a running
     process, and a UA pinned at import would silently ignore the override
     that exists to answer the next blocklist widening.
     """
+    if config is not None:
+        return config.libgen_user_agent or DEFAULT_LIBGEN_USER_AGENT
     try:
         from .config import get_source_config  # noqa: PLC0415
 
@@ -130,12 +138,18 @@ class _RequestsWithUA:
     ``LibgenAdapter.search`` can tell "no matches" from "served a page with no
     results table".
 
-    ``last_response`` is **thread-local**. The search runs under
-    `net.run_bounded`, which abandons its daemon thread when the budget
+    ``last_response`` and ``user_agent`` are **thread-local**. The search runs
+    under `net.run_bounded`, which abandons its daemon thread when the budget
     elapses; an abandoned `requests.get` that completes minutes later would
     otherwise overwrite the slot a *later* mirror attempt is about to read,
     and the adapter would attribute one mirror's stub page to another. Each
     bounded attempt gets its own thread, so each gets its own slot.
+
+    ``user_agent`` rides the same mechanism so an adapter's *own*
+    `SourceConfig` reaches the search path. This shim is a module singleton
+    swapped into third-party code, so it cannot hold a config of its own;
+    `LibgenAdapter.search` sets the slot inside the bounded thread that is
+    about to use it. Unset, it falls back to the environment.
     """
 
     exceptions = requests.exceptions
@@ -151,9 +165,17 @@ class _RequestsWithUA:
     def last_response(self, response: Optional[requests.Response]) -> None:
         self._state.last_response = response
 
+    @property
+    def user_agent(self) -> Optional[str]:
+        return getattr(self._state, "user_agent", None)
+
+    @user_agent.setter
+    def user_agent(self, value: Optional[str]) -> None:
+        self._state.user_agent = value
+
     def get(self, url: str, **kwargs) -> requests.Response:
         headers = kwargs.pop("headers", None) or {}
-        headers.setdefault("User-Agent", get_user_agent())
+        headers.setdefault("User-Agent", self.user_agent or get_user_agent())
         # libgen-api-enhanced omits the timeout on some calls; a mirror that
         # accepts the connection and never responds would otherwise hold the
         # search thread past every outer budget (Codex on #128).
@@ -194,21 +216,29 @@ def _nginx_stub(text: str) -> bool:
     Matched on the title rather than the byte count: the length is incidental
     and the same block on a different vhost may pad differently, while the
     default-page title is the thing that identifies it.
+
+    Scoped to the title element specifically, not a body-wide substring: a
+    real LibGen record whose own title or description contains the phrase
+    would otherwise be classified as a block, and `_resolve_key` would discard
+    a page carrying a perfectly good GET anchor (Codex on #146).
     """
-    return "welcome to nginx" in text.lower()
+    match = re.search(r"<title>([^<]*)</title>", text, re.I)
+    return bool(match and "welcome to nginx" in match.group(1).lower())
 
 
-def _blocked_ua_detail(context: str) -> str:
+def _blocked_ua_detail(context: str, config: Optional[SourceConfig] = None) -> str:
     """Detail text naming the UA a mirror refused, and how to change it."""
     return (
         f"{context} served nginx's default stub for User-Agent "
-        f"{get_user_agent()!r} — this UA is blocklisted, which is NOT an "
+        f"{get_user_agent(config)!r} — this UA is blocklisted, which is NOT an "
         f"outage and NOT an empty catalogue. Set LIBGEN_USER_AGENT to a "
         f"string the mirror admits (#141)."
     )
 
 
-def _unparseable_search_page(page) -> Optional[str]:
+def _unparseable_search_page(
+    page, config: Optional[SourceConfig] = None
+) -> Optional[str]:
     """Detail text when a zero-result page is a parse failure, else None.
 
     A genuinely-empty search still renders the (empty) results table (verified
@@ -243,7 +273,7 @@ def _unparseable_search_page(page) -> Optional[str]:
         # title, status and byte count are what distinguish a stub from a
         # redesign, and dropping them would trade one diagnosis for another.
         return (
-            f"{_blocked_ua_detail('search page')} "
+            f"{_blocked_ua_detail('search page', config)} "
             f"[HTTP {status}, {len(text)} bytes, title {page_title!r}]"
         )
     return (
@@ -334,6 +364,10 @@ class LibgenAdapter(SourceAdapter):
                 # thread-local precisely so an abandoned earlier attempt
                 # cannot supply it.
                 _search_requests.last_response = None
+                # Set on the same thread that is about to issue the request,
+                # so this adapter's configured UA reaches the search path
+                # rather than the shim re-reading the environment.
+                _search_requests.user_agent = get_user_agent(self.config)
                 # search_default covers title+author+series+publisher —
                 # search_title made author-bearing queries return nothing
                 # and got swamped on generic titles (#134).
@@ -355,7 +389,7 @@ class LibgenAdapter(SourceAdapter):
                 continue
 
             if not results:
-                unparseable = _unparseable_search_page(page)
+                unparseable = _unparseable_search_page(page, self.config)
                 if unparseable:
                     failure = ProviderResponseError(
                         PROVIDER, host, unparseable, reason="protocol_error"
@@ -493,7 +527,7 @@ class LibgenAdapter(SourceAdapter):
         response.raise_for_status()
 
         if _nginx_stub(response.text):
-            return None, _blocked_ua_detail("ads.php")
+            return None, _blocked_ua_detail("ads.php", self.config)
 
         soup = BeautifulSoup(response.text, "html.parser")
         for anchor in soup.find_all("a"):
@@ -584,7 +618,7 @@ class LibgenAdapter(SourceAdapter):
         async with httpx.AsyncClient(
             timeout=build_timeout(self.config),
             follow_redirects=True,
-            headers={"User-Agent": get_user_agent()},
+            headers={"User-Agent": get_user_agent(self.config)},
         ) as client:
             for mirror in self._mirror_candidates():
                 try:

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -74,12 +74,19 @@ def get_user_agent(config: Optional[SourceConfig] = None) -> str:
     process, and a UA pinned at import would silently ignore the override
     that exists to answer the next blocklist widening.
     """
+    # Stripped, not merely truthiness-tested: the environment path strips its
+    # input, so an injected `SourceConfig(libgen_user_agent="   ")` would
+    # otherwise put whitespace on the wire where the same value from the
+    # environment would have fallen back to the default (Codex on #146). A
+    # blank UA earns the nginx stub, i.e. the exact failure this exists to
+    # avoid, and does so while the config looks like it addressed it.
     if config is not None:
-        return config.libgen_user_agent or DEFAULT_LIBGEN_USER_AGENT
+        return (config.libgen_user_agent or "").strip() or DEFAULT_LIBGEN_USER_AGENT
     try:
         from .config import get_source_config  # noqa: PLC0415
 
-        return get_source_config().libgen_user_agent or DEFAULT_LIBGEN_USER_AGENT
+        configured = (get_source_config().libgen_user_agent or "").strip()
+        return configured or DEFAULT_LIBGEN_USER_AGENT
     except Exception:  # noqa: BLE001 - a config fault must not remove the UA
         return DEFAULT_LIBGEN_USER_AGENT
 
@@ -224,6 +231,18 @@ def _nginx_stub(text: str) -> bool:
     """
     match = re.search(r"<title>([^<]*)</title>", text, re.I)
     return bool(match and "welcome to nginx" in match.group(1).lower())
+
+
+class LibgenUserAgentBlocked(ProviderResponseError):
+    """A mirror served nginx's default stub instead of the page we asked for.
+
+    A distinct type rather than a distinguishing message, because the doctor
+    has to tell this apart from ordinary upstream drift and a string sniff
+    across a process boundary is not a contract. `probe_libgen` catches
+    `AllSourcesFailedError` as an optional failure; without a type to test for,
+    a search refused on every mirror reported WARN while the download probe
+    reported BLOCK on the identical refusal (Codex on #146).
+    """
 
 
 def _blocked_ua_detail(context: str, config: Optional[SourceConfig] = None) -> str:
@@ -391,7 +410,11 @@ class LibgenAdapter(SourceAdapter):
             if not results:
                 unparseable = _unparseable_search_page(page, self.config)
                 if unparseable:
-                    failure = ProviderResponseError(
+                    blocked = _nginx_stub(getattr(page, "text", "") or "")
+                    failure_cls = (
+                        LibgenUserAgentBlocked if blocked else ProviderResponseError
+                    )
+                    failure = failure_cls(
                         PROVIDER, host, unparseable, reason="protocol_error"
                     )
                     logger.warning("LibGen search unusable on %s: %s", mirror, failure)

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -39,7 +39,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "zlibrary" / "src"))
 from lib.sources.config import get_source_config  # noqa: E402
 from lib.sources.libgen import FALLBACK_MIRRORS as LIBGEN_FALLBACK_MIRRORS  # noqa: E402
-from lib.sources.libgen import USER_AGENT as LIBGEN_PRODUCTION_UA  # noqa: E402
+from lib.sources.libgen import _nginx_stub as _libgen_nginx_stub  # noqa: E402
+from lib.sources.libgen import get_user_agent as libgen_user_agent  # noqa: E402
 from zlibrary.eapi import DEFAULT_EAPI_DOMAINS, WALLED_STATUS_CODES  # noqa: E402
 
 TIMEOUT = httpx.Timeout(20.0, connect=10.0)
@@ -422,6 +423,17 @@ def _libgen_block_detail(mirror: str, resp: httpx.Response) -> Optional[str]:
     wall and names ZLIB_DOMAIN. A refusal is not drift: the resolve-and-fetch
     contract may be intact for clients the wall lets through.
     """
+    # A blocklisted UA is refused with HTTP 200 and nginx's default page, so
+    # the status-code check below never sees it. Left unclassified it reaches
+    # the operator as "DOM drift" or "no results" — a parser bug or an outage,
+    # neither of which is true — which is what #141 cost a sweep to discover.
+    if _libgen_nginx_stub(resp.text):
+        return (
+            f"libgen.{mirror} served nginx's default stub for User-Agent "
+            f"{libgen_user_agent()!r} — this UA is blocklisted. Not an outage "
+            "and not upstream drift; set LIBGEN_USER_AGENT to a string the "
+            "mirror admits (#141)"
+        )
     if resp.status_code not in (403, 429, *WALLED_STATUS_CODES):
         return None
     return (
@@ -451,7 +463,7 @@ async def _probe_libgen_download_mirror(
         resp = await client.get(
             ads_url,
             params={"md5": LIBGEN_PROBE_MD5},
-            headers={"User-Agent": LIBGEN_PRODUCTION_UA},
+            headers={"User-Agent": libgen_user_agent()},
         )
         blocked = _libgen_block_detail(mirror, resp)
         if blocked:
@@ -479,7 +491,7 @@ async def _probe_libgen_download_mirror(
             get_url,
             headers={
                 "Range": f"bytes=0-{LIBGEN_PROBE_RANGE_BYTES - 1}",
-                "User-Agent": LIBGEN_PRODUCTION_UA,
+                "User-Agent": libgen_user_agent(),
             },
         )
     except Exception as exc:  # noqa: BLE001

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -360,12 +360,18 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
         # here and BLOCK from the download probe — and the summary counted it
         # as an optional failure while the message said it was not drift
         # (Codex on #146). The adapter raises a distinct type for exactly this.
+        # ALL mirrors, not any: a run where one mirror served the stub and
+        # another timed out is a mixed result, and calling it BLOCK would drop
+        # the genuine transport failure out of the optional-failure count and
+        # describe drift as a wall (Codex on #146). This is the same
+        # all-mirrors rule `probe_libgen_download` applies via `blocked_count`,
+        # and the two probes have to agree or the doctor contradicts itself
+        # again in the opposite direction.
+        failures = list(getattr(exc, "failures", None) or [])
         blocked = isinstance(exc, LibgenUserAgentBlocked) or (
             isinstance(exc, AllSourcesFailedError)
-            and any(
-                isinstance(failure, LibgenUserAgentBlocked)
-                for failure in getattr(exc, "failures", []) or []
-            )
+            and bool(failures)
+            and all(isinstance(f, LibgenUserAgentBlocked) for f in failures)
         )
         return ProbeResult(
             name="libgen:search",

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -632,6 +632,18 @@ def render(results: list[ProbeResult]) -> str:
     return "\n".join(lines)
 
 
+def zlibrary_blocked(results: list[ProbeResult]) -> bool:
+    """True when a **Z-Library** probe was walled, ignoring other sources.
+
+    Scoped by the `zlibrary:` name prefix. This value feeds
+    upstream-check.yml's decision to skip filing the Z-Library drift issue, so
+    folding another source's block into it suppresses a genuine Z-Library
+    report for an unrelated reason — and #141 made that reachable, since a
+    LibGen UA block is now classified as `blocked` too (Codex on #146).
+    """
+    return any(r.blocked for r in results if r.name.startswith("zlibrary:"))
+
+
 def emit_github_output(report: str, failed: bool, zlib_blocked: bool = False) -> None:
     path: Optional[str] = os.environ.get("GITHUB_OUTPUT")
     if not path:
@@ -661,7 +673,7 @@ def main() -> int:
 
     results = asyncio.run(run_probes())
     required_failed = bool(actionable_failures(results))
-    zlib_blocked = any(r.blocked for r in results)
+    zlib_blocked = zlibrary_blocked(results)
 
     if args.json:
         print(

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -336,7 +336,11 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
     never a status code or byte count. ``client`` is unused by design: the
     adapter builds production's own HTTP stack.
     """
-    from lib.sources.libgen import LibgenAdapter  # noqa: PLC0415
+    from lib.sources.errors import AllSourcesFailedError  # noqa: PLC0415
+    from lib.sources.libgen import (  # noqa: PLC0415
+        LibgenAdapter,
+        LibgenUserAgentBlocked,
+    )
 
     canary = "Pride and Prejudice"
     config = get_source_config()
@@ -351,9 +355,22 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
             timeout=libgen_probe_timeout(config, LibgenAdapter.MIN_REQUEST_INTERVAL),
         )
     except Exception as exc:  # noqa: BLE001
+        # A UA block is not upstream drift and must not be summarised as one.
+        # Without this the same refusal, on the same run, came back as WARN
+        # here and BLOCK from the download probe — and the summary counted it
+        # as an optional failure while the message said it was not drift
+        # (Codex on #146). The adapter raises a distinct type for exactly this.
+        blocked = isinstance(exc, LibgenUserAgentBlocked) or (
+            isinstance(exc, AllSourcesFailedError)
+            and any(
+                isinstance(failure, LibgenUserAgentBlocked)
+                for failure in getattr(exc, "failures", []) or []
+            )
+        )
         return ProbeResult(
             name="libgen:search",
             ok=False,
+            blocked=blocked,
             detail=f"adapter search failed: {type(exc).__name__}: {exc}",
             required=False,
         )


### PR DESCRIPTION
Fixes #141.

## What was wrong

LibGen's blocklist widened on 2026-08-23 to include the honest self-identifying UA that #124 had established as admitted. Measured against `libgen.li` while writing this:

| User-Agent | `index.php` search | `ads.php?md5=` |
|---|---|---|
| `python-requests/2.32.3` | 641 B, `Welcome to nginx!` | 637 B, `Welcome to nginx!`, no key |
| `zlibrary-mcp (+https://…)` — the production UA | 641 B, `Welcome to nginx!` | 637 B, `Welcome to nginx!`, no key |
| desktop Firefox 128 | 265 KB, 105 rows | 21,414 B, `key=…` present |

**Both paths were down, not just search.** #141's body reports `ads.php` still serving 20,909 B to the production UA and concludes downloads were fine. Re-measured while fixing this, the same UA gets the 637-byte stub and no `GET` anchor, so key resolution fails too. Either the blocklist widened again after the issue was filed or the original probe differed; the table above is what the mirrors do now. I've added the measurement to #141 rather than editing its body.

The failure is silent by construction — a blocked UA is HTTP 200 with a short body, so nothing upstream distinguishes it from an outage, an empty catalogue, or DOM drift. #141 records that costing a sweep ~40 minutes and a round of false conclusions about the catalogue's coverage.

## What this does

#141 asked for the UA policy to be decided explicitly, since the current string is now equivalent to sending nothing. It offered three options; this takes all three.

- **Default UA becomes a desktop Firefox string.** The honest string now costs total failure and buys nothing.
- **`LIBGEN_USER_AGENT` override**, so an operator can set their own policy — including going back to an identifying string — without forking, and the next widening is a config change rather than a release. Read per request rather than pinned at import, because `get_source_config` is uncached by design and a UA fixed at import would silently ignore the override that exists to answer that widening.
- **Classify the stub and name it.** Search failures, `ads.php` key resolution, and the `npm run doctor` canary now report *which UA was refused* and point at the override, instead of reporting "parse failure" or "DOM drift". Matched on the page title, not the byte count — length is incidental and vhost-specific.

The `ads.php` resolver previously returned a bare `None` for both a blocked UA and real markup drift, which produced identical symptoms; it now returns a reason alongside, so those two stay distinguishable.

## Verification

Full suites on this commit: **1304 Python passed** (70.96% coverage, gate 60%), **272 Node passed**, build validation passed, eslint and prettier clean.

Live against `libgen.li` after the change — search returns the three critical editions #141 named as missing, and `get_download_url` resolves a CDN key:

```
'Plotinus Enneads Armstrong': Loeb Classical Library Plotinus Volume IV
'Empedocles extant fragments Wright': Empedocles The Extant Fragments (3 rows)
download url: https://libgen.li/get.php?md5=588c…&key=NDQCIT24DYRZXZCJ
```

New tests cover the default, the override, a blank override falling back rather than sending an empty header, per-request reads, title-based matching independent of length, and — the two that matter for not regressing the diagnosis — that a genuine parse failure keeps its own wording and a genuinely empty result still passes through.

## Note on the UA policy itself

This makes the client present as a browser, which is a stance, not just a fix. It is recorded here rather than left implicit: the alternative is that LibGen search and download are both unavailable, and LibGen is the uncapped fallback for Z-Library's ~10/day ceiling. The override exists so that stance is the operator's to change.