### PR TITLE
docs: the browser-resident session is in scope for Anna's (#95)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,13 +197,31 @@ When a document and the code disagree, the code is right and the document is a b
 
 ## Two terms with sharp edges
 
-**"Keyless" is banned.** Anna's Archive has exactly one supported download route: keyed
-`fast_download`. The free route sits behind a DDoS-Guard challenge that is permanently
-out of scope (#76), and the operator-cookie route was ruled out in #84 — DDoS-Guard binds
-the cookie to the issuing IP inside `__ddg9_`, so a transplanted cookie is rejected
-exactly as an absent one is. Anna's **key-free search** works and is why Anna's remains a
-source at all. Writing "keyless" conflates *no API key* with *no human in the loop*, and
-that conflation already caused approved work to be recorded as cancelled.
+**"Keyless" is banned.** Anna's Archive has one *server-side* download route: keyed
+`fast_download`. The free route sits behind a DDoS-Guard challenge, and the
+operator-cookie route was ruled out in #84 — DDoS-Guard binds the cookie to the issuing
+IP inside `__ddg9_`, so a transplanted cookie is rejected exactly as an absent one is.
+Anna's **key-free search** works and is why Anna's remains a source at all. Writing
+"keyless" conflates *no API key* with *no human in the loop*, and that conflation already
+caused approved work to be recorded as cancelled.
+
+**A second route is now in scope: the browser-resident session** (operator ruling
+2026-08-23, measured in #142). A real browser on the operator's machine holds the
+clearance and issues search and download requests from inside it — nothing is exported to
+another client, so #84's IP-binding finding does not apply to it. This reverses the
+"permanently out of scope" clause that #76 and #95 carried from 2026-08-11: non-API
+Anna's access is a hard requirement, because Anna's aggregates LibGen, Z-Library and IA
+and uniquely carries the scholarly editions that are the reason it is a source at all.
+
+Read that honestly rather than as a re-scoping. It does route around an anti-abuse control
+Anna's operates deliberately, and Anna's states its reason plainly — *"browser verification
+for our slow downloads, because otherwise bots and scrapers will abuse them."* What keeps
+this on the right side of that claim is that #144's rate limiting ships **in the same pass**
+as the route rather than after it, bounded to the personal-use scale #95 fixed: 10–15 books
+typical, 30 maximum, per roughly a four-hour reading session. A route that shipped without
+those limits would make the politeness claim rhetorical, which is the one outcome this
+paragraph exists to prevent. #76 stays closed as written; what changed is the clause, not
+the finding.
 
 **LibGen needs no account and has no daily limit**, which is why it matters: it is the
 fallback for Z-Library's ~10 downloads/day ceiling. Failover across mirrors (`li → vg →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,13 +205,13 @@ Anna's **key-free search** works and is why Anna's remains a source at all. Writ
 "keyless" conflates *no API key* with *no human in the loop*, and that conflation already
 caused approved work to be recorded as cancelled.
 
-**A second route is now in scope: the browser-resident session** (operator ruling
-2026-08-23, measured in #142). A real browser on the operator's machine holds the
-clearance and issues search and download requests from inside it — nothing is exported to
-another client, so #84's IP-binding finding does not apply to it. This reverses the
-"permanently out of scope" clause that #76 and #95 carried from 2026-08-11: non-API
-Anna's access is a hard requirement, because Anna's aggregates LibGen, Z-Library and IA
-and uniquely carries the scholarly editions that are the reason it is a source at all.
+**A second route is in scope: the browser-resident session** (operator ruling, measured
+in #142). A real browser on the operator's machine holds the clearance and issues search
+and download requests from inside it — nothing is exported to another client, so #84's
+IP-binding finding does not apply to it. This reverses the "permanently out of scope"
+clause that #76 and #95 carried: non-API Anna's access is a hard requirement, because
+Anna's aggregates LibGen, Z-Library and IA and uniquely carries the scholarly editions
+that are the reason it is a source at all.
 
 Read that honestly rather than as a re-scoping. It does route around an anti-abuse control
 Anna's operates deliberately, and Anna's states its reason plainly — *"browser verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,14 @@ those limits would make the politeness claim rhetorical, which is the one outcom
 paragraph exists to prevent. #76 stays closed as written; what changed is the clause, not
 the finding.
 
+The reversal is scoped to that route and nothing wider. Fingerprint work is in scope only
+where it keeps a real, person-established browser session from being walled for its
+automation markers. A **machine-solved challenge** — an unattended headless solver, or
+spoofing standing in for a browser session nobody opened — is still not the route being
+built, and it is not merely deferred: #142 measured that headless fails while holding
+clearance that works headful minutes earlier. "No human in the loop" remains ruled out, as
+the `CONTEXT.md` glossary says.
+
 **LibGen needs no account and has no daily limit**, which is why it matters: it is the
 fallback for Z-Library's ~10 downloads/day ceiling. Failover across mirrors (`li → vg →
 la`) is driven by bytes actually served, not by key resolution — a mirror can return a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,7 +47,7 @@ than describing a guarantee the server presently offers.
 
 ### Anna's Archive routes
 
-These three terms exist because "keyless" was ambiguous and the ambiguity caused a real
+These terms exist because "keyless" was ambiguous and the ambiguity caused a real
 planning error: work the maintainer had approved was recorded as ruled out.
 
 **Keyed fast_download**:
@@ -67,8 +67,10 @@ so a transplanted cookie is rejected byte-for-byte identically to no cookie at a
 keyed `fast_download` endpoint and raises without `ANNAS_SECRET_KEY`. **Anna's therefore
 has exactly one supported download route: keyed `fast_download`.** The term is retained
 here because the distinction it names is still needed to read #75, #84 and #97 — not
-because the route is planned. Guardrails for it (#97) are moot rather than deferred; if a
-sanctioned rate-limited route ever appears, reopen those rather than restarting.
+because the route is planned. Its guardrail work, #97, is closed as moot **and has a
+successor**: the sanctioned rate-limited route it anticipated did appear, as the
+browser-resident session below, and #144 carries the guardrails for it. Read #97 for the
+thresholds it settled; do not reopen it.
 _Avoid_: Keyless download (ambiguous — say this instead)
 
 **Browser-resident session**:
@@ -78,17 +80,17 @@ a different client, so the IP binding that defeated the operator-cookie route ab
 apply. #142 measured that clearance can be held this way — headful only, roughly 20 minutes
 per solve — and #143 and #144 build on that answer.
 
-**In scope as of 2026-08-23** (operator ruling; the reasoning and its limits are in
-`AGENTS.md` §"Two terms with sharp edges"). Until then the entry below read "permanently out
-of scope" and #95 carried that clause forward to every successor map. What the ruling opened
-is *this* route, on the condition that #144's rate limiting ships in the same pass as it
-rather than after it. Fingerprint work counts as in scope only where it keeps this route
-working — a real browser whose automation markers would otherwise get it walled.
+**In scope** (operator ruling; the reasoning and its limits are in `AGENTS.md`
+§"Two terms with sharp edges", the measurement in #142). The entry below previously read
+"permanently out of scope" and #95 carried that clause forward to every successor map; what
+the ruling opened is *this* route, on the condition that #144's rate limiting ships in the
+same pass as it rather than after it. Fingerprint work counts as in scope only where it keeps
+this route working — a real browser whose automation markers would otherwise get it walled.
 
 **Machine-solved challenge**:
 Any route where the *server* defeats the browser verification itself with no browser session
 a person established — a headless solver run unattended, spoofing alone in place of a real
-browser. Still not the route being built, and the 2026-08-23 ruling did not open it: #142
+browser. Still not the route being built, and the ruling above did not open it: #142
 measured that headless fails even holding valid clearance, so this is not a design being
 deferred but one that does not work. Read the reversal above as scoped to the
 browser-resident session; nothing here is licensed by it.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,10 +71,22 @@ because the route is planned. Guardrails for it (#97) are moot rather than defer
 sanctioned rate-limited route ever appears, reopen those rather than restarting.
 _Avoid_: Keyless download (ambiguous — say this instead)
 
+**Browser-resident session**:
+A route where a *real browser on the operator's machine* holds the DDoS-Guard clearance and
+search and download requests are issued from inside it, rate-limited. Nothing is exported to
+a different client, so the IP binding that defeated the operator-cookie route above does not
+apply. #142 measured that clearance can be held this way — headful only, roughly 20 minutes
+per solve — and #143 and #144 build on that answer.
+
 **Machine-solved challenge**:
 Any route where the *server* defeats the browser verification itself — headless browser,
-fingerprint spoofing. Permanently out of scope: it defeats an anti-abuse control Anna's
-operates deliberately.
+fingerprint spoofing.
+
+**Scope reversed 2026-08-23** (operator ruling; the reasoning and its limits are in
+`AGENTS.md` §"Two terms with sharp edges"). This entry read "permanently out of scope" from
+2026-08-11 until then, and #95 carried the clause forward to every successor map. Both are
+retired for the purpose of reaching Anna's search and download, on the condition that #144's
+rate limiting ships in the same pass as the route rather than after it.
 _Avoid_: Keyless download, automated download
 
 Note that "keyless" alone should not be used. It has meant both *no API key* (a live

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,15 +78,20 @@ a different client, so the IP binding that defeated the operator-cookie route ab
 apply. #142 measured that clearance can be held this way — headful only, roughly 20 minutes
 per solve — and #143 and #144 build on that answer.
 
-**Machine-solved challenge**:
-Any route where the *server* defeats the browser verification itself — headless browser,
-fingerprint spoofing.
+**In scope as of 2026-08-23** (operator ruling; the reasoning and its limits are in
+`AGENTS.md` §"Two terms with sharp edges"). Until then the entry below read "permanently out
+of scope" and #95 carried that clause forward to every successor map. What the ruling opened
+is *this* route, on the condition that #144's rate limiting ships in the same pass as it
+rather than after it. Fingerprint work counts as in scope only where it keeps this route
+working — a real browser whose automation markers would otherwise get it walled.
 
-**Scope reversed 2026-08-23** (operator ruling; the reasoning and its limits are in
-`AGENTS.md` §"Two terms with sharp edges"). This entry read "permanently out of scope" from
-2026-08-11 until then, and #95 carried the clause forward to every successor map. Both are
-retired for the purpose of reaching Anna's search and download, on the condition that #144's
-rate limiting ships in the same pass as the route rather than after it.
+**Machine-solved challenge**:
+Any route where the *server* defeats the browser verification itself with no browser session
+a person established — a headless solver run unattended, spoofing alone in place of a real
+browser. Still not the route being built, and the 2026-08-23 ruling did not open it: #142
+measured that headless fails even holding valid clearance, so this is not a design being
+deferred but one that does not work. Read the reversal above as scoped to the
+browser-resident session; nothing here is licensed by it.
 _Avoid_: Keyless download, automated download
 
 Note that "keyless" alone should not be used. It has meant both *no API key* (a live


### PR DESCRIPTION
Retires the "permanently out of scope" clause on Anna's DDoS-Guard-protected free route, per an operator ruling on 2026-08-23. Split out of #146, where Codex flagged it — correctly — as scope creep inside a LibGen User-Agent fix.

## Why the clause is going

Non-API Anna's access is a hard requirement of this project, not a nice-to-have. Anna's aggregates LibGen, Z-Library and the Internet Archive, and it uniquely carries the scholarly editions that are the reason it is a source at all. The clause as written blocked the requirement outright.

## What is actually in scope, and what is not

The route named is deliberately narrow so this cannot be read as a general licence:

- **In scope — browser-resident session.** A real browser on the operator's machine holds the clearance and issues search and download requests from inside it. Nothing is exported to another client, so #84's finding (DDoS-Guard binds the cookie to the issuing IP inside `__ddg9_`) does not apply to it. #142 measured that this works — headful only, roughly twenty minutes of clearance per solve.
- **Unchanged — #76 stays closed as written.** Its finding about the unattended keyless route still holds. What changed is the doctrine clause, not the measurement.

## The condition is not separable

#144's rate limiting ships **in the same pass** as the route, not after it, bounded to the personal-use scale #95 already fixed: 10–15 books typical, 30 maximum, per roughly a four-hour reading session. That is what keeps this on the right side of Anna's own stated reason for the control — *"browser verification for our slow downloads, because otherwise bots and scrapers will abuse them."* A route shipped without those limits would make the politeness claim rhetorical. The doc says so explicitly, so a later reader cannot take the licence without the condition.

## Why two files

`AGENTS.md` is the canonical contract; `CONTEXT.md` is the living state doc. This repo has documented history of a doctrine change landing in one artifact and leaving the other contradicting it — that is precisely the failure Codex caught on #146, where `CONTEXT.md` moved alone. Both move here, in one commit, and the citations are durable public issues rather than any local file.

Closes nothing on its own; unblocks #143 and #144.