### PR TITLE
fix(ci): clear the three advisories failing the audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,12 @@ jobs:
       # needs a reason on the line.
       - run: >
           uv run pip-audit
-          --ignore-vuln CVE-2026-4539
           --ignore-vuln CVE-2026-3029
+          --ignore-vuln PYSEC-2026-3001
           --ignore-vuln PYSEC-2026-597
-        # CVE-2026-4539  pygments  - no compatible fix published
-        # CVE-2026-3029  pymupdf   - fix requires 1.26.7, which breaks footnote extraction
-        # PYSEC-2026-597 nltk      - no fix published as of 2026-07
+        # CVE-2026-3029   pymupdf - fix requires 1.26.7, blocked by the pin in pyproject.toml
+        # PYSEC-2026-3001 pymupdf - same pin, same fix version; tracked in #148
+        # PYSEC-2026-597  nltk    - no fix published as of 2026-07
 
   lint:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     "jsonschema>=4.26.0",
     "pytest-cov>=7.0.0",
     "pip-audit>=2.7.0",
-    "pip>=26.1.2",  # PYSEC-2026-196, PYSEC-2026-2875, PYSEC-2026-2876 (pulled in by pip-audit)
+    "pip>=26.2.1",  # PYSEC-2026-196, PYSEC-2026-2875, PYSEC-2026-2876, PYSEC-2026-3721 (pulled in by pip-audit)
 ]
 
 [project.urls]
@@ -122,6 +122,7 @@ constraint-dependencies = [
     "msgpack>=1.2.1",        # PYSEC-2026 msgpack advisory
     "nltk>=3.10.0",          # CVE-2025-14009, CVE-2026-33230, PYSEC-2026-3582..3584
     "pi-heif>=1.3.0",        # transitive via ocrmypdf image stack
+    "pygments>=2.20.0",      # PYSEC-2026-2987, CVE-2026-4539 (transitive via pytest/rich)
     "pillow>=12.3.0",        # PYSEC-2026-3451..3496 (26 advisories)
     "pymupdf==1.26.5",         # Pin — 1.26.6 lacks Docker wheel, 1.26.7 breaks footnote extraction; CVE-2026-3029 ignored in CI
     "python-dotenv>=1.2.2",  # PYSEC-2026-2270

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ constraints = [
     { name = "pdfminer-six", specifier = ">=20251230" },
     { name = "pi-heif", specifier = ">=1.3.0" },
     { name = "pillow", specifier = ">=12.3.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pymupdf", specifier = "==1.26.5" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "requests", specifier = ">=2.33.0" },
@@ -806,7 +807,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1788,11 +1789,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]
@@ -2088,11 +2089,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
 ]
 
 [[package]]
@@ -2973,7 +2974,7 @@ provides-extras = ["ocr", "dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "pip", specifier = ">=26.1.2" },
+    { name = "pip", specifier = ">=26.2.1" },
     { name = "pip-audit", specifier = ">=2.7.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },


### PR DESCRIPTION
The `audit` check has been red on **every** open branch — #112, #114, #146 — which is why this is worth its own PR rather than a fix inside one of them. It is not caused by any of their changes.

## What was actually failing

**On CI: one advisory — `pip` / PYSEC-2026-3721.** The `audit` job log reads `Found 1 known vulnerability, ignored 2 in 1 package`.

A local `pip-audit` run surfaces two more, which CI does not see — the two environments resolve a different advisory set. They are real and worth fixing, but they were not what turned the gate red; see the correction comment on this PR. The full local picture:

| Package | Version | Advisory | Fix |
|---|---|---|---|
| `pip` | 26.1.2 | PYSEC-2026-3721 | 26.2 |
| `pygments` | 2.19.2 | PYSEC-2026-2987 | 2.20.0 |
| `pymupdf` | 1.26.5 | PYSEC-2026-3001 | 1.26.7 |

## Two are fixed, one is masked — and they are different situations

**Fixed by bumping.** `pip` is dev-only (pulled in by pip-audit itself) and `pygments` is transitive via pytest and rich, so neither is on the runtime path. The lock moves pip to 26.2.1 and pygments to 2.21.0.

**Masked, with a reason and an expiry.** `pymupdf`'s fix requires 1.26.7, which `pyproject.toml` pins away from — *"1.26.6 lacks Docker wheel, 1.26.7 breaks footnote extraction"*. The gate's own rule permits an ignore when a documented pin blocks the fix, so PYSEC-2026-3001 joins CVE-2026-3029 on the same reason. Unpinning is a RAG-pipeline change and follows the stricter real-PDF process in `AGENTS.md`; it does not belong in a dependency sweep. It is tracked in #148 instead, because a masked advisory with no expiry is how a pin outlives its reason — the count against this pin is now two and will keep growing.

## One ignore removed

`--ignore-vuln CVE-2026-4539` (pygments) was justified as *"no compatible fix published"*. One has been published since, and the bump above takes it, so the ignore now masks nothing and only widens the blind spot. Removed.

## Verification

- `uv run pip-audit` with the three remaining ignores → **"No known vulnerabilities found, 1 ignored"**, exit 0.
- Fast Python suite → **1290 passed, 3 skipped, 7 xfailed**.

## Relationship to #122

Supersedes it. #122 is dependabot's pip bump alone, which would have left the pygments advisory failing the gate — and being a dependabot PR it does not attract a connector review, so it cannot clear the review requirement on its own. Close #122 when this lands.
