### PR TITLE
feat(annas): key-free downloads through a browser-resident session (#143, #144)

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -91,7 +91,7 @@ keep working. See `docs/api.md` for the full response shapes.
 |--------|---------------|
 | `base.py` | `SourceAdapter` ABC: `search()`, `get_download_url(md5)`, `close()` |
 | `models.py` | `UnifiedBookResult`, `DownloadResult` (shared result shapes) |
-| `config.py` | `SourceConfig` from env (`ANNAS_SECRET_KEY`, `ANNAS_BASE_URL`, `LIBGEN_MIRROR`, `BOOK_SOURCE_DEFAULT`, `BOOK_SOURCE_FALLBACK_ENABLED`) |
+| `config.py` | `SourceConfig` from env (`ANNAS_SECRET_KEY`, `ANNAS_BASE_URL`, `LIBGEN_MIRROR`, `BOOK_SOURCE_DEFAULT`, `BOOK_SOURCE_FALLBACK_ENABLED`, the `ANNAS_BROWSER_*` family) |
 | `annas.py` | Anna's Archive adapter — HTML scraping (BeautifulSoup); DOM-fragile surface |
 | `libgen.py` | LibGen adapter (fallback source) |
 | `router.py` | `SourceRouter`: Anna's primary when key configured, LibGen fallback on error/quota exhaustion; source selection `auto`/`annas`/`libgen` |
@@ -278,6 +278,11 @@ zlibrary-mcp/
 
 ### Alternative Sources
 - Anna's Archive: HTML-scraped; fast downloads gated on `ANNAS_SECRET_KEY`; quota-aware
+- Anna's Archive, key-free: `annas_browser.py` drives a headful browser on the operator's
+  machine to *resolve* download links, then hands the URL back for the ordinary httpx
+  transfer. The browser never sees the file bytes, so content-md5 verification, throughput
+  bounding and atomic staging stay in one place. Serialised and rate-limited in the same
+  module, because the route's scope is conditional on the limits (#143, #144)
 - LibGen: mirror-configurable fallback
 - Both monitored daily by the Upstream Contract Check workflow
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,10 @@ capabilities.
 |--------|---------|-------------|--------|----------|
 | Library Genesis | No | None | Yes | Yes |
 | Z-Library | Yes | Approximately 10 books | Yes | Yes |
-| Anna's Archive | API key for downloads | Set by membership | Yes | Only with an API key |
+| Anna's Archive | API key, or a browser you solve one challenge in | Membership, or 30 requests/day | Yes | Keyed, or key-free through your own browser |
+
+Anna's Archive has **two** download routes and the table compresses both; see
+[Anna's Archive](#annas-archive) below for which one you want.
 
 ### Library Genesis
 

--- a/README.md
+++ b/README.md
@@ -213,8 +213,13 @@ The server then reads the download links out of that same browser and fetches th
 normally. Set `ANNAS_BROWSER_ENABLED=true` and install the extra:
 
 ```bash
-uv sync --extra annas-browser && playwright install chrome
+uv sync --extra annas-browser
+uv run --extra annas-browser playwright install chrome
 ```
+
+(`uv run` is not optional there: `uv sync` puts the `playwright` script in
+`.venv/bin` without putting that directory on your `PATH`, so calling it
+directly fails with `command not found` on a fresh setup.)
 
 A visible browser window opens when a download starts. Solve the challenge if it appears;
 clearance then lasts about twenty minutes. **This route cannot run headless** — a headless

--- a/README.md
+++ b/README.md
@@ -218,16 +218,28 @@ unattended.
 download route with a browser verification challenge, and this server does not solve that
 challenge — a real Chrome window on your own machine does, once, with you in front of it.
 The server then reads the download links out of that same browser and fetches the file
-normally. Set `ANNAS_BROWSER_ENABLED=true` and install the extra:
+normally. Set `ANNAS_BROWSER_ENABLED=true` and add the browser extra to the tier you use:
 
 ```bash
+# Core only
+uv sync --no-dev --extra annas-browser
+
+# Core + RAG, or the complete scholar tier
+uv sync --no-dev --extra rag --extra annas-browser
+uv sync --no-dev --extra scholar --extra annas-browser
+
+# Contributor environment (keeps the default dev group)
 uv sync --extra annas-browser
-uv run --extra annas-browser playwright install chrome
+
+# Run after one of the sync commands above; --no-sync preserves that tier.
+uv run --no-sync playwright install chrome
 ```
 
 (`uv run` is not optional there: `uv sync` puts the `playwright` script in
-`.venv/bin` without putting that directory on your `PATH`, so calling it
-directly fails with `command not found` on a fresh setup.)
+`.venv/bin` without putting that directory on your `PATH`. The `--no-sync`
+flag is also deliberate: running `uv run` with only `--extra annas-browser`
+would re-synchronize the environment and remove an existing `rag` or `scholar`
+tier.)
 
 A visible browser window opens when a download starts. Solve the challenge if it appears;
 clearance then lasts about twenty minutes. **This route cannot run headless** — a headless

--- a/README.md
+++ b/README.md
@@ -200,10 +200,45 @@ An absent `also_available_on` field is not present in the result.
 the file can leave the other source later. Use it to prefer a source that has no daily
 limit. Do not depend on it.
 
-Anna's Archive downloads need a membership API key in `ANNAS_SECRET_KEY`. Without a key,
-the server cannot download from Anna's Archive. Anna's Archive protects its free download
-route with a browser verification challenge, and this server does not defeat that
-protection. Open the record URL in a web browser to download a file without a key.
+Anna's Archive has two download routes.
+
+**Keyed fast downloads** need a membership API key in `ANNAS_SECRET_KEY`. This is the
+route to use if you have a membership: it is fast, it needs no browser, and it works
+unattended.
+
+**The browser-resident route** needs no key, and needs you. Anna's protects its free
+download route with a browser verification challenge, and this server does not solve that
+challenge — a real Chrome window on your own machine does, once, with you in front of it.
+The server then reads the download links out of that same browser and fetches the file
+normally. Set `ANNAS_BROWSER_ENABLED=true` and install the extra:
+
+```bash
+uv sync --extra annas-browser && playwright install chrome
+```
+
+A visible browser window opens when a download starts. Solve the challenge if it appears;
+clearance then lasts about twenty minutes. **This route cannot run headless** — a headless
+browser fails even holding clearance a visible one earned minutes earlier.
+
+It is also deliberately slow. Anna's states its reason for the challenge plainly —
+*"browser verification for our slow downloads, because otherwise bots and scrapers will
+abuse them"* — so this route is rate-limited to personal reading pace and refuses rather
+than speeding up: one request at a time, 20 seconds apart, 30 per day. On a challenge or a
+refusal it backs off for five minutes instead of retrying. The limits are configurable
+(`ANNAS_BROWSER_MIN_INTERVAL`, `ANNAS_BROWSER_DAILY_LIMIT`, `ANNAS_BROWSER_BACKOFF`),
+which is not an invitation to raise them.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ANNAS_BROWSER_ENABLED` | `false` | Turn the browser route on |
+| `ANNAS_BROWSER_PROFILE_DIR` | `~/.cache/zlibrary-mcp/annas-browser-profile` | Where clearance is kept between runs |
+| `ANNAS_BROWSER_MIN_INTERVAL` | `20` | Seconds between requests |
+| `ANNAS_BROWSER_DAILY_LIMIT` | `30` | Requests per day (a book costs about two) |
+| `ANNAS_BROWSER_BACKOFF` | `300` | Seconds to wait after a challenge or refusal |
+| `ANNAS_BROWSER_SETTLE` | `40` | Seconds to let the challenge hop finish |
+| `ANNAS_BROWSER_MAX_SERVERS` | `3` | Partner servers to try before giving up |
+
+LibGen needs neither key nor browser, and remains the credential-free default.
 
 **Warning:** the fast-download API sends `ANNAS_SECRET_KEY` as a URL parameter. Therefore
 the server sends the key only to hosts in `ANNAS_TRUSTED_HOSTS` in `lib/sources/config.py`.

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -809,26 +809,88 @@ class TestCrossProcessSerialisation:
         )
         holder.release()
 
-    def test_an_unreadable_usage_count_is_unknown_not_zero(self, tmp_path):
-        """Fail-open must not look like an exhausted quota.
+    def test_an_unlockable_counter_refuses_rather_than_running_uncounted(
+        self, tmp_path
+    ):
+        """Fail CLOSED, because an unlockable path is not transient (#150).
 
-        Codex on #150: the fail-open path returned -1, which reached
-        `QuotaInfo.downloads_left`, and the router reads a non-positive value
-        as exhausted — so it discarded a URL the walk had already paid for.
+        An earlier version allowed the request uncounted so a lock problem
+        would not block the operator. But every later process takes the same
+        branch, so the ceiling disappears permanently and silently — and this
+        route's scope is conditional on the ceiling being real. A refusal is
+        visible and fixable in one command; an unbounded browser route against
+        an anti-abuse control is neither.
         """
-        from lib.sources.annas_usage import DailyUsage
+        from lib.sources.annas_usage import DailyUsage, UsageCounterUnavailableError
 
         usage = DailyUsage(str(tmp_path / "usage.json"))
-        usage._acquire = lambda: False  # simulate a lock we cannot take
+        usage._acquire = lambda: False  # a lock we can never take
 
-        allowed, remaining, wait = usage.spend(30, 20.0)
+        with pytest.raises(UsageCounterUnavailableError) as excinfo:
+            usage.spend(30, 20.0)
 
-        assert allowed is True, "a lock problem must not block the operator"
-        assert remaining is None, "unknown must not be representable as a count"
-        assert wait == 20.0, (
-            "spacing must still apply when the count is unknown; failing open "
-            "on the ceiling is not a reason to also stop being polite"
+        assert "ANNAS_BROWSER_PROFILE_DIR" in str(excinfo.value), (
+            "the refusal has to say how to fix it, or it is just an outage"
         )
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_reaches_the_caller_as_a_configuration_error(
+        self, tmp_path
+    ):
+        """Permanent until the operator acts, so not evidence Anna's is down."""
+        from lib.sources.errors import ProviderConfigurationError
+
+        session = _session([BOOK_PAGE, PARTNER_PAGE], tmp_path)
+        session._limiter.usage._acquire = lambda: False
+
+        with pytest.raises(ProviderConfigurationError) as excinfo:
+            await session.resolve_download_url(MD5)
+
+        assert excinfo.value.reason == "configuration_error"
+
+    def test_liveness_never_signals_the_process_it_asks_about(self, tmp_path):
+        """`os.kill(pid, 0)` terminates the target on Windows (#150).
+
+        CPython maps any signal but the console-control values onto
+        `TerminateProcess`, so the "harmless" probe would have killed the
+        bridge holding the browser lock — and then waited behind a lock whose
+        owner it had just destroyed.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from lib.sources import annas_usage
+
+        tree = ast.parse(
+            textwrap.dedent(inspect.getsource(annas_usage._process_exists))
+        )
+        body = tree.body[0].body
+        # Drop the docstring, which legitimately *mentions* os.kill while
+        # explaining why it is guarded.
+        if isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+            body = body[1:]
+        code = "\n".join(ast.unparse(node) for node in body)
+
+        assert "win32" in code, "the Windows path must be handled in code"
+        assert "OpenProcess" in code
+        # The POSIX probe must sit behind the platform check, not before it.
+        assert code.index("win32") < code.index("os.kill("), (
+            "os.kill reached before the platform check would terminate the "
+            "process on Windows"
+        )
+
+    def test_liveness_reports_a_dead_pid_as_dead(self):
+        from lib.sources.annas_usage import _process_exists
+
+        assert _process_exists(999999999) is False
+
+    def test_liveness_reports_this_process_as_alive(self):
+        import os
+
+        from lib.sources.annas_usage import _process_exists
+
+        assert _process_exists(os.getpid()) is True
 
     def test_an_unknown_budget_omits_quota_rather_than_reporting_zero(self):
         from lib.sources.annas import AnnasArchiveAdapter

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -21,7 +21,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from lib.sources.annas_usage import DailyUsage  # noqa: E402
+from lib.sources.annas_usage import CrossProcessLock, DailyUsage  # noqa: E402
 from lib.sources.annas_browser import (  # noqa: E402
     AnnasBrowserSession,
     visible_text,
@@ -778,48 +778,117 @@ class TestCrossProcessSerialisation:
         )
         session._process_lock.release()
 
-    def test_a_lock_whose_owner_died_is_reclaimed(self, tmp_path):
-        """A crashed process must not block the operator's tool forever."""
-        import os
-        import time
+    def test_a_lock_whose_holder_was_killed_is_immediately_available(self, tmp_path):
+        """A crashed holder must not wedge the operator's tool.
 
-        from lib.sources.annas_usage import CrossProcessLock
+        This is the finding that made the lock an OS lock. The directory
+        version had to *judge* staleness — read an owner pid, decide it was
+        dead, delete the directory — and two processes could pass that check
+        together, the second deleting a lock the first had already retaken
+        (Codex on #150, twice). There is nothing to judge here: the child is
+        SIGKILLed, so it runs no cleanup at all, and the kernel drops the lock
+        because the file descriptor holding it is closed.
 
-        path = tmp_path / "held.lock"
-        os.makedirs(path)
-        # A PID that cannot be running: os.kill(0, 0) targets the process
-        # group, so use a recorded value that reads back as absent instead.
-        (path / "owner").write_text("999999999")
-        time.sleep(0.06)
+        A real subprocess, killed for real. A mocked pid would only test the
+        bookkeeping that this change deletes.
+        """
+        import subprocess
+        import sys as _sys
 
-        lock = CrossProcessLock(str(path), stale_after=0.05)
+        repo_root = Path(__file__).resolve().parents[2]
+        lock_path = tmp_path / "held.lock"
+        child = subprocess.Popen(
+            [
+                _sys.executable,
+                "-c",
+                (
+                    "import sys, time\n"
+                    f"sys.path.insert(0, {str(repo_root)!r})\n"
+                    "from lib.sources.annas_usage import CrossProcessLock\n"
+                    f"lock = CrossProcessLock({str(lock_path)!r})\n"
+                    "assert lock.acquire(5.0)\n"
+                    "print('HELD', flush=True)\n"
+                    "time.sleep(300)\n"
+                ),
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert child.stdout.readline().strip() == "HELD", (
+                "the child never took the lock, so this test proves nothing"
+            )
+            contender = CrossProcessLock(str(lock_path))
+            assert contender.acquire(0.3) is False, (
+                "a live holder's lock was handed to a second process"
+            )
+            child.kill()
+            child.wait(timeout=10)
+        finally:
+            if child.poll() is None:  # pragma: no cover - only on an early failure
+                child.kill()
+                child.wait(timeout=10)
 
-        assert lock.acquire(1.0) is True
-        lock.release()
+        reclaimer = CrossProcessLock(str(lock_path))
+        assert reclaimer.acquire(2.0) is True, (
+            "the kernel did not release the lock when its holder died"
+        )
+        reclaimer.release()
 
-    def test_a_live_owner_is_never_reclaimed_however_old(self, tmp_path):
-        """Age is not evidence of staleness while the holder is running.
+    def test_a_live_holder_is_never_displaced_however_long_it_holds(self, tmp_path):
+        """Age is not evidence of anything while the holder is running.
 
         Codex on #150: a payload transfer may legitimately run for 25 minutes
-        with the holder suspended, still owning the Chrome profile. Reclaiming
-        on age alone would launch a second Chrome against a profile in use and
-        break both downloads.
+        with the holder suspended, still owning the Chrome profile. The old
+        lock reclaimed on age and would have launched a second Chrome against
+        a profile in use. An OS lock has no age to consult.
         """
         import time
 
-        from lib.sources.annas_usage import CrossProcessLock
-
-        holder = CrossProcessLock(str(tmp_path / "held.lock"), stale_after=0.05)
+        holder = CrossProcessLock(str(tmp_path / "held.lock"))
         assert holder.acquire(1.0) is True
-        time.sleep(0.1)  # well past stale_after
+        time.sleep(0.1)
 
-        other = CrossProcessLock(str(tmp_path / "held.lock"), stale_after=0.05)
+        other = CrossProcessLock(str(tmp_path / "held.lock"))
+        try:
+            assert other.acquire(0.3) is False, (
+                "a second holder took a lock the first is still using"
+            )
+        finally:
+            holder.release()
 
-        assert other.acquire(0.3) is False, (
-            "the owner of this lock is this very process; reclaiming it on age "
-            "would hand the browser to a second holder while the first is using it"
-        )
-        holder.release()
+        assert other.acquire(1.0) is True, "the lock was not released"
+        other.release()
+
+    def test_nothing_reads_the_owner_pid_to_make_a_decision(self):
+        """The pid in the lock file is diagnostics, and must stay that way.
+
+        Every version of this lock that consulted a pid to decide whether it
+        could take the lock had a check-then-act race. This asserts the source
+        carries no liveness probe, so a future round cannot reintroduce one
+        without deleting this test and saying why.
+        """
+        import inspect
+
+        from lib.sources import annas_usage
+
+        source = inspect.getsource(annas_usage)
+
+        for banned in ("os.kill(", "OpenProcess", "/proc/", "stale_after"):
+            assert banned not in source, (
+                f"{banned!r} is back in the lock module; the OS lock exists "
+                f"precisely so no pid has to be judged"
+            )
+
+    def test_acquiring_a_lock_this_object_already_holds_is_an_error(self, tmp_path):
+        """Silently re-entering would make one release() drop a held lock."""
+        lock = CrossProcessLock(str(tmp_path / "held.lock"))
+        assert lock.acquire(1.0) is True
+        try:
+            with pytest.raises(RuntimeError):
+                lock.acquire(1.0)
+        finally:
+            lock.release()
 
     def test_an_unlockable_counter_refuses_rather_than_running_uncounted(
         self, tmp_path
@@ -859,50 +928,6 @@ class TestCrossProcessSerialisation:
             await session.resolve_download_url(MD5)
 
         assert excinfo.value.reason == "configuration_error"
-
-    def test_liveness_never_signals_the_process_it_asks_about(self, tmp_path):
-        """`os.kill(pid, 0)` terminates the target on Windows (#150).
-
-        CPython maps any signal but the console-control values onto
-        `TerminateProcess`, so the "harmless" probe would have killed the
-        bridge holding the browser lock — and then waited behind a lock whose
-        owner it had just destroyed.
-        """
-        import ast
-        import inspect
-        import textwrap
-
-        from lib.sources import annas_usage
-
-        tree = ast.parse(
-            textwrap.dedent(inspect.getsource(annas_usage._process_exists))
-        )
-        body = tree.body[0].body
-        # Drop the docstring, which legitimately *mentions* os.kill while
-        # explaining why it is guarded.
-        if isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
-            body = body[1:]
-        code = "\n".join(ast.unparse(node) for node in body)
-
-        assert "win32" in code, "the Windows path must be handled in code"
-        assert "OpenProcess" in code
-        # The POSIX probe must sit behind the platform check, not before it.
-        assert code.index("win32") < code.index("os.kill("), (
-            "os.kill reached before the platform check would terminate the "
-            "process on Windows"
-        )
-
-    def test_liveness_reports_a_dead_pid_as_dead(self):
-        from lib.sources.annas_usage import _process_exists
-
-        assert _process_exists(999999999) is False
-
-    def test_liveness_reports_this_process_as_alive(self):
-        import os
-
-        from lib.sources.annas_usage import _process_exists
-
-        assert _process_exists(os.getpid()) is True
 
     def test_an_unknown_budget_omits_quota_rather_than_reporting_zero(self):
         from lib.sources.annas import AnnasArchiveAdapter

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -307,10 +307,47 @@ class TestRateLimiter:
 
         limiter.penalise(60.0)
 
-        assert limiter._last_request > asyncio.get_running_loop().time() - 1, (
+        _, _, wait = limiter.usage.spend(limiter.daily_limit, limiter.min_interval)
+        assert wait > 50, (
             "penalise must push the next allowed request into the future; a "
             "no-op here means retrying straight back into the wall"
         )
+
+    @pytest.mark.asyncio
+    async def test_the_backoff_survives_a_new_process(self, tmp_path):
+        """The fifth instance of state-dies-with-the-process on this PR.
+
+        A backoff held in memory was true of the call that hit the wall and
+        false of the next one an operator made, so "back off five minutes
+        rather than retrying into it" held only within a single bridge process
+        — which is never where the next request comes from.
+        """
+        state = str(tmp_path / "usage.json")
+        first = _RateLimiter(min_interval=0.0, daily_limit=10, usage=DailyUsage(state))
+        await first.acquire()
+        first.penalise(120.0)
+
+        second = _RateLimiter(min_interval=0.0, daily_limit=10, usage=DailyUsage(state))
+        _, _, wait = second.usage.spend(10, 0.0)
+
+        assert wait > 100, "a fresh process walked straight back into the wall"
+
+    @pytest.mark.asyncio
+    async def test_spacing_survives_a_new_process(self, tmp_path):
+        """Two sequential MCP downloads are two processes, not two coroutines.
+
+        The 20-second minimum interval held inside one call and reset on the
+        next, so back-to-back downloads were not spaced at all — and
+        back-to-back is the ordinary case.
+        """
+        state = str(tmp_path / "usage.json")
+        first = _RateLimiter(min_interval=5.0, daily_limit=10, usage=DailyUsage(state))
+        await first.acquire()
+
+        second = _RateLimiter(min_interval=5.0, daily_limit=10, usage=DailyUsage(state))
+        _, _, wait = second.usage.spend(10, 5.0)
+
+        assert wait > 3, f"a second process must wait out the interval, got {wait:.1f}s"
 
     def test_remaining_is_reported_so_the_caller_can_see_the_budget(self, tmp_path):
         limiter = _limiter(tmp_path, daily_limit=4)
@@ -426,12 +463,11 @@ class TestResolveDownloadUrl:
         session = _session(
             [BOOK_PAGE, challenge], tmp_path, annas_browser_backoff_seconds=120.0
         )
-        before = session._limiter._last_request
-
         with pytest.raises(ChallengeNotClearedError):
             await session.resolve_download_url(MD5)
 
-        assert session._limiter._last_request > before + 60
+        _, _, wait = session._limiter.usage.spend(session._limiter.daily_limit, 0.0)
+        assert wait > 60, "the challenge must leave a durable backoff behind"
 
     @pytest.mark.asyncio
     async def test_annas_own_limit_is_reported_as_quota_not_as_a_challenge(
@@ -785,10 +821,14 @@ class TestCrossProcessSerialisation:
         usage = DailyUsage(str(tmp_path / "usage.json"))
         usage._acquire = lambda: False  # simulate a lock we cannot take
 
-        allowed, remaining = usage.spend(30)
+        allowed, remaining, wait = usage.spend(30, 20.0)
 
         assert allowed is True, "a lock problem must not block the operator"
         assert remaining is None, "unknown must not be representable as a count"
+        assert wait == 20.0, (
+            "spacing must still apply when the count is unknown; failing open "
+            "on the ceiling is not a reason to also stop being polite"
+        )
 
     def test_an_unknown_budget_omits_quota_rather_than_reporting_zero(self):
         from lib.sources.annas import AnnasArchiveAdapter

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -21,6 +21,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from lib.sources.annas_usage import DailyUsage  # noqa: E402
 from lib.sources.annas_browser import (  # noqa: E402
     AnnasBrowserSession,
     visible_text,
@@ -39,9 +40,13 @@ pytestmark = pytest.mark.unit
 MD5 = "a" * 32
 
 
-def _config(**overrides) -> SourceConfig:
+def _config(tmp_path, **overrides) -> SourceConfig:
     base = dict(
         annas_base_url="https://annas-archive.gl",
+        # Always a per-test directory. The daily counter is a real file beside
+        # the profile, so a test that used the default would spend the
+        # operator's actual budget and leak state between tests.
+        annas_browser_profile_dir=str(tmp_path / "profile"),
         annas_browser_enabled=True,
         annas_browser_min_interval=0.0,
         annas_browser_settle_seconds=0.0,
@@ -76,8 +81,16 @@ class _FakePage:
         self.closed = True
 
 
-def _session(bodies, **overrides) -> AnnasBrowserSession:
-    session = AnnasBrowserSession(_config(**overrides))
+def _limiter(tmp_path, min_interval=0.0, daily_limit=10) -> _RateLimiter:
+    return _RateLimiter(
+        min_interval=min_interval,
+        daily_limit=daily_limit,
+        usage=DailyUsage(str(tmp_path / "usage.json")),
+    )
+
+
+def _session(bodies, tmp_path, **overrides) -> AnnasBrowserSession:
+    session = AnnasBrowserSession(_config(tmp_path, **overrides))
     page = _FakePage(bodies)
 
     class _Ctx:
@@ -108,7 +121,7 @@ PARTNER_PAGE = """
 class TestLinkSelection:
     """The browser's whole job is picking the right link off Anna's own pages."""
 
-    def test_only_this_book_s_partner_links_are_taken(self):
+    def test_only_this_book_s_partner_links_are_taken(self, tmp_path):
         paths = AnnasBrowserSession._slow_download_paths(BOOK_PAGE, MD5)
 
         assert paths == [f"/slow_download/{MD5}/0/0", f"/slow_download/{MD5}/0/1"], (
@@ -116,7 +129,7 @@ class TestLinkSelection:
             "would spend rate budget and download the wrong file"
         )
 
-    def test_annas_own_ordering_is_preserved(self):
+    def test_annas_own_ordering_is_preserved(self, tmp_path):
         page = (
             f'<a href="/slow_download/{MD5}/0/5">e</a>'
             f'<a href="/slow_download/{MD5}/0/2">b</a>'
@@ -129,12 +142,12 @@ class TestLinkSelection:
             "Anna's lists the servers it expects to work first; sorting invents knowledge"
         )
 
-    def test_duplicate_links_are_visited_once(self):
+    def test_duplicate_links_are_visited_once(self, tmp_path):
         page = f'<a href="/slow_download/{MD5}/0/0">x</a>' * 3
 
         assert len(AnnasBrowserSession._slow_download_paths(page, MD5)) == 1
 
-    def test_the_payload_link_must_be_off_site(self):
+    def test_the_payload_link_must_be_off_site(self, tmp_path):
         """Same-host candidates are other Anna's pages, not the file."""
         page = (
             '<a href="https://annas-archive.gl/md5/deadbeef.pdf">not the file</a>'
@@ -145,7 +158,7 @@ class TestLinkSelection:
 
         assert url == "https://cdn9.example.org/x/book.epub"
 
-    def test_no_payload_link_returns_none_rather_than_a_page_url(self):
+    def test_no_payload_link_returns_none_rather_than_a_page_url(self, tmp_path):
         page = '<a href="https://annas-archive.gl/faq">faq</a><a href="/x">y</a>'
 
         assert AnnasBrowserSession._direct_file_url(page, "annas-archive.gl") is None
@@ -166,10 +179,10 @@ class TestWallClassification:
     def test_challenge_bodies_are_named(self, body):
         assert _classify_page(body) == "challenge"
 
-    def test_annas_own_limit_is_distinguished_from_the_challenge(self):
+    def test_annas_own_limit_is_distinguished_from_the_challenge(self, tmp_path):
         assert _classify_page("You have downloaded too many files today") == "exhausted"
 
-    def test_an_ordinary_page_is_not_a_wall(self):
+    def test_an_ordinary_page_is_not_a_wall(self, tmp_path):
         assert _classify_page(BOOK_PAGE) is None
 
 
@@ -211,17 +224,17 @@ class TestTheWallDetectorDoesNotFireOnRealPages:
     </body></html>
     """
 
-    def test_a_real_book_page_is_not_a_wall(self):
+    def test_a_real_book_page_is_not_a_wall(self, tmp_path):
         assert _classify_page(self.REAL_PAGE) is None, (
             "Anna's own source comments mention DDOS-GUARD on every page; "
             "reading them as a wall fails every successful request"
         )
 
-    def test_script_comments_are_not_visible_text(self):
+    def test_script_comments_are_not_visible_text(self, tmp_path):
         assert "ddos-guard" not in visible_text(self.REAL_PAGE).lower()
         assert "Feynman" in visible_text(self.REAL_PAGE)
 
-    def test_a_page_with_book_links_is_never_a_wall(self):
+    def test_a_page_with_book_links_is_never_a_wall(self, tmp_path):
         """Positive evidence outranks a phrase match.
 
         A challenge interstitial has no book links in it. If they are present
@@ -232,7 +245,7 @@ class TestTheWallDetectorDoesNotFireOnRealPages:
 
         assert _classify_page(awkward) is None
 
-    def test_a_genuine_interstitial_still_registers(self):
+    def test_a_genuine_interstitial_still_registers(self, tmp_path):
         """The guards must not have turned the detector off entirely."""
         interstitial = (
             "<html><head><title>Just a moment...</title></head>"
@@ -246,7 +259,7 @@ class TestTheWallDetectorDoesNotFireOnRealPages:
 class TestRateLimiter:
     """#144 is structural here, not a documented convention."""
 
-    def test_defaults_are_slow_on_purpose(self):
+    def test_defaults_are_slow_on_purpose(self, tmp_path):
         """Guard the production numbers against being 'tuned' for test speed.
 
         The scope reversal that put this route in scope is conditional on these
@@ -262,8 +275,8 @@ class TestRateLimiter:
         assert config.annas_browser_enabled is False, "must stay opt-in"
 
     @pytest.mark.asyncio
-    async def test_requests_are_spaced(self):
-        limiter = _RateLimiter(min_interval=0.05, daily_limit=10)
+    async def test_requests_are_spaced(self, tmp_path):
+        limiter = _limiter(tmp_path, min_interval=0.05)
         loop = asyncio.get_running_loop()
 
         await limiter.acquire()
@@ -273,8 +286,8 @@ class TestRateLimiter:
         assert loop.time() - start >= 0.04
 
     @pytest.mark.asyncio
-    async def test_the_daily_ceiling_refuses_rather_than_sleeping(self):
-        limiter = _RateLimiter(min_interval=0.0, daily_limit=2)
+    async def test_the_daily_ceiling_refuses_rather_than_sleeping(self, tmp_path):
+        limiter = _limiter(tmp_path, daily_limit=2)
 
         await limiter.acquire()
         await limiter.acquire()
@@ -288,8 +301,8 @@ class TestRateLimiter:
         ), "the message must not read as a provider failure"
 
     @pytest.mark.asyncio
-    async def test_backing_off_moves_the_floor_not_just_the_clock(self):
-        limiter = _RateLimiter(min_interval=0.0, daily_limit=10)
+    async def test_backing_off_moves_the_floor_not_just_the_clock(self, tmp_path):
+        limiter = _limiter(tmp_path)
         await limiter.acquire()
 
         limiter.penalise(60.0)
@@ -299,16 +312,56 @@ class TestRateLimiter:
             "no-op here means retrying straight back into the wall"
         )
 
-    def test_remaining_is_reported_so_the_caller_can_see_the_budget(self):
-        limiter = _RateLimiter(min_interval=0.0, daily_limit=4)
+    def test_remaining_is_reported_so_the_caller_can_see_the_budget(self, tmp_path):
+        limiter = _limiter(tmp_path, daily_limit=4)
 
         assert limiter.remaining_today == 4
+
+    @pytest.mark.asyncio
+    async def test_the_ceiling_survives_a_new_process(self, tmp_path):
+        """The finding that made this ceiling real rather than decorative.
+
+        Codex on #150: every MCP operation starts a fresh `python_bridge.py`,
+        so a counter held in the limiter instance reset to zero on every
+        download. The advertised 30-per-day ceiling could never be reached, and
+        the scope this route was granted is conditional on the limits being
+        real. A second `_RateLimiter` over the same state file stands in for
+        the second process.
+        """
+        state = str(tmp_path / "usage.json")
+        first = _RateLimiter(min_interval=0.0, daily_limit=2, usage=DailyUsage(state))
+        await first.acquire()
+        await first.acquire()
+
+        second = _RateLimiter(min_interval=0.0, daily_limit=2, usage=DailyUsage(state))
+
+        assert second.remaining_today == 0
+        with pytest.raises(DailyLimitReachedError):
+            await second.acquire()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_processes_cannot_both_take_the_last_slot(self, tmp_path):
+        """Two bridge processes must not each read `limit - 1` and proceed."""
+        state = str(tmp_path / "usage.json")
+        limiters = [
+            _RateLimiter(min_interval=0.0, daily_limit=1, usage=DailyUsage(state))
+            for _ in range(4)
+        ]
+
+        results = await asyncio.gather(
+            *(limiter.acquire() for limiter in limiters), return_exceptions=True
+        )
+        granted = [r for r in results if not isinstance(r, BaseException)]
+
+        assert len(granted) == 1, f"exactly one slot exists, {len(granted)} granted"
 
 
 class TestResolveDownloadUrl:
     @pytest.mark.asyncio
-    async def test_the_happy_path_returns_a_url_and_the_remaining_budget(self):
-        session = _session([BOOK_PAGE, PARTNER_PAGE])
+    async def test_the_happy_path_returns_a_url_and_the_remaining_budget(
+        self, tmp_path
+    ):
+        session = _session([BOOK_PAGE, PARTNER_PAGE], tmp_path)
 
         url, remaining = await session.resolve_download_url(MD5)
 
@@ -320,9 +373,9 @@ class TestResolveDownloadUrl:
         ]
 
     @pytest.mark.asyncio
-    async def test_the_browser_never_fetches_the_file(self):
+    async def test_the_browser_never_fetches_the_file(self, tmp_path):
         """The transfer belongs to httpx, which already verifies content md5."""
-        session = _session([BOOK_PAGE, PARTNER_PAGE])
+        session = _session([BOOK_PAGE, PARTNER_PAGE], tmp_path)
 
         url, _ = await session.resolve_download_url(MD5)
 
@@ -333,9 +386,9 @@ class TestResolveDownloadUrl:
         )
 
     @pytest.mark.asyncio
-    async def test_a_dead_partner_server_falls_through_to_the_next(self):
+    async def test_a_dead_partner_server_falls_through_to_the_next(self, tmp_path):
         dead = '<html><body><a href="/faq">nothing here</a></body></html>'
-        session = _session([BOOK_PAGE, dead, PARTNER_PAGE])
+        session = _session([BOOK_PAGE, dead, PARTNER_PAGE], tmp_path)
 
         url, _ = await session.resolve_download_url(MD5)
 
@@ -343,10 +396,12 @@ class TestResolveDownloadUrl:
         assert len(session._page.visited) == 3
 
     @pytest.mark.asyncio
-    async def test_a_challenge_stops_immediately_rather_than_trying_more_servers(self):
+    async def test_a_challenge_stops_immediately_rather_than_trying_more_servers(
+        self, tmp_path
+    ):
         """Retrying into the wall is the behaviour the limiter exists to stop."""
         challenge = "<html><body>Checking your browser before accessing</body></html>"
-        session = _session([BOOK_PAGE, challenge, PARTNER_PAGE])
+        session = _session([BOOK_PAGE, challenge, PARTNER_PAGE], tmp_path)
 
         with pytest.raises(ChallengeNotClearedError) as excinfo:
             await session.resolve_download_url(MD5)
@@ -361,9 +416,11 @@ class TestResolveDownloadUrl:
         )
 
     @pytest.mark.asyncio
-    async def test_a_challenge_backs_the_limiter_off(self):
+    async def test_a_challenge_backs_the_limiter_off(self, tmp_path):
         challenge = "<html><body>Checking your browser before accessing</body></html>"
-        session = _session([BOOK_PAGE, challenge], annas_browser_backoff_seconds=120.0)
+        session = _session(
+            [BOOK_PAGE, challenge], tmp_path, annas_browser_backoff_seconds=120.0
+        )
         before = session._limiter._last_request
 
         with pytest.raises(ChallengeNotClearedError):
@@ -372,9 +429,11 @@ class TestResolveDownloadUrl:
         assert session._limiter._last_request > before + 60
 
     @pytest.mark.asyncio
-    async def test_annas_own_limit_is_reported_as_quota_not_as_a_challenge(self):
+    async def test_annas_own_limit_is_reported_as_quota_not_as_a_challenge(
+        self, tmp_path
+    ):
         limited = "<html><body>You have downloaded too many files</body></html>"
-        session = _session([BOOK_PAGE, limited, PARTNER_PAGE])
+        session = _session([BOOK_PAGE, limited, PARTNER_PAGE], tmp_path)
 
         with pytest.raises(ProviderRateLimitedError) as excinfo:
             await session.resolve_download_url(MD5)
@@ -388,10 +447,10 @@ class TestResolveDownloadUrl:
         )
 
     @pytest.mark.asyncio
-    async def test_a_missing_book_is_not_found_not_a_wall(self):
+    async def test_a_missing_book_is_not_found_not_a_wall(self, tmp_path):
         """The page loaded and no challenge fired, so retrying is pointless."""
         empty = "<html><body><h1>Not found</h1></body></html>"
-        session = _session([empty])
+        session = _session([empty], tmp_path)
 
         with pytest.raises(ProviderResponseError) as excinfo:
             await session.resolve_download_url(MD5)
@@ -399,11 +458,12 @@ class TestResolveDownloadUrl:
         assert excinfo.value.reason == "not_found"
 
     @pytest.mark.asyncio
-    async def test_the_walk_is_bounded_by_max_servers(self):
+    async def test_the_walk_is_bounded_by_max_servers(self, tmp_path):
         many = "".join(f'<a href="/slow_download/{MD5}/0/{n}">s</a>' for n in range(8))
         dead = "<html><body>no link</body></html>"
         session = _session(
             [f"<html><body>{many}</body></html>", dead, dead],
+            tmp_path,
             annas_browser_max_servers=2,
         )
 
@@ -416,8 +476,8 @@ class TestResolveDownloadUrl:
         )
 
     @pytest.mark.asyncio
-    async def test_the_page_is_closed_even_when_the_walk_fails(self):
-        session = _session(["<html><body>Not found</body></html>"])
+    async def test_the_page_is_closed_even_when_the_walk_fails(self, tmp_path):
+        session = _session(["<html><body>Not found</body></html>"], tmp_path)
 
         with pytest.raises(ProviderResponseError):
             await session.resolve_download_url(MD5)
@@ -425,14 +485,14 @@ class TestResolveDownloadUrl:
         assert session._page.closed is True
 
     @pytest.mark.asyncio
-    async def test_concurrent_callers_are_serialised(self):
+    async def test_concurrent_callers_are_serialised(self, tmp_path):
         """One request in flight per session, structurally (#144).
 
         The repo has already paid for fanning lanes out against a
         single-session provider; this is that lesson as a lock rather than as a
         convention someone has to remember.
         """
-        session = _session([BOOK_PAGE, PARTNER_PAGE])
+        session = _session([BOOK_PAGE, PARTNER_PAGE], tmp_path)
         assert session._lock is not None
 
         await session._lock.acquire()
@@ -448,7 +508,9 @@ class TestResolveDownloadUrl:
 
 class TestMissingPlaywright:
     @pytest.mark.asyncio
-    async def test_absent_playwright_is_a_configuration_error(self, monkeypatch):
+    async def test_absent_playwright_is_a_configuration_error(
+        self, tmp_path, monkeypatch
+    ):
         """Permanent until the operator acts, so not evidence Anna's is down."""
         import builtins
 
@@ -460,7 +522,7 @@ class TestMissingPlaywright:
             return real_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", refuse)
-        session = AnnasBrowserSession(_config())
+        session = AnnasBrowserSession(_config(tmp_path))
 
         with pytest.raises(BrowserUnavailableError) as excinfo:
             await session._ensure_context()
@@ -471,3 +533,62 @@ class TestMissingPlaywright:
         assert "LibGen" in message, (
             "a credential-free LibGen user must be told this does not affect them"
         )
+
+
+class TestPayloadExtensions:
+    """The allowlist is derived, and its fallback cannot silently drift."""
+
+    def test_every_supported_format_is_matched(self):
+        from lib.sources.annas_browser import _FILE_EXTENSION_RE
+
+        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "lib"))
+        from filename_utils import SAFE_DOCUMENT_EXTENSIONS
+
+        missing = [
+            ext
+            for ext in SAFE_DOCUMENT_EXTENSIONS
+            if not _FILE_EXTENSION_RE.search(f"https://cdn.example/x/book.{ext}")
+        ]
+
+        assert not missing, (
+            f"a partner page can carry a valid link in {missing} and "
+            f"_direct_file_url would return None, failing the download with a "
+            f"protocol error (Codex on #150)"
+        )
+
+    def test_the_fallback_mirrors_the_source_of_truth(self):
+        """Or the mirror rots exactly as the hand-written allowlist did."""
+        from lib.sources.annas_browser import _FALLBACK_EXTENSIONS
+
+        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "lib"))
+        from filename_utils import SAFE_DOCUMENT_EXTENSIONS
+
+        assert _FALLBACK_EXTENSIONS == SAFE_DOCUMENT_EXTENSIONS
+
+    def test_a_web_page_link_is_not_mistaken_for_a_payload(self):
+        from lib.sources.annas_browser import _FILE_EXTENSION_RE
+
+        assert not _FILE_EXTENSION_RE.search("https://cdn.example/page.html")
+
+
+class TestEntityDecoding:
+    def test_a_signed_url_with_several_parameters_survives(self):
+        """`page.content()` serialises `&` as `&amp;` (Codex on #150).
+
+        Sent to httpx unchanged, `&amp;Signature=` becomes the parameter
+        `amp;Signature`, the signature no longer validates, and a perfectly good
+        link 403s. The live URL that verified this route was path-signed and had
+        no `&` in it at all — which is how a bug like this survives a green
+        end-to-end run.
+        """
+        page = (
+            '<a href="https://cdn.example.net/x/book.pdf?'
+            'Expires=1&amp;Signature=abc&amp;Key-Pair-Id=K1">Download</a>'
+        )
+
+        url = AnnasBrowserSession._direct_file_url(page, "annas-archive.gl")
+
+        assert url == (
+            "https://cdn.example.net/x/book.pdf?Expires=1&Signature=abc&Key-Pair-Id=K1"
+        )
+        assert "amp;" not in url

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -168,6 +168,22 @@ class TestLinkSelection:
 
         assert AnnasBrowserSession._direct_file_url(page, "annas-archive.gl") is None
 
+    def test_an_opaque_signed_payload_url_is_not_discarded(self, tmp_path):
+        """The transfer layer validates bytes; the resolver must retain candidates.
+
+        Signed CDN routes do not have to expose a filename or extension.  The
+        old extractor discarded them before the content signature, response
+        URL, Content-Disposition, and Content-Type classifiers could run.
+        """
+        page = (
+            '<a href="https://example.org/about.html">About the mirror</a>'
+            '<a href="https://cdn9.example.org/download?id=opaque-token">Download</a>'
+        )
+
+        assert AnnasBrowserSession._direct_file_url(page, "annas-archive.gl") == (
+            "https://cdn9.example.org/download?id=opaque-token"
+        )
+
 
 class TestWallClassification:
     """A wall and a missing book need opposite responses, so they need names."""
@@ -337,6 +353,22 @@ class TestRateLimiter:
 
         assert wait > 100, "a fresh process walked straight back into the wall"
 
+    def test_lock_contention_keeps_the_backoff_in_this_process(
+        self, tmp_path, monkeypatch
+    ):
+        """Failure to persist a penalty cannot erase it from the current process."""
+        usage = DailyUsage(str(tmp_path / "usage.json"))
+        real_acquire = usage._acquire
+        monkeypatch.setattr(usage, "_acquire", lambda: False)
+
+        usage.penalise(120.0)
+
+        monkeypatch.setattr(usage, "_acquire", real_acquire)
+        allowed, _remaining, wait = usage.spend(10, 0.0)
+
+        assert allowed is True
+        assert wait > 100, "counter-lock contention erased the promised backoff"
+
     @pytest.mark.asyncio
     async def test_spacing_survives_a_new_process(self, tmp_path):
         """Two sequential MCP downloads are two processes, not two coroutines.
@@ -418,6 +450,13 @@ class TestResolveDownloadUrl:
             f"https://annas-archive.gl/md5/{MD5}",
             f"https://annas-archive.gl/slow_download/{MD5}/0/0",
         ]
+        assert session._page.closed is True, (
+            "the single-result wrapper returned without closing its async generator"
+        )
+        assert session._process_lock.acquire(1.0) is True, (
+            "the single-result wrapper left the browser process lock held"
+        )
+        session._process_lock.release()
 
     @pytest.mark.asyncio
     async def test_the_browser_never_fetches_the_file(self, tmp_path):
@@ -576,6 +615,9 @@ class TestMissingPlaywright:
         assert excinfo.value.reason == "configuration_error"
         message = str(excinfo.value)
         assert "annas-browser" in message, "must name the extra that installs it"
+        assert "uv run --no-sync playwright install chrome" in message, (
+            "installing Chrome must not re-sync away an already selected dependency tier"
+        )
         assert "LibGen" in message, (
             "a credential-free LibGen user must be told this does not affect them"
         )
@@ -777,6 +819,35 @@ class TestCrossProcessSerialisation:
             "for it to go stale"
         )
         session._process_lock.release()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_lock_acquisition_releases_a_late_lock(
+        self, tmp_path, monkeypatch
+    ):
+        """Cancelling the await cannot abandon a worker that later gets the lock."""
+        import time
+
+        session = _session([BOOK_PAGE, PARTNER_PAGE], tmp_path)
+        real_acquire = session._process_lock.acquire
+
+        def delayed_acquire(wait):
+            time.sleep(0.1)
+            return real_acquire(wait)
+
+        monkeypatch.setattr(session._process_lock, "acquire", delayed_acquire)
+        walk = asyncio.create_task(session.resolve_download_url(MD5))
+        await asyncio.sleep(0.02)
+
+        walk.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await walk
+
+        await asyncio.sleep(0.2)
+        contender = CrossProcessLock(session._process_lock.path)
+        assert contender.acquire(0.2) is True, (
+            "the cancelled await abandoned a worker that acquired the OS lock later"
+        )
+        contender.release()
 
     def test_a_lock_whose_holder_was_killed_is_immediately_available(self, tmp_path):
         """A crashed holder must not wedge the operator's tool.

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from lib.sources.annas_browser import (  # noqa: E402
     AnnasBrowserSession,
+    visible_text,
     BrowserUnavailableError,
     ChallengeNotClearedError,
     DailyLimitReachedError,
@@ -157,8 +158,9 @@ class TestWallClassification:
         "body",
         [
             "<h1>Checking your browser before accessing</h1>",
-            "<p>DDoS-Guard</p>",
+            "<p>DDoS-Guard protection. Please wait...</p>",
             "<div>Please enable JavaScript and cookies to continue</div>",
+            "<title>Just a moment...</title><p>Just a moment</p>",
         ],
     )
     def test_challenge_bodies_are_named(self, body):
@@ -169,6 +171,76 @@ class TestWallClassification:
 
     def test_an_ordinary_page_is_not_a_wall(self):
         assert _classify_page(BOOK_PAGE) is None
+
+
+class TestTheWallDetectorDoesNotFireOnRealPages:
+    """The bug a live run found and twenty-six mocked tests did not.
+
+    Every Anna's page carries the literal JavaScript comment
+    `// "text/css" for DDOS-GUARD caching.` — three times on a book page.
+    Matching raw HTML meant the wall detector fired on a real, HTTP 200,
+    295KB book page with eight partner-server links on it. It would have failed
+    100% of successful requests, and told the operator to go solve a challenge
+    that was not there.
+
+    Mocked pages could not have shown this, because a mock only contains what
+    the person writing it thought was relevant. That is the stated limitation
+    of the rest of this module's tests; these two exist to close the specific
+    hole it left.
+    """
+
+    # Verbatim from a live capture on 2026-08-23 (annas-archive.gl book page,
+    # HTTP 200, 295643 bytes). Shortened, but the marker context is untouched.
+    REAL_PAGE = """
+    <html><head><title>The Feynman Lectures on Physics - Anna’s Archive</title></head>
+    <body>
+      <a href="/md5/e2055de39f1c745d606301917fe66344">The Feynman Lectures</a>
+      <a href="/slow_download/e2055de39f1c745d606301917fe66344/0/0">Slow Partner Server #1</a>
+      <script>
+        function refreshRecentDownloads(cb) {
+          setTimeout(() => {
+            // "text/css" for DDOS-GUARD caching.
+            fetch("/dyn/recent_downloads/", { headers: { 'Accept': 'text/css' } })
+          });
+        }
+        window.md5ReloadSummary = function() {
+          // "text/css" for DDOS-GUARD caching.
+          fetch("/dyn/md5/summary/" + md5);
+        };
+      </script>
+    </body></html>
+    """
+
+    def test_a_real_book_page_is_not_a_wall(self):
+        assert _classify_page(self.REAL_PAGE) is None, (
+            "Anna's own source comments mention DDOS-GUARD on every page; "
+            "reading them as a wall fails every successful request"
+        )
+
+    def test_script_comments_are_not_visible_text(self):
+        assert "ddos-guard" not in visible_text(self.REAL_PAGE).lower()
+        assert "Feynman" in visible_text(self.REAL_PAGE)
+
+    def test_a_page_with_book_links_is_never_a_wall(self):
+        """Positive evidence outranks a phrase match.
+
+        A challenge interstitial has no book links in it. If they are present
+        the page is Anna's own, whatever prose it also happens to carry — a
+        book whose *title* contains a marker phrase must not brick the route.
+        """
+        awkward = '<a href="/md5/' + "c" * 32 + '">Checking Your Browser: A History</a>'
+
+        assert _classify_page(awkward) is None
+
+    def test_a_genuine_interstitial_still_registers(self):
+        """The guards must not have turned the detector off entirely."""
+        interstitial = (
+            "<html><head><title>Just a moment...</title></head>"
+            "<body><h1>Checking your browser before accessing "
+            "annas-archive.gl</h1></body></html>"
+        )
+
+        assert _classify_page(interstitial) == "challenge"
 
 
 class TestRateLimiter:
@@ -290,7 +362,7 @@ class TestResolveDownloadUrl:
 
     @pytest.mark.asyncio
     async def test_a_challenge_backs_the_limiter_off(self):
-        challenge = "<html><body>DDoS-Guard</body></html>"
+        challenge = "<html><body>Checking your browser before accessing</body></html>"
         session = _session([BOOK_PAGE, challenge], annas_browser_backoff_seconds=120.0)
         before = session._limiter._last_request
 

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -1,0 +1,401 @@
+"""Tests for the browser-resident Anna's route (#143) and its limits (#144).
+
+Playwright is mocked throughout, per the repo invariant that unit tests mock
+every third-party call. That is a deliberate limitation with a stated boundary:
+these tests pin the *logic* — link selection, wall classification, rate
+limiting, error typing — and say nothing about whether a real browser clears a
+real challenge. #142 measured that separately, and only a live run can.
+
+The rate-limiter tests use tiny intervals so the suite stays fast. The
+production defaults are deliberately slow (20s spacing, 30 requests/day) and
+`test_defaults_are_slow_on_purpose` guards them, because a future change that
+"tunes" them for test speed would silently remove the politeness this route's
+scope is conditional on.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lib.sources.annas_browser import (  # noqa: E402
+    AnnasBrowserSession,
+    BrowserUnavailableError,
+    ChallengeNotClearedError,
+    DailyLimitReachedError,
+    ProviderRateLimitedError,
+    _classify_page,
+    _RateLimiter,
+)
+from lib.sources.config import SourceConfig  # noqa: E402
+from lib.sources.errors import ProviderResponseError  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+MD5 = "a" * 32
+
+
+def _config(**overrides) -> SourceConfig:
+    base = dict(
+        annas_base_url="https://annas-archive.gl",
+        annas_browser_enabled=True,
+        annas_browser_min_interval=0.0,
+        annas_browser_settle_seconds=0.0,
+        annas_browser_daily_limit=100,
+        annas_browser_max_servers=3,
+    )
+    base.update(overrides)
+    return SourceConfig(**base)
+
+
+class _FakePage:
+    """A page that returns queued bodies, one per `goto`."""
+
+    def __init__(self, bodies):
+        self._bodies = list(bodies)
+        self.visited = []
+        self.closed = False
+
+    async def goto(self, url, **_kwargs):
+        self.visited.append(url)
+        if not self._bodies:
+            raise AssertionError(f"unexpected extra navigation to {url}")
+        self._current = self._bodies.pop(0)
+        if isinstance(self._current, Exception):
+            raise self._current
+        return None
+
+    async def content(self):
+        return self._current
+
+    async def close(self):
+        self.closed = True
+
+
+def _session(bodies, **overrides) -> AnnasBrowserSession:
+    session = AnnasBrowserSession(_config(**overrides))
+    page = _FakePage(bodies)
+
+    class _Ctx:
+        async def new_page(self):
+            return page
+
+    session._context = _Ctx()
+    session._page = page  # for assertions
+    return session
+
+
+BOOK_PAGE = f"""
+<html><body>
+  <a href="/slow_download/{MD5}/0/0">Slow Partner Server #1</a>
+  <a href="/slow_download/{MD5}/0/1">Slow Partner Server #2</a>
+  <a href="/slow_download/{"b" * 32}/0/0">a different book</a>
+</body></html>
+"""
+
+PARTNER_PAGE = """
+<html><body>
+  <a href="/faq">Anna's FAQ</a>
+  <a href="https://cdn3.example.net/d/9f2/Plotinus-Enneads.pdf?sig=abc">Download now</a>
+</body></html>
+"""
+
+
+class TestLinkSelection:
+    """The browser's whole job is picking the right link off Anna's own pages."""
+
+    def test_only_this_book_s_partner_links_are_taken(self):
+        paths = AnnasBrowserSession._slow_download_paths(BOOK_PAGE, MD5)
+
+        assert paths == [f"/slow_download/{MD5}/0/0", f"/slow_download/{MD5}/0/1"], (
+            "another book's link on the same page must not be followed — it "
+            "would spend rate budget and download the wrong file"
+        )
+
+    def test_annas_own_ordering_is_preserved(self):
+        page = (
+            f'<a href="/slow_download/{MD5}/0/5">e</a>'
+            f'<a href="/slow_download/{MD5}/0/2">b</a>'
+        )
+
+        assert AnnasBrowserSession._slow_download_paths(page, MD5) == [
+            f"/slow_download/{MD5}/0/5",
+            f"/slow_download/{MD5}/0/2",
+        ], (
+            "Anna's lists the servers it expects to work first; sorting invents knowledge"
+        )
+
+    def test_duplicate_links_are_visited_once(self):
+        page = f'<a href="/slow_download/{MD5}/0/0">x</a>' * 3
+
+        assert len(AnnasBrowserSession._slow_download_paths(page, MD5)) == 1
+
+    def test_the_payload_link_must_be_off_site(self):
+        """Same-host candidates are other Anna's pages, not the file."""
+        page = (
+            '<a href="https://annas-archive.gl/md5/deadbeef.pdf">not the file</a>'
+            '<a href="https://cdn9.example.org/x/book.epub">the file</a>'
+        )
+
+        url = AnnasBrowserSession._direct_file_url(page, "annas-archive.gl")
+
+        assert url == "https://cdn9.example.org/x/book.epub"
+
+    def test_no_payload_link_returns_none_rather_than_a_page_url(self):
+        page = '<a href="https://annas-archive.gl/faq">faq</a><a href="/x">y</a>'
+
+        assert AnnasBrowserSession._direct_file_url(page, "annas-archive.gl") is None
+
+
+class TestWallClassification:
+    """A wall and a missing book need opposite responses, so they need names."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "<h1>Checking your browser before accessing</h1>",
+            "<p>DDoS-Guard</p>",
+            "<div>Please enable JavaScript and cookies to continue</div>",
+        ],
+    )
+    def test_challenge_bodies_are_named(self, body):
+        assert _classify_page(body) == "challenge"
+
+    def test_annas_own_limit_is_distinguished_from_the_challenge(self):
+        assert _classify_page("You have downloaded too many files today") == "exhausted"
+
+    def test_an_ordinary_page_is_not_a_wall(self):
+        assert _classify_page(BOOK_PAGE) is None
+
+
+class TestRateLimiter:
+    """#144 is structural here, not a documented convention."""
+
+    def test_defaults_are_slow_on_purpose(self):
+        """Guard the production numbers against being 'tuned' for test speed.
+
+        The scope reversal that put this route in scope is conditional on these
+        limits shipping with it. A change that quietly widened them would make
+        the politeness claim rhetorical, which is the one outcome the doctrine
+        entry exists to prevent.
+        """
+        config = SourceConfig()
+
+        assert config.annas_browser_min_interval >= 20.0
+        assert config.annas_browser_daily_limit <= 30
+        assert config.annas_browser_backoff_seconds >= 300.0
+        assert config.annas_browser_enabled is False, "must stay opt-in"
+
+    @pytest.mark.asyncio
+    async def test_requests_are_spaced(self):
+        limiter = _RateLimiter(min_interval=0.05, daily_limit=10)
+        loop = asyncio.get_running_loop()
+
+        await limiter.acquire()
+        start = loop.time()
+        await limiter.acquire()
+
+        assert loop.time() - start >= 0.04
+
+    @pytest.mark.asyncio
+    async def test_the_daily_ceiling_refuses_rather_than_sleeping(self):
+        limiter = _RateLimiter(min_interval=0.0, daily_limit=2)
+
+        await limiter.acquire()
+        await limiter.acquire()
+
+        with pytest.raises(DailyLimitReachedError) as excinfo:
+            await limiter.acquire()
+
+        assert excinfo.value.reason == "quota_exhausted"
+        assert "our limit, not Anna's" in str(excinfo.value) or "not Anna" in str(
+            excinfo.value
+        ), "the message must not read as a provider failure"
+
+    @pytest.mark.asyncio
+    async def test_backing_off_moves_the_floor_not_just_the_clock(self):
+        limiter = _RateLimiter(min_interval=0.0, daily_limit=10)
+        await limiter.acquire()
+
+        limiter.penalise(60.0)
+
+        assert limiter._last_request > asyncio.get_running_loop().time() - 1, (
+            "penalise must push the next allowed request into the future; a "
+            "no-op here means retrying straight back into the wall"
+        )
+
+    def test_remaining_is_reported_so_the_caller_can_see_the_budget(self):
+        limiter = _RateLimiter(min_interval=0.0, daily_limit=4)
+
+        assert limiter.remaining_today == 4
+
+
+class TestResolveDownloadUrl:
+    @pytest.mark.asyncio
+    async def test_the_happy_path_returns_a_url_and_the_remaining_budget(self):
+        session = _session([BOOK_PAGE, PARTNER_PAGE])
+
+        url, remaining = await session.resolve_download_url(MD5)
+
+        assert url.startswith("https://cdn3.example.net/")
+        assert remaining == 98, "two navigations spent, out of a 100 ceiling"
+        assert session._page.visited == [
+            f"https://annas-archive.gl/md5/{MD5}",
+            f"https://annas-archive.gl/slow_download/{MD5}/0/0",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_the_browser_never_fetches_the_file(self):
+        """The transfer belongs to httpx, which already verifies content md5."""
+        session = _session([BOOK_PAGE, PARTNER_PAGE])
+
+        url, _ = await session.resolve_download_url(MD5)
+
+        assert url not in session._page.visited, (
+            "resolving must stop at the URL; fetching it here would bypass the "
+            "content-md5, throughput and atomic-staging machinery in "
+            "_download_url_to_file and reimplement all three worse"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_dead_partner_server_falls_through_to_the_next(self):
+        dead = '<html><body><a href="/faq">nothing here</a></body></html>'
+        session = _session([BOOK_PAGE, dead, PARTNER_PAGE])
+
+        url, _ = await session.resolve_download_url(MD5)
+
+        assert url.startswith("https://cdn3.example.net/")
+        assert len(session._page.visited) == 3
+
+    @pytest.mark.asyncio
+    async def test_a_challenge_stops_immediately_rather_than_trying_more_servers(self):
+        """Retrying into the wall is the behaviour the limiter exists to stop."""
+        challenge = "<html><body>Checking your browser before accessing</body></html>"
+        session = _session([BOOK_PAGE, challenge, PARTNER_PAGE])
+
+        with pytest.raises(ChallengeNotClearedError) as excinfo:
+            await session.resolve_download_url(MD5)
+
+        assert len(session._page.visited) == 2, (
+            "a challenge must abort the walk, not cost another request per "
+            "remaining partner server"
+        )
+        assert "20 minutes" in str(excinfo.value), (
+            "the message must tell the operator what to do — clearance lapses "
+            "and is re-established by hand"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_challenge_backs_the_limiter_off(self):
+        challenge = "<html><body>DDoS-Guard</body></html>"
+        session = _session([BOOK_PAGE, challenge], annas_browser_backoff_seconds=120.0)
+        before = session._limiter._last_request
+
+        with pytest.raises(ChallengeNotClearedError):
+            await session.resolve_download_url(MD5)
+
+        assert session._limiter._last_request > before + 60
+
+    @pytest.mark.asyncio
+    async def test_annas_own_limit_is_reported_as_quota_not_as_a_challenge(self):
+        limited = "<html><body>You have downloaded too many files</body></html>"
+        session = _session([BOOK_PAGE, limited, PARTNER_PAGE])
+
+        with pytest.raises(ProviderRateLimitedError) as excinfo:
+            await session.resolve_download_url(MD5)
+
+        assert excinfo.value.reason == "quota_exhausted"
+        assert not isinstance(excinfo.value, ChallengeNotClearedError)
+        assert len(session._page.visited) == 2, (
+            "Anna's own limit applies to the whole session, so the remaining "
+            "partner servers cannot succeed — trying them would sleep out a "
+            "full backoff each time and spend the day's budget proving it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_missing_book_is_not_found_not_a_wall(self):
+        """The page loaded and no challenge fired, so retrying is pointless."""
+        empty = "<html><body><h1>Not found</h1></body></html>"
+        session = _session([empty])
+
+        with pytest.raises(ProviderResponseError) as excinfo:
+            await session.resolve_download_url(MD5)
+
+        assert excinfo.value.reason == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_the_walk_is_bounded_by_max_servers(self):
+        many = "".join(f'<a href="/slow_download/{MD5}/0/{n}">s</a>' for n in range(8))
+        dead = "<html><body>no link</body></html>"
+        session = _session(
+            [f"<html><body>{many}</body></html>", dead, dead],
+            annas_browser_max_servers=2,
+        )
+
+        with pytest.raises(ProviderResponseError):
+            await session.resolve_download_url(MD5)
+
+        assert len(session._page.visited) == 3, (
+            "one book page plus max_servers partner pages; walking all eight "
+            "would spend the day's budget on a single failing book"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_page_is_closed_even_when_the_walk_fails(self):
+        session = _session(["<html><body>Not found</body></html>"])
+
+        with pytest.raises(ProviderResponseError):
+            await session.resolve_download_url(MD5)
+
+        assert session._page.closed is True
+
+    @pytest.mark.asyncio
+    async def test_concurrent_callers_are_serialised(self):
+        """One request in flight per session, structurally (#144).
+
+        The repo has already paid for fanning lanes out against a
+        single-session provider; this is that lesson as a lock rather than as a
+        convention someone has to remember.
+        """
+        session = _session([BOOK_PAGE, PARTNER_PAGE])
+        assert session._lock is not None
+
+        await session._lock.acquire()
+        task = asyncio.create_task(session.resolve_download_url(MD5))
+        await asyncio.sleep(0)
+
+        assert not task.done(), "a second caller must wait, not proceed in parallel"
+
+        session._lock.release()
+        url, _ = await task
+        assert url.startswith("https://cdn3.example.net/")
+
+
+class TestMissingPlaywright:
+    @pytest.mark.asyncio
+    async def test_absent_playwright_is_a_configuration_error(self, monkeypatch):
+        """Permanent until the operator acts, so not evidence Anna's is down."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def refuse(name, *args, **kwargs):
+            if name.startswith("playwright"):
+                raise ImportError("No module named 'playwright'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", refuse)
+        session = AnnasBrowserSession(_config())
+
+        with pytest.raises(BrowserUnavailableError) as excinfo:
+            await session._ensure_context()
+
+        assert excinfo.value.reason == "configuration_error"
+        message = str(excinfo.value)
+        assert "annas-browser" in message, "must name the extra that installs it"
+        assert "LibGen" in message, (
+            "a credential-free LibGen user must be told this does not affect them"
+        )

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -738,8 +738,15 @@ class TestCrossProcessSerialisation:
         from lib.sources.annas_browser import BrowserBusyError
 
         first = _session([BOOK_PAGE, PARTNER_PAGE], tmp_path)
+        # Both budgets shrunk: the wait is derived from `download_timeout`
+        # (25 minutes by default, deliberately — the holder keeps the lock
+        # across the whole transfer), so a test that overrode only the
+        # navigation timeout would sit there for the full budget.
         second = _session(
-            [BOOK_PAGE, PARTNER_PAGE], tmp_path, annas_browser_nav_timeout=0.1
+            [BOOK_PAGE, PARTNER_PAGE],
+            tmp_path,
+            annas_browser_nav_timeout=0.05,
+            download_timeout=0.05,
         )
 
         assert first._process_lock.path == second._process_lock.path, (
@@ -902,3 +909,91 @@ class TestCrossProcessSerialisation:
 
         assert result.quota_info is None
         assert result.url == "https://cdn.example/x.pdf"
+
+
+class TestLockWaitCoversAWholeDownload:
+    """Sizing the wait to a browser walk refused to serialise (#150).
+
+    The holder keeps the process lock across the transfer, which is allowed to
+    run for `download_timeout`. A wait of `3 * nav_timeout` gave up after 180s
+    while the first download was legitimately still running — so ordinary
+    overlapping downloads failed with a non-retryable `BrowserBusyError`, in
+    the function whose comment promises they will be serialised.
+    """
+
+    def test_the_wait_is_derived_from_the_download_budget(self):
+        import inspect
+
+        source = inspect.getsource(AnnasBrowserSession.iter_download_urls)
+
+        assert "self.config.download_timeout" in source, (
+            "a wait shorter than a permitted download turns serialisation into refusal"
+        )
+
+
+class TestBareRefusalStatuses:
+    """A 403 or 429 with no marker phrase is still a refusal (#150).
+
+    Playwright reports such a navigation as successful and the body carries no
+    challenge or quota text, so discarding the response made a refusal look
+    like an ordinary page: the walk continued into the remaining partner
+    servers and the generic bridge retries followed, spending the daily
+    allowance against a host that was actively saying no.
+    """
+
+    def _session_with(self, bodies, statuses, tmp_path, **overrides):
+        session = AnnasBrowserSession(_config(tmp_path, **overrides))
+        page = _FakePage(bodies)
+        pending = list(statuses)
+        original_goto = page.goto
+
+        async def goto(url, **kwargs):
+            await original_goto(url, **kwargs)
+            status = pending.pop(0) if pending else 200
+            return type("_Response", (), {"status": status})()
+
+        page.goto = goto
+
+        class _Ctx:
+            async def new_page(self):
+                return page
+
+        session._context = _Ctx()
+        session._page = page
+        return session
+
+    @pytest.mark.asyncio
+    async def test_a_bare_429_backs_off_instead_of_walking_on(self, tmp_path):
+        plain = "<html><body><p>Nothing to see.</p></body></html>"
+        session = self._session_with(
+            [BOOK_PAGE, plain, PARTNER_PAGE], [200, 429, 200], tmp_path
+        )
+
+        with pytest.raises(ProviderRateLimitedError):
+            await session.resolve_download_url(MD5)
+
+        assert len(session._page.visited) == 2, (
+            "a refusal must abort the walk, not cost a request per remaining "
+            "partner server"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_challenge_status_still_reads_as_a_challenge(self, tmp_path):
+        """Status is consulted after the markers, not instead of them.
+
+        A challenge served with 403 must keep its own type and message, which
+        tells the operator to re-solve rather than to wait out a quota.
+        """
+        challenge = "<html><body>Checking your browser before accessing</body></html>"
+        session = self._session_with([BOOK_PAGE, challenge], [200, 403], tmp_path)
+
+        with pytest.raises(ChallengeNotClearedError):
+            await session.resolve_download_url(MD5)
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_200_is_untouched(self, tmp_path):
+        session = self._session_with([BOOK_PAGE, PARTNER_PAGE], [200, 200], tmp_path)
+
+        url, _ = await session.resolve_download_url(MD5)
+
+        assert url.startswith("https://cdn3.example.net/")

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -730,19 +730,73 @@ class TestCrossProcessSerialisation:
         )
         session._process_lock.release()
 
-    def test_a_stale_lock_is_reclaimed(self, tmp_path):
+    def test_a_lock_whose_owner_died_is_reclaimed(self, tmp_path):
         """A crashed process must not block the operator's tool forever."""
         import os
         import time
 
         from lib.sources.annas_usage import CrossProcessLock
 
-        lock = CrossProcessLock(str(tmp_path / "held.lock"), stale_after=0.05)
+        path = tmp_path / "held.lock"
+        os.makedirs(path)
+        # A PID that cannot be running: os.kill(0, 0) targets the process
+        # group, so use a recorded value that reads back as absent instead.
+        (path / "owner").write_text("999999999")
+        time.sleep(0.06)
+
+        lock = CrossProcessLock(str(path), stale_after=0.05)
+
         assert lock.acquire(1.0) is True
-        time.sleep(0.1)
+        lock.release()
+
+    def test_a_live_owner_is_never_reclaimed_however_old(self, tmp_path):
+        """Age is not evidence of staleness while the holder is running.
+
+        Codex on #150: a payload transfer may legitimately run for 25 minutes
+        with the holder suspended, still owning the Chrome profile. Reclaiming
+        on age alone would launch a second Chrome against a profile in use and
+        break both downloads.
+        """
+        import time
+
+        from lib.sources.annas_usage import CrossProcessLock
+
+        holder = CrossProcessLock(str(tmp_path / "held.lock"), stale_after=0.05)
+        assert holder.acquire(1.0) is True
+        time.sleep(0.1)  # well past stale_after
 
         other = CrossProcessLock(str(tmp_path / "held.lock"), stale_after=0.05)
 
-        assert other.acquire(1.0) is True
-        assert os.path.isdir(tmp_path / "held.lock")
-        other.release()
+        assert other.acquire(0.3) is False, (
+            "the owner of this lock is this very process; reclaiming it on age "
+            "would hand the browser to a second holder while the first is using it"
+        )
+        holder.release()
+
+    def test_an_unreadable_usage_count_is_unknown_not_zero(self, tmp_path):
+        """Fail-open must not look like an exhausted quota.
+
+        Codex on #150: the fail-open path returned -1, which reached
+        `QuotaInfo.downloads_left`, and the router reads a non-positive value
+        as exhausted — so it discarded a URL the walk had already paid for.
+        """
+        from lib.sources.annas_usage import DailyUsage
+
+        usage = DailyUsage(str(tmp_path / "usage.json"))
+        usage._acquire = lambda: False  # simulate a lock we cannot take
+
+        allowed, remaining = usage.spend(30)
+
+        assert allowed is True, "a lock problem must not block the operator"
+        assert remaining is None, "unknown must not be representable as a count"
+
+    def test_an_unknown_budget_omits_quota_rather_than_reporting_zero(self):
+        from lib.sources.annas import AnnasArchiveAdapter
+        from lib.sources.config import SourceConfig
+
+        adapter = AnnasArchiveAdapter(SourceConfig(annas_browser_enabled=True))
+
+        result = adapter._browser_result("https://cdn.example/x.pdf", None)
+
+        assert result.quota_info is None
+        assert result.url == "https://cdn.example/x.pdf"

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -366,7 +366,12 @@ class TestResolveDownloadUrl:
         url, remaining = await session.resolve_download_url(MD5)
 
         assert url.startswith("https://cdn3.example.net/")
-        assert remaining == 98, "two navigations spent, out of a 100 ceiling"
+        assert remaining == 100, (
+            "the budget reported is the one that applied when this resolution "
+            "started, not what is left after it — reporting 0 for a download "
+            "that legitimately spent the last slots makes the router discard "
+            "the URL it just paid for (Codex on #150)"
+        )
         assert session._page.visited == [
             f"https://annas-archive.gl/md5/{MD5}",
             f"https://annas-archive.gl/slow_download/{MD5}/0/0",
@@ -592,3 +597,152 @@ class TestEntityDecoding:
             "https://cdn.example.net/x/book.pdf?Expires=1&Signature=abc&Key-Pair-Id=K1"
         )
         assert "amp;" not in url
+
+
+class TestPartnerFailover:
+    """A dead CDN must not end acquisition for the whole provider (#150).
+
+    The transfer happens after resolution returns, so a syntactically valid URL
+    whose partner server is dead, expired, or serving wrong bytes is only
+    discovered downstream. Returning one URL ended Anna's candidate stream
+    before the remaining partner servers were tried — while
+    ANNAS_BROWSER_MAX_SERVERS advertised exactly that failover.
+    """
+
+    @pytest.mark.asyncio
+    async def test_every_working_partner_is_yielded(self, tmp_path):
+        second = PARTNER_PAGE.replace("cdn3.example.net", "cdn7.example.net")
+        session = _session([BOOK_PAGE, PARTNER_PAGE, second], tmp_path)
+
+        urls = [url async for url, _ in session.iter_download_urls(MD5)]
+
+        assert len(urls) == 2, "both partner servers must be offered"
+        assert "cdn3.example.net" in urls[0]
+        assert "cdn7.example.net" in urls[1]
+
+    @pytest.mark.asyncio
+    async def test_a_partner_without_a_link_is_skipped_not_fatal(self, tmp_path):
+        dead = "<html><body><a href='/faq'>nothing</a></body></html>"
+        session = _session([BOOK_PAGE, dead, PARTNER_PAGE], tmp_path)
+
+        urls = [url async for url, _ in session.iter_download_urls(MD5)]
+
+        assert len(urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_budget_reported_is_the_one_that_applied(self, tmp_path):
+        """Every candidate reports the budget as of the start of the walk.
+
+        Reporting the post-spend figure made the last fully-budgeted download
+        fail: the router discards a result whose `downloads_left` is 0 and
+        raises QuotaExhaustedError, after the slots were already spent.
+        """
+        session = _session(
+            [BOOK_PAGE, PARTNER_PAGE], tmp_path, annas_browser_daily_limit=2
+        )
+
+        # Take only the first candidate, which is what the router does when the
+        # transfer succeeds — the walk is lazy and costs nothing further.
+        stream = session.iter_download_urls(MD5)
+        _, remaining = await stream.__anext__()
+        await stream.aclose()
+
+        assert remaining == 2, (
+            "two slots existed when this download began; reporting the "
+            "post-spend 0 makes the router discard the URL it just paid for"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_adapter_exposes_the_stream_to_the_router(self, tmp_path):
+        """`SourceRouter` only fails over when the adapter is a generator."""
+        import inspect
+
+        from lib.sources.annas import AnnasArchiveAdapter
+
+        method = AnnasArchiveAdapter.iter_download_candidates
+
+        assert inspect.isasyncgenfunction(method), (
+            "the router checks isasyncgenfunction; a coroutine here silently "
+            "falls back to the single-candidate path and failover is lost"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_walk_is_lazy(self, tmp_path):
+        """Later partner servers cost nothing unless the caller asks for them.
+
+        The generator suspends at each yield, so a download whose first
+        candidate works never pays for the rest — which is what keeps failover
+        cheap enough to be worth having under a 30-request daily budget.
+        """
+        session = _session([BOOK_PAGE, PARTNER_PAGE, PARTNER_PAGE], tmp_path)
+
+        stream = session.iter_download_urls(MD5)
+        await stream.__anext__()
+        visited_after_first = len(session._page.visited)
+        await stream.aclose()
+
+        assert visited_after_first == 2, (
+            "one book page plus one partner page; walking the rest eagerly "
+            "would spend the daily budget on candidates nobody asked for"
+        )
+
+
+class TestCrossProcessSerialisation:
+    """One browser walk at a time, across processes (#144, #150).
+
+    An `asyncio.Lock` orders coroutines inside one event loop, and every MCP
+    operation runs in its own `python_bridge.py` process — so the in-process
+    lock never saw the case it was written for. Chrome would also refuse the
+    second launch against a profile the first owns, turning a policy violation
+    into a confusing browser error.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_second_session_waits_for_the_first(self, tmp_path):
+        from lib.sources.annas_browser import BrowserBusyError
+
+        first = _session([BOOK_PAGE, PARTNER_PAGE], tmp_path)
+        second = _session(
+            [BOOK_PAGE, PARTNER_PAGE], tmp_path, annas_browser_nav_timeout=0.1
+        )
+
+        assert first._process_lock.path == second._process_lock.path, (
+            "two sessions on one profile must contend for the same lock"
+        )
+        assert first._process_lock.acquire(1.0) is True
+        try:
+            with pytest.raises(BrowserBusyError):
+                await second.resolve_download_url(MD5)
+        finally:
+            first._process_lock.release()
+
+    @pytest.mark.asyncio
+    async def test_the_lock_is_released_when_the_walk_fails(self, tmp_path):
+        """A failed walk must not wedge every later download."""
+        session = _session(["<html><body>Not found</body></html>"], tmp_path)
+
+        with pytest.raises(ProviderResponseError):
+            await session.resolve_download_url(MD5)
+
+        assert session._process_lock.acquire(1.0) is True, (
+            "the lock survived a failed walk; every later download would wait "
+            "for it to go stale"
+        )
+        session._process_lock.release()
+
+    def test_a_stale_lock_is_reclaimed(self, tmp_path):
+        """A crashed process must not block the operator's tool forever."""
+        import os
+        import time
+
+        from lib.sources.annas_usage import CrossProcessLock
+
+        lock = CrossProcessLock(str(tmp_path / "held.lock"), stale_after=0.05)
+        assert lock.acquire(1.0) is True
+        time.sleep(0.1)
+
+        other = CrossProcessLock(str(tmp_path / "held.lock"), stale_after=0.05)
+
+        assert other.acquire(1.0) is True
+        assert os.path.isdir(tmp_path / "held.lock")
+        other.release()

--- a/__tests__/python/test_annas_browser.py
+++ b/__tests__/python/test_annas_browser.py
@@ -110,9 +110,14 @@ BOOK_PAGE = f"""
 </body></html>
 """
 
-PARTNER_PAGE = """
+# Shaped like the real thing: a live capture of a partner-server page carried
+# 20 `/md5/` navigation links alongside the payload anchor. The earlier minimal
+# stub was what let a challenge-hop 403 look like a refusal in testing while
+# passing live, and vice versa.
+PARTNER_PAGE = f"""
 <html><body>
   <a href="/faq">Anna's FAQ</a>
+  <a href="/md5/{"c" * 32}">Another edition</a>
   <a href="https://cdn3.example.net/d/9f2/Plotinus-Enneads.pdf?sig=abc">Download now</a>
 </body></html>
 """
@@ -997,3 +1002,34 @@ class TestBareRefusalStatuses:
         url, _ = await session.resolve_download_url(MD5)
 
         assert url.startswith("https://cdn3.example.net/")
+
+    @pytest.mark.asyncio
+    async def test_a_403_challenge_hop_on_a_good_page_is_not_a_refusal(self, tmp_path):
+        """The regression a live run caught and the mocks did not (#142, #150).
+
+        `page.goto()` returns the FIRST response, and DDoS-Guard's challenge
+        hop answers **403 while succeeding** — the JS challenge then solves and
+        the real page loads. So on a perfectly ordinary successful request the
+        status is 403 and the settled content is the book.
+
+        A status check with no content guard therefore rejected *every*
+        successful request. #142 lost a probe to exactly this reading once
+        before; the fixed-marker classifier lost it again here.
+        """
+        session = self._session_with([BOOK_PAGE, PARTNER_PAGE], [403, 403], tmp_path)
+
+        url, _ = await session.resolve_download_url(MD5)
+
+        assert url.startswith("https://cdn3.example.net/"), (
+            "a 403 on the challenge hop must not veto a page that plainly "
+            "loaded — the settled content is the evidence, not the first status"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_403_with_no_annas_content_is_still_a_refusal(self, tmp_path):
+        """The guard must not disarm the check it guards."""
+        empty = "<html><body><p>Forbidden.</p></body></html>"
+        session = self._session_with([BOOK_PAGE, empty], [200, 403], tmp_path)
+
+        with pytest.raises(ProviderRateLimitedError):
+            await session.resolve_download_url(MD5)

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -734,6 +734,12 @@ class TestAnnasDownloadDomProbe:
     close, reintroduced on a new surface.
     """
 
+    PARTNER_PAGE = (
+        '<html><body><a href="/faq">FAQ</a>'
+        '<a href="https://cdn9.example.net/d/x/Book.pdf?sig=1">Download now</a>'
+        "</body></html>"
+    )
+
     def _run(self, check_upstream, handler):
         import asyncio
 
@@ -745,6 +751,17 @@ class TestAnnasDownloadDomProbe:
 
         return asyncio.run(go())
 
+    def _two_page(self, book, partner=None):
+        """Serve the book page first, the partner page on the second request."""
+        partner = self.PARTNER_PAGE if partner is None else partner
+
+        def handler(request):
+            if "/slow_download/" in str(request.url):
+                return httpx.Response(200, text=partner)
+            return httpx.Response(200, text=book)
+
+        return handler
+
     def test_partner_links_in_the_expected_shape_pass(self, check_upstream):
         md5 = check_upstream.ANNAS_DOM_CANARY_MD5
         page = (
@@ -752,10 +769,14 @@ class TestAnnasDownloadDomProbe:
             f'<a href="/slow_download/{md5}/0/1">Server 2</a></body></html>'
         )
 
-        result = self._run(check_upstream, lambda r: httpx.Response(200, text=page))
+        result = self._run(check_upstream, self._two_page(page))
 
         assert result.ok is True
         assert "2 partner-server link" in result.detail
+        assert "cdn9.example.net" in result.detail, (
+            "the probe must report the payload host it actually reached, or "
+            "green says nothing about the half of the flow that moves the file"
+        )
 
     def test_a_page_without_partner_links_is_drift_not_a_block(self, check_upstream):
         """Loaded, unchallenged, and missing the links the extractor needs."""
@@ -799,7 +820,84 @@ class TestAnnasDownloadDomProbe:
             'fetch("/dyn/recent_downloads/");</script></body></html>'
         )
 
-        result = self._run(check_upstream, lambda r: httpx.Response(200, text=page))
+        result = self._run(check_upstream, self._two_page(page))
 
         assert result.ok is True
         assert result.blocked is False
+
+    def test_a_partner_page_without_a_payload_link_is_drift(self, check_upstream):
+        """The half of the flow that was previously unmonitored (#150).
+
+        A book page can be perfectly intact while the partner page redesigns
+        underneath it, and the probe used to return green on the book page
+        alone — reporting the adapter healthy while every download failed.
+        """
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        book = f'<html><body><a href="/slow_download/{md5}/0/0">S1</a></body></html>'
+        redesigned = '<html><body><button id="dl">Get it</button></body></html>'
+
+        result = self._run(check_upstream, self._two_page(book, redesigned))
+
+        assert result.ok is False
+        assert result.blocked is False
+        assert "partner-page drift" in result.detail
+
+    def test_a_walled_partner_page_is_blocked_not_drift(self, check_upstream):
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        book = f'<html><body><a href="/slow_download/{md5}/0/0">S1</a></body></html>'
+        wall = "<html><body><h1>Checking your browser</h1></body></html>"
+
+        result = self._run(check_upstream, self._two_page(book, wall))
+
+        assert result.blocked is True
+        assert result.symbol == "BLOCK"
+        assert "UNVERIFIED" in result.detail
+
+
+class TestRunProbesReturnsEveryProbe:
+    """`run_probes` must unpack and return every probe it gathers.
+
+    Codex on #150: a probe was added to the `gather()` call without a target,
+    so the tuple unpack raised and `npm run doctor` plus the scheduled
+    upstream check failed before producing a report — the health check
+    disabled by an addition to it. The per-probe tests all passed, because
+    they call the probe functions directly and never go through here.
+
+    This test is deliberately structural rather than behavioural: it counts
+    what goes in against what comes out, so the next probe added without a
+    target fails here instead of in CI.
+    """
+
+    def test_every_gathered_probe_appears_in_the_result(self, check_upstream):
+        import asyncio
+        import inspect
+
+        source = inspect.getsource(check_upstream.run_probes)
+        import re
+
+        gathered = re.findall(r"\b(probe_\w+)\(client\)", source)
+        assert len(gathered) >= 5, f"expected the full probe set, saw {gathered}"
+
+        async def stub(_client):
+            return check_upstream.ProbeResult(
+                name="stub", ok=True, detail="", required=False
+            )
+
+        async def stub_list(_client):
+            return [
+                check_upstream.ProbeResult(
+                    name="zlibrary:stub", ok=True, detail="", required=False
+                )
+            ]
+
+        import unittest.mock as mock
+
+        patches = {name: stub for name in gathered}
+        patches["probe_zlibrary_eapi"] = stub_list
+        with mock.patch.multiple(check_upstream, **patches):
+            results = asyncio.run(check_upstream.run_probes())
+
+        assert len(results) == len(gathered), (
+            f"{len(gathered)} probes gathered but {len(results)} returned — a "
+            f"probe is being dropped, or the unpack will raise"
+        )

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -763,7 +763,15 @@ class TestAnnasDownloadDomProbe:
 
         return asyncio.run(go())
 
-    def _two_page(self, book, partner=None, payload_status=206):
+    def _two_page(
+        self,
+        book,
+        partner=None,
+        payload_status=206,
+        *,
+        book_status=200,
+        partner_status=200,
+    ):
         """Book page, then partner page, then the payload range request."""
         partner = self.PARTNER_PAGE if partner is None else partner
 
@@ -772,8 +780,8 @@ class TestAnnasDownloadDomProbe:
             if "cdn9.example.net" in url:
                 return httpx.Response(payload_status, content=b"%PDF-1.5" + b"\0" * 64)
             if "/slow_download/" in url:
-                return httpx.Response(200, text=partner)
-            return httpx.Response(200, text=book)
+                return httpx.Response(partner_status, text=partner)
+            return httpx.Response(book_status, text=book)
 
         return handler
 
@@ -867,6 +875,128 @@ class TestAnnasDownloadDomProbe:
         assert result.blocked is True
         assert result.symbol == "BLOCK"
         assert "UNVERIFIED" in result.detail
+
+    @pytest.mark.parametrize(
+        ("status", "body"),
+        [
+            (200, "<h1>Checking your browser before accessing</h1>"),
+            (200, "<p>You have downloaded too many files today</p>"),
+            (403, "<p>refused</p>"),
+            (429, "<p>slow down</p>"),
+            (503, "<p>temporarily refused</p>"),
+        ],
+    )
+    def test_every_book_page_wall_is_blocked_and_persistently_penalised(
+        self, check_upstream, monkeypatch, status, body
+    ):
+        from lib.sources.annas_usage import DailyUsage
+
+        penalties = []
+        monkeypatch.setattr(
+            DailyUsage,
+            "penalise",
+            lambda _usage, seconds: penalties.append(seconds),
+        )
+
+        result = self._run(
+            check_upstream, lambda _request: httpx.Response(status, text=body)
+        )
+
+        assert result.blocked is True
+        assert penalties == [pytest.approx(300.0)]
+
+    @pytest.mark.parametrize(
+        ("status", "body"),
+        [
+            (200, "<h1>Checking your browser before accessing</h1>"),
+            (200, "<p>You have downloaded too many files today</p>"),
+            (403, "<p>refused</p>"),
+            (429, "<p>slow down</p>"),
+            (503, "<p>temporarily refused</p>"),
+        ],
+    )
+    def test_every_partner_page_wall_is_blocked_and_persistently_penalised(
+        self, check_upstream, monkeypatch, status, body
+    ):
+        from lib.sources.annas_usage import DailyUsage
+
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        book = f'<a href="/slow_download/{md5}/0/0">S1</a>'
+        penalties = []
+        monkeypatch.setattr(
+            DailyUsage,
+            "penalise",
+            lambda _usage, seconds: penalties.append(seconds),
+        )
+
+        result = self._run(
+            check_upstream,
+            self._two_page(book, body, partner_status=status),
+        )
+
+        assert result.blocked is True
+        assert penalties == [pytest.approx(300.0)]
+
+    @pytest.mark.parametrize("stage", ["book", "partner"])
+    @pytest.mark.parametrize("status", [401, 500])
+    def test_http_errors_are_provider_failures_not_dom_drift_or_backoff(
+        self, check_upstream, monkeypatch, stage, status
+    ):
+        from lib.sources.annas_usage import DailyUsage
+
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        book = f'<a href="/slow_download/{md5}/0/0">S1</a>'
+        error = "<p>temporary upstream error</p>"
+        penalties = []
+        monkeypatch.setattr(
+            DailyUsage,
+            "penalise",
+            lambda _usage, seconds: penalties.append(seconds),
+        )
+        handler = (
+            (lambda _request: httpx.Response(status, text=error))
+            if stage == "book"
+            else self._two_page(book, error, partner_status=status)
+        )
+
+        result = self._run(check_upstream, handler)
+
+        assert result.ok is False
+        assert result.blocked is False
+        assert "HTTP error" in result.detail
+        assert "DOM drift" not in result.detail
+        assert penalties == []
+
+    def test_a_challenge_hop_status_cannot_veto_a_real_book_page(self, check_upstream):
+        """Production trusts settled Anna content over the first-hop 403."""
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        book = f'<a href="/slow_download/{md5}/0/0">S1</a>'
+
+        result = self._run(
+            check_upstream,
+            self._two_page(book, book_status=403),
+        )
+
+        assert result.ok is True
+        assert result.blocked is False
+
+    def test_a_challenge_hop_status_cannot_veto_an_opaque_payload_link(
+        self, check_upstream
+    ):
+        """A signed CDN route can be a real payload without a file extension."""
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        book = f'<a href="/slow_download/{md5}/0/0">S1</a>'
+        partner = (
+            '<a href="https://cdn9.example.net/download?id=opaque-token">Download</a>'
+        )
+
+        result = self._run(
+            check_upstream,
+            self._two_page(book, partner, partner_status=403),
+        )
+
+        assert result.ok is True
+        assert result.blocked is False
 
     def test_an_unfetchable_payload_is_not_healthy(self, check_upstream):
         """Extraction is not the end of the flow (#150).
@@ -1183,58 +1313,8 @@ class TestAnnasProbeDiagnosticsNameAnnas:
         assert "UNVERIFIED" in result.detail
 
 
-class TestTheProbeReusesProductionRatherThanRedefiningIt:
-    """Six round-7 findings on #150 were one mistake: the probe re-derived
-    every property the production route already has — backoff, serialisation,
-    refusal statuses, body validation, user agent, bounded reads — and got each
-    of them wrong once. These assert the reuse rather than the behaviour, so a
-    future edit that forks the logic again fails here.
-    """
-
-    def test_the_probe_uses_productions_refusal_statuses(self, check_upstream):
-        import inspect
-
-        source = inspect.getsource(check_upstream._annas_block_detail)
-
-        assert "_REFUSAL_STATUSES" in source, (
-            "reusing Z-Library's WALLED_STATUS_CODES missed a bare 429/503, so "
-            "Anna's throttling was reported as DOM drift"
-        )
-
-    def test_the_probe_takes_the_production_browser_lock(self, check_upstream):
-        import inspect
-
-        source = inspect.getsource(check_upstream.probe_annas_download_dom)
-
-        assert "CrossProcessLock" in source
-        assert "browser_lock.release()" in source, (
-            "every early return sits inside walk(); the release has to be in "
-            "the outer finally or a blocked probe wedges the browser"
-        )
-
-    def test_the_probe_backs_off_on_a_wall(self, check_upstream):
-        import inspect
-
-        source = inspect.getsource(check_upstream.probe_annas_download_dom)
-
-        assert "usage.penalise(" in source, (
-            "production penalises on a wall; a probe that does not lets the "
-            "next request hit Anna's after only the spacing interval"
-        )
-
-    def test_the_payload_probe_is_streamed_and_bounded(self, check_upstream):
-        import inspect
-
-        source = inspect.getsource(check_upstream.probe_annas_download_dom)
-
-        assert "client.stream(" in source, (
-            "a plain get() buffers the whole file when a CDN ignores Range — "
-            "a 4KB probe that can pull 30MB is not a 4KB probe"
-        )
-        assert "DEFAULT_BROWSER_USER_AGENT" in source, (
-            "the doctor client identifies as zlibrary-mcp-upstream-check; a CDN "
-            "that blocks it would report a healthy handoff as broken"
-        )
+class TestTheProbeMatchesProductionBehavior:
+    """Behavioral oracles for policy shared by production and the probe."""
 
     def test_every_response_production_rejects_is_rejected_here(self, check_upstream):
         """The probe must refuse what `_download_url_to_file` refuses (#150).
@@ -1255,7 +1335,6 @@ class TestTheProbeReusesProductionRatherThanRedefiningIt:
             b"<body>Access denied</body>",
             b"<script>location='/login'</script>",
             b"<!-- soft block -->",
-            b"<?xml version='1.0'?><error/>",
         ):
             assert reject(opening, "application/octet-stream"), opening
 
@@ -1266,19 +1345,4 @@ class TestTheProbeReusesProductionRatherThanRedefiningIt:
         assert reject(b"%PDF-1.5\n%\xe2\xe3", "application/octet-stream") is None
         assert (
             reject(b"The_Feynman\x00\x00BOOKMOBI", "application/octet-stream") is None
-        )
-
-    def test_the_probe_handles_both_classifier_verdicts(self, check_upstream):
-        """`_classify_page` returns "exhausted" as well as "challenge".
-
-        Accepting only "challenge" meant Anna's own download-limit page, served
-        at HTTP 200, was reported as DOM drift and skipped the backoff.
-        """
-        import inspect
-
-        source = inspect.getsource(check_upstream.probe_annas_download_dom)
-
-        assert '"exhausted"' in source, (
-            "throttling reported as a layout change sends a maintainer to fix "
-            "something that is not broken"
         )

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -1236,9 +1236,49 @@ class TestTheProbeReusesProductionRatherThanRedefiningIt:
             "that blocks it would report a healthy handoff as broken"
         )
 
-    def test_an_html_body_at_200_is_not_a_healthy_handoff(self, check_upstream):
-        """Production rejects an HTML body; the probe must ask the same question."""
-        assert check_upstream._looks_like_html(b"<!DOCTYPE html><html>...")
-        assert check_upstream._looks_like_html(b"  \n<html><body>login</body>")
-        assert not check_upstream._looks_like_html(b"%PDF-1.5\n%\xe2\xe3")
-        assert not check_upstream._looks_like_html(b"The_Feynman\x00\x00BOOKMOBI")
+    def test_every_response_production_rejects_is_rejected_here(self, check_upstream):
+        """The probe must refuse what `_download_url_to_file` refuses (#150).
+
+        `<html`/`<!doctype` alone missed a fragment opening with `<head>`,
+        `<body>`, `<script>` or a comment, an empty body, and an HTML
+        content-type on non-HTML-looking bytes — all of which production
+        rejects and a narrower probe reported as a healthy transfer.
+        """
+        reject = check_upstream._payload_rejection
+
+        assert reject(b"", "application/octet-stream"), "an empty body"
+        assert reject(b"%PDF-1.5", "text/html; charset=utf-8"), "html content-type"
+        for opening in (
+            b"<!DOCTYPE html><html>",
+            b"  \n<html><body>login</body>",
+            b"<head><title>Blocked</title>",
+            b"<body>Access denied</body>",
+            b"<script>location='/login'</script>",
+            b"<!-- soft block -->",
+            b"<?xml version='1.0'?><error/>",
+        ):
+            assert reject(opening, "application/octet-stream"), opening
+
+    def test_real_file_bytes_are_accepted(self, check_upstream):
+        """Both openings from live captures on this branch."""
+        reject = check_upstream._payload_rejection
+
+        assert reject(b"%PDF-1.5\n%\xe2\xe3", "application/octet-stream") is None
+        assert (
+            reject(b"The_Feynman\x00\x00BOOKMOBI", "application/octet-stream") is None
+        )
+
+    def test_the_probe_handles_both_classifier_verdicts(self, check_upstream):
+        """`_classify_page` returns "exhausted" as well as "challenge".
+
+        Accepting only "challenge" meant Anna's own download-limit page, served
+        at HTTP 200, was reported as DOM drift and skipped the backoff.
+        """
+        import inspect
+
+        source = inspect.getsource(check_upstream.probe_annas_download_dom)
+
+        assert '"exhausted"' in source, (
+            "throttling reported as a layout change sends a maintainer to fix "
+            "something that is not broken"
+        )

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -1073,3 +1073,54 @@ class TestLibgenSearchProbeReportsUserAgentBlocks:
         result = self._run(check_upstream, empty)
 
         assert result.blocked is False
+
+
+class TestAnnasProbeDiagnosticsNameAnnas:
+    """A block report that names the wrong provider is worse than none (#150).
+
+    `_block_detail` hardcodes the Z-Library domain and tells the operator to
+    export `ZLIBRARY_EAPI_DOMAIN`. Reusing it for Anna's reported a Z-Library
+    host and an irrelevant remedy in the exact anti-bot scenario the probe
+    exists to distinguish.
+    """
+
+    def _run(self, check_upstream, handler):
+        import asyncio
+
+        async def go():
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(handler)
+            ) as client:
+                return await check_upstream.probe_annas_download_dom(client)
+
+        return asyncio.run(go())
+
+    def test_a_403_names_annas_not_zlibrary(self, check_upstream):
+        result = self._run(check_upstream, lambda r: httpx.Response(403, text="nope"))
+
+        assert result.blocked is True
+        assert "annas" in result.detail.lower()
+        assert "zlibrary_eapi_domain" not in result.detail.lower(), (
+            "sending an operator to change a Z-Library variable for an Anna's "
+            "block is an actively wrong remedy"
+        )
+        assert "z-library" not in result.detail.lower()
+
+    def test_the_probe_uses_the_production_challenge_classifier(self, check_upstream):
+        """A partial marker copy called a challenge page DOM drift.
+
+        Production `_classify_page` knows five challenge markers; the probe
+        carried three. A 200 page saying only "enable JavaScript and cookies"
+        was therefore reported as a layout change.
+        """
+        page = (
+            "<html><body><p>Please enable JavaScript and cookies to continue</p>"
+            "</body></html>"
+        )
+
+        result = self._run(check_upstream, lambda r: httpx.Response(200, text=page))
+
+        assert result.blocked is True, (
+            "a challenge marker production recognises must not read as drift"
+        )
+        assert "UNVERIFIED" in result.detail

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -723,3 +723,83 @@ class TestLibgenSearchProbeUsesProductionAdapter:
         result = self._run(check_upstream, fake_search)
         assert result.ok is False
         assert "Welcome to nginx!" in result.detail
+
+
+class TestAnnasDownloadDomProbe:
+    """The browser route's DOM shape needs its own drift check (#150).
+
+    `probe_annas` only exercises `/search`. Anna's could change the book page
+    and every browser download would fail while the doctor still reported the
+    adapter healthy — the reachability-vs-capability gap this script exists to
+    close, reintroduced on a new surface.
+    """
+
+    def _run(self, check_upstream, handler):
+        import asyncio
+
+        async def go():
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(handler)
+            ) as client:
+                return await check_upstream.probe_annas_download_dom(client)
+
+        return asyncio.run(go())
+
+    def test_partner_links_in_the_expected_shape_pass(self, check_upstream):
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        page = (
+            f'<html><body><a href="/slow_download/{md5}/0/0">Server 1</a>'
+            f'<a href="/slow_download/{md5}/0/1">Server 2</a></body></html>'
+        )
+
+        result = self._run(check_upstream, lambda r: httpx.Response(200, text=page))
+
+        assert result.ok is True
+        assert "2 partner-server link" in result.detail
+
+    def test_a_page_without_partner_links_is_drift_not_a_block(self, check_upstream):
+        """Loaded, unchallenged, and missing the links the extractor needs."""
+        page = "<html><body><h1>The Feynman Lectures</h1><p>No links.</p></body></html>"
+
+        result = self._run(check_upstream, lambda r: httpx.Response(200, text=page))
+
+        assert result.ok is False
+        assert result.blocked is False
+        assert "DOM drift" in result.detail
+
+    def test_a_challenge_reports_block_and_says_the_shape_is_unverified(
+        self, check_upstream
+    ):
+        """Being walled is not evidence the DOM changed, and must not say so."""
+        page = (
+            "<html><head><title>Just a moment...</title></head><body>"
+            "<h1>Checking your browser before accessing</h1></body></html>"
+        )
+
+        result = self._run(check_upstream, lambda r: httpx.Response(200, text=page))
+
+        assert result.ok is False
+        assert result.blocked is True
+        assert result.symbol == "BLOCK"
+        assert "UNVERIFIED" in result.detail
+        assert "not \nevidence" in result.detail or "not " in result.detail
+
+    def test_annas_own_script_comments_do_not_read_as_a_challenge(self, check_upstream):
+        """The live bug from #150, guarded on this surface too.
+
+        Every Anna's page carries `// "text/css" for DDOS-GUARD caching.` in a
+        script block. A probe that matched raw HTML would report BLOCK on every
+        healthy run, which is worse than no probe: it teaches the operator to
+        ignore the row.
+        """
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        page = (
+            f'<html><body><a href="/slow_download/{md5}/0/0">Server 1</a>'
+            '<script>// "text/css" for DDOS-GUARD caching.\n'
+            'fetch("/dyn/recent_downloads/");</script></body></html>'
+        )
+
+        result = self._run(check_upstream, lambda r: httpx.Response(200, text=page))
+
+        assert result.ok is True
+        assert result.blocked is False

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -734,6 +734,18 @@ class TestAnnasDownloadDomProbe:
     close, reintroduced on a new surface.
     """
 
+    @pytest.fixture(autouse=True)
+    def _isolated_usage_counter(self, tmp_path, monkeypatch):
+        """Never spend the operator's real Anna's budget from a test.
+
+        The probe is metered by the same persistent counter as production
+        (#144), so without this a test run consumes real daily slots and, once
+        they are gone, every later test sees "budget spent" instead of the
+        behaviour it is checking. Found exactly that way.
+        """
+        monkeypatch.setenv("ANNAS_BROWSER_PROFILE_DIR", str(tmp_path / "profile"))
+        monkeypatch.setenv("ANNAS_BROWSER_MIN_INTERVAL", "0.001")
+
     PARTNER_PAGE = (
         '<html><body><a href="/faq">FAQ</a>'
         '<a href="https://cdn9.example.net/d/x/Book.pdf?sig=1">Download now</a>'
@@ -751,12 +763,15 @@ class TestAnnasDownloadDomProbe:
 
         return asyncio.run(go())
 
-    def _two_page(self, book, partner=None):
-        """Serve the book page first, the partner page on the second request."""
+    def _two_page(self, book, partner=None, payload_status=206):
+        """Book page, then partner page, then the payload range request."""
         partner = self.PARTNER_PAGE if partner is None else partner
 
         def handler(request):
-            if "/slow_download/" in str(request.url):
+            url = str(request.url)
+            if "cdn9.example.net" in url:
+                return httpx.Response(payload_status, content=b"%PDF-1.5" + b"\0" * 64)
+            if "/slow_download/" in url:
                 return httpx.Response(200, text=partner)
             return httpx.Response(200, text=book)
 
@@ -852,6 +867,36 @@ class TestAnnasDownloadDomProbe:
         assert result.blocked is True
         assert result.symbol == "BLOCK"
         assert "UNVERIFIED" in result.detail
+
+    def test_an_unfetchable_payload_is_not_healthy(self, check_upstream):
+        """Extraction is not the end of the flow (#150).
+
+        The browser hands the URL to httpx, and that handoff is what every
+        download depends on. A signed URL that started requiring browser
+        cookies or a referrer would extract cleanly while every production
+        transfer failed — so a probe that stopped at extraction would report
+        green through a total outage of the thing it exists to watch.
+        """
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        book = f'<html><body><a href="/slow_download/{md5}/0/0">S1</a></body></html>'
+
+        result = self._run(check_upstream, self._two_page(book, payload_status=403))
+
+        assert result.ok is False
+        assert result.blocked is False
+        assert "outside the browser" in result.detail
+
+    def test_a_fetchable_payload_is_named_in_the_detail(self, check_upstream):
+        md5 = check_upstream.ANNAS_DOM_CANARY_MD5
+        book = f'<html><body><a href="/slow_download/{md5}/0/0">S1</a></body></html>'
+
+        result = self._run(check_upstream, self._two_page(book))
+
+        assert result.ok is True
+        assert "plain httpx" in result.detail, (
+            "green must state that the handoff was exercised, or it reads as "
+            "a claim about extraction alone"
+        )
 
 
 class TestRunProbesReturnsEveryProbe:
@@ -1083,6 +1128,18 @@ class TestAnnasProbeDiagnosticsNameAnnas:
     host and an irrelevant remedy in the exact anti-bot scenario the probe
     exists to distinguish.
     """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_usage_counter(self, tmp_path, monkeypatch):
+        """Never spend the operator's real Anna's budget from a test.
+
+        The probe is metered by the same persistent counter as production
+        (#144), so without this a test run consumes real daily slots and, once
+        they are gone, every later test sees "budget spent" instead of the
+        behaviour it is checking. Found exactly that way.
+        """
+        monkeypatch.setenv("ANNAS_BROWSER_PROFILE_DIR", str(tmp_path / "profile"))
+        monkeypatch.setenv("ANNAS_BROWSER_MIN_INTERVAL", "0.001")
 
     def _run(self, check_upstream, handler):
         import asyncio

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -1181,3 +1181,64 @@ class TestAnnasProbeDiagnosticsNameAnnas:
             "a challenge marker production recognises must not read as drift"
         )
         assert "UNVERIFIED" in result.detail
+
+
+class TestTheProbeReusesProductionRatherThanRedefiningIt:
+    """Six round-7 findings on #150 were one mistake: the probe re-derived
+    every property the production route already has — backoff, serialisation,
+    refusal statuses, body validation, user agent, bounded reads — and got each
+    of them wrong once. These assert the reuse rather than the behaviour, so a
+    future edit that forks the logic again fails here.
+    """
+
+    def test_the_probe_uses_productions_refusal_statuses(self, check_upstream):
+        import inspect
+
+        source = inspect.getsource(check_upstream._annas_block_detail)
+
+        assert "_REFUSAL_STATUSES" in source, (
+            "reusing Z-Library's WALLED_STATUS_CODES missed a bare 429/503, so "
+            "Anna's throttling was reported as DOM drift"
+        )
+
+    def test_the_probe_takes_the_production_browser_lock(self, check_upstream):
+        import inspect
+
+        source = inspect.getsource(check_upstream.probe_annas_download_dom)
+
+        assert "CrossProcessLock" in source
+        assert "browser_lock.release()" in source, (
+            "every early return sits inside walk(); the release has to be in "
+            "the outer finally or a blocked probe wedges the browser"
+        )
+
+    def test_the_probe_backs_off_on_a_wall(self, check_upstream):
+        import inspect
+
+        source = inspect.getsource(check_upstream.probe_annas_download_dom)
+
+        assert "usage.penalise(" in source, (
+            "production penalises on a wall; a probe that does not lets the "
+            "next request hit Anna's after only the spacing interval"
+        )
+
+    def test_the_payload_probe_is_streamed_and_bounded(self, check_upstream):
+        import inspect
+
+        source = inspect.getsource(check_upstream.probe_annas_download_dom)
+
+        assert "client.stream(" in source, (
+            "a plain get() buffers the whole file when a CDN ignores Range — "
+            "a 4KB probe that can pull 30MB is not a 4KB probe"
+        )
+        assert "DEFAULT_BROWSER_USER_AGENT" in source, (
+            "the doctor client identifies as zlibrary-mcp-upstream-check; a CDN "
+            "that blocks it would report a healthy handoff as broken"
+        )
+
+    def test_an_html_body_at_200_is_not_a_healthy_handoff(self, check_upstream):
+        """Production rejects an HTML body; the probe must ask the same question."""
+        assert check_upstream._looks_like_html(b"<!DOCTYPE html><html>...")
+        assert check_upstream._looks_like_html(b"  \n<html><body>login</body>")
+        assert not check_upstream._looks_like_html(b"%PDF-1.5\n%\xe2\xe3")
+        assert not check_upstream._looks_like_html(b"The_Feynman\x00\x00BOOKMOBI")

--- a/lib/download_validation.py
+++ b/lib/download_validation.py
@@ -1,0 +1,38 @@
+"""Shared classification for bytes returned by document download endpoints.
+
+Production transfers and the credential-free drift probe ask the same narrow
+question: did the endpoint return file bytes, or an HTML error surface?  Keep
+that policy here so a health check cannot report healthy for bytes production
+will deterministically refuse (or reject a supported XML document that
+production accepts).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+_HTML_OPENING_RE = re.compile(
+    rb"^(?:<!doctype\s+html|<html(?:\s|>)|<head(?:\s|>)|<body(?:\s|>)|<script(?:\s|>)|<!--)"
+)
+
+
+def signature_probe(signature: bytes) -> bytes:
+    """Strip a UTF-8 BOM and leading whitespace for content classification."""
+    return signature.removeprefix(b"\xef\xbb\xbf").lstrip()
+
+
+def looks_like_html(signature: bytes) -> bool:
+    """Recognize common leading HTML shapes independent of response headers."""
+    return bool(_HTML_OPENING_RE.match(signature_probe(signature).lower()))
+
+
+def payload_rejection(sample: bytes, content_type: str) -> Optional[str]:
+    """Why a transfer must refuse this response, or ``None`` if it may proceed."""
+    if not sample:
+        return "an empty body"
+    if "html" in (content_type or "").lower():
+        return f"content-type {content_type!r}"
+    if looks_like_html(sample):
+        return "an HTML body rather than file bytes"
+    return None

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -21,6 +21,11 @@ from pathlib import Path
 from filename_utils import create_unified_filename, normalize_document_extension
 import logging
 
+from lib.download_validation import (
+    payload_rejection as _payload_rejection,
+    signature_probe as _signature_probe,
+)
+
 # Import the new RAG processing functions
 from lib import rag_processing
 
@@ -791,22 +796,6 @@ def _response_extension(
     return "", ""
 
 
-def _signature_probe(signature: bytes) -> bytes:
-    """Strip a UTF-8 BOM and leading whitespace for content classification."""
-    return signature.removeprefix(b"\xef\xbb\xbf").lstrip()
-
-
-def _looks_like_html(signature: bytes) -> bool:
-    """Recognize common leading HTML shapes independent of response headers."""
-    probe = _signature_probe(signature).lower()
-    return bool(
-        re.match(
-            rb"^(?:<!doctype\s+html|<html(?:\s|>)|<head(?:\s|>)|<body(?:\s|>)|<script(?:\s|>)|<!--)",
-            probe,
-        )
-    )
-
-
 def _signature_extension(signature: bytes) -> tuple[str, str]:
     """Classify supported document bytes without trusting names or MIME.
 
@@ -987,11 +976,12 @@ async def _download_url_to_file(
                     response.raise_for_status()
 
                     content_type = response.headers.get("content-type", "")
-                    if "text/html" in content_type:
+                    header_rejection = _payload_rejection(b"probe", content_type)
+                    if header_rejection:
                         raise ProviderResponseError(
                             provider,
                             active_host,
-                            f"HTML response for {md5}; download key may have expired",
+                            f"{header_rejection} for {md5}; download key may have expired",
                             reason="protocol_error",
                         )
 
@@ -1005,11 +995,14 @@ async def _download_url_to_file(
                             if len(signature) < 4096:
                                 signature.extend(chunk[: 4096 - len(signature)])
                             written += len(chunk)
-                    if _looks_like_html(bytes(signature)):
+                    payload_rejection = _payload_rejection(
+                        bytes(signature), content_type
+                    )
+                    if payload_rejection:
                         raise ProviderResponseError(
                             provider,
                             active_host,
-                            f"HTML body for {md5}; download key may have expired",
+                            f"{payload_rejection} for {md5}; download key may have expired",
                             reason="protocol_error",
                         )
                     actual_md5 = digest.hexdigest()

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -515,17 +515,28 @@ class AnnasArchiveAdapter(SourceAdapter):
             self._browser = AnnasBrowserSession(self.config)
         return self._browser
 
-    def _browser_result(self, url: str, remaining: int) -> DownloadResult:
-        return DownloadResult(
-            url=url,
-            source=SourceType.ANNAS_ARCHIVE,
-            quota_info=QuotaInfo(
+    def _browser_result(self, url: str, remaining) -> DownloadResult:
+        """Wrap a resolved URL, omitting quota entirely when it is unknown.
+
+        `remaining is None` means the counter could not be read, not that it is
+        zero. Putting a number there anyway is how the fail-open path came to
+        report an exhausted quota and have the router discard a URL it had
+        already paid for (Codex on #150). No quota block says "unknown", which
+        is the truth; a zero says something false and consequential.
+        """
+        quota = None
+        if remaining is not None:
+            quota = QuotaInfo(
                 downloads_left=remaining,
                 downloads_per_day=self.config.annas_browser_daily_limit,
                 downloads_done_today=max(
                     0, self.config.annas_browser_daily_limit - remaining
                 ),
-            ),
+            )
+        return DownloadResult(
+            url=url,
+            source=SourceType.ANNAS_ARCHIVE,
+            quota_info=quota,
         )
 
     async def _browser_download_url(self, md5: str) -> DownloadResult:

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -493,6 +493,41 @@ class AnnasArchiveAdapter(SourceAdapter):
             quota_info=quota_info,
         )
 
+    async def iter_download_candidates(self, md5: str):
+        """Yield every usable download URL, best first.
+
+        The router consumes this as a stream and moves to the next candidate
+        when a transfer fails, so a partner server whose CDN is dead no longer
+        ends acquisition for the whole provider (Codex on #150). The keyed
+        route has exactly one answer and yields it unchanged.
+        """
+        if not self.secret_key and self.config.annas_browser_enabled:
+            session = self._browser_session()
+            async for url, remaining in session.iter_download_urls(md5):
+                yield self._browser_result(url, remaining)
+            return
+        yield await self.get_download_url(md5)
+
+    def _browser_session(self):
+        from .annas_browser import AnnasBrowserSession  # noqa: PLC0415
+
+        if self._browser is None:
+            self._browser = AnnasBrowserSession(self.config)
+        return self._browser
+
+    def _browser_result(self, url: str, remaining: int) -> DownloadResult:
+        return DownloadResult(
+            url=url,
+            source=SourceType.ANNAS_ARCHIVE,
+            quota_info=QuotaInfo(
+                downloads_left=remaining,
+                downloads_per_day=self.config.annas_browser_daily_limit,
+                downloads_done_today=max(
+                    0, self.config.annas_browser_daily_limit - remaining
+                ),
+            ),
+        )
+
     async def _browser_download_url(self, md5: str) -> DownloadResult:
         """Resolve a payload URL through the browser-resident session (#143).
 
@@ -503,22 +538,8 @@ class AnnasArchiveAdapter(SourceAdapter):
         moving bytes through Playwright would have meant reimplementing three
         pieces of working machinery for no gain.
         """
-        from .annas_browser import AnnasBrowserSession  # noqa: PLC0415
-
-        if self._browser is None:
-            self._browser = AnnasBrowserSession(self.config)
-        url, remaining = await self._browser.resolve_download_url(md5)
-        return DownloadResult(
-            url=url,
-            source=SourceType.ANNAS_ARCHIVE,
-            quota_info=QuotaInfo(
-                downloads_left=remaining,
-                downloads_per_day=self.config.annas_browser_daily_limit,
-                downloads_done_today=(
-                    self.config.annas_browser_daily_limit - remaining
-                ),
-            ),
-        )
+        url, remaining = await self._browser_session().resolve_download_url(md5)
+        return self._browser_result(url, remaining)
 
     async def close(self) -> None:
         """Clean up HTTP client resources."""

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -148,6 +148,9 @@ class AnnasArchiveAdapter(SourceAdapter):
         self.port = port_of(self.base_url)
         self.scheme = urlsplit(self.base_url).scheme or "https"
         self._client: Optional[httpx.AsyncClient] = None
+        # Created on first use, not here: starting a browser is expensive and
+        # every credential-free LibGen caller constructs this adapter too.
+        self._browser = None
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client.
@@ -360,10 +363,25 @@ class AnnasArchiveAdapter(SourceAdapter):
         """
         host = (urlsplit(self.base_url).hostname or "").lower()
         if not self.secret_key:
+            # The browser-resident route is the key-free alternative, in scope
+            # since the ruling recorded in #147 and measured in #142. It is
+            # tried only when explicitly enabled, because it needs a real
+            # display and a person to solve the challenge once — a server that
+            # reached for it unasked would hang on a window nobody can see.
+            if self.config.annas_browser_enabled:
+                return await self._browser_download_url(md5)
             raise ProviderConfigurationError(
                 PROVIDER,
                 host,
-                "ANNAS_SECRET_KEY not configured",
+                "ANNAS_SECRET_KEY not configured"
+                + (
+                    ""
+                    if self.config.annas_browser_enabled
+                    else ". The key-free browser-resident route exists (#143) "
+                    "but is off; set ANNAS_BROWSER_ENABLED=true to use it. It "
+                    "needs a visible browser window and one human challenge "
+                    "solve."
+                ),
             )
 
         if host not in ANNAS_TRUSTED_HOSTS:
@@ -459,7 +477,10 @@ class AnnasArchiveAdapter(SourceAdapter):
                     "account_fast_download_info must be an object",
                     reason="protocol_error",
                 )
-            if "downloads_left" in account_info and account_info["downloads_left"] is not None:
+            if (
+                "downloads_left" in account_info
+                and account_info["downloads_left"] is not None
+            ):
                 quota_info = QuotaInfo(
                     downloads_left=account_info["downloads_left"],
                     downloads_per_day=account_info.get("downloads_per_day", 0),
@@ -472,8 +493,38 @@ class AnnasArchiveAdapter(SourceAdapter):
             quota_info=quota_info,
         )
 
+    async def _browser_download_url(self, md5: str) -> DownloadResult:
+        """Resolve a payload URL through the browser-resident session (#143).
+
+        The browser hands back a URL and nothing else. The transfer stays on
+        the ordinary httpx path, which already verifies content md5, bounds
+        throughput and stages atomically — the spike measured that the signed
+        URL is fetchable outside the browser (HTTP 206, correct content), so
+        moving bytes through Playwright would have meant reimplementing three
+        pieces of working machinery for no gain.
+        """
+        from .annas_browser import AnnasBrowserSession  # noqa: PLC0415
+
+        if self._browser is None:
+            self._browser = AnnasBrowserSession(self.config)
+        url, remaining = await self._browser.resolve_download_url(md5)
+        return DownloadResult(
+            url=url,
+            source=SourceType.ANNAS_ARCHIVE,
+            quota_info=QuotaInfo(
+                downloads_left=remaining,
+                downloads_per_day=self.config.annas_browser_daily_limit,
+                downloads_done_today=(
+                    self.config.annas_browser_daily_limit - remaining
+                ),
+            ),
+        )
+
     async def close(self) -> None:
         """Clean up HTTP client resources."""
         if self._client:
             await self._client.aclose()
             self._client = None
+        if self._browser is not None:
+            await self._browser.close()
+            self._browser = None

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -155,6 +155,11 @@ _CHALLENGE_MARKERS = (
 # were here and are not, because a normal slow-download page legitimately asks
 # the reader to wait, and reading a countdown as an exhausted quota would abort
 # a request that was about to succeed.
+# Statuses that are a refusal whatever the body says. 401 is deliberately
+# absent: Anna's key-free routes never authenticate, so a 401 here would be a
+# contract change worth surfacing as an error rather than absorbing as a wall.
+_REFUSAL_STATUSES = frozenset({403, 429, 503})
+
 _EXHAUSTED_MARKERS = (
     "you have downloaded too many",
     "too many downloads",
@@ -444,7 +449,7 @@ class AnnasBrowserSession:
             # when the download started.
             self._remaining_at_start = self._remaining_today + 1
         try:
-            await page.goto(
+            response = await page.goto(
                 url,
                 wait_until="domcontentloaded",
                 timeout=self.config.annas_browser_nav_timeout * 1000,
@@ -460,7 +465,26 @@ class AnnasBrowserSession:
         await asyncio.sleep(self.config.annas_browser_settle_seconds)
         html = await page.content()
 
+        # A bare 429 or 403 carries no marker phrase, and Playwright reports the
+        # navigation as successful — so discarding the response meant a refusal
+        # looked like an ordinary page, the walk continued into the remaining
+        # partner servers, and the generic bridge retries followed (Codex on
+        # #150). The status is the plainest statement Anna's can make; it is
+        # only consulted after the challenge markers, so a challenge served with
+        # a refusal status still reads as a challenge.
+        status = getattr(response, "status", None)
         wall = _classify_page(html)
+        if wall is None and status in _REFUSAL_STATUSES:
+            self._limiter.penalise(self.config.annas_browser_backoff_seconds)
+            raise ProviderRateLimitedError(
+                PROVIDER,
+                self.host,
+                f"HTTP {status} with no challenge or quota text — a refusal "
+                f"either way. Backing off "
+                f"{self.config.annas_browser_backoff_seconds:.0f}s rather than "
+                f"walking the remaining servers into it.",
+                reason="quota_exhausted",
+            )
         if wall == "challenge":
             self._limiter.penalise(self.config.annas_browser_backoff_seconds)
             raise ChallengeNotClearedError(
@@ -563,15 +587,25 @@ class AnnasBrowserSession:
             # wait is generous: queueing behind another download is correct
             # behaviour, not a fault. `to_thread` keeps the blocking wait off
             # the event loop.
-            wait = self.config.annas_browser_nav_timeout * 3
+            # Derived from the *download* budget, not the navigation budget: the
+            # holder keeps this lock across the transfer, which is allowed to
+            # run for `download_timeout`. Sizing the wait to a browser walk made
+            # ordinary overlapping downloads fail with BrowserBusyError after
+            # 180s while the first was legitimately still running — refusing to
+            # serialise, in the function whose comment promises serialisation
+            # (Codex on #150).
+            wait = self.config.download_timeout + (
+                self.config.annas_browser_nav_timeout * 3
+            )
             if not await asyncio.to_thread(self._process_lock.acquire, wait):
                 raise BrowserBusyError(
                     PROVIDER,
                     self.host,
                     f"another process has held the Anna's browser for more "
-                    f"than {wait:.0f}s. One download at a time is deliberate "
-                    f"(#144) and Chrome will not share a profile anyway. Retry "
-                    f"once the other download finishes.",
+                    f"than {wait:.0f}s — longer than a whole permitted download, "
+                    f"so the holder is stuck rather than busy. One download at a "
+                    f"time is deliberate (#144) and Chrome will not share a "
+                    f"profile anyway.",
                 )
             # The release below must cover launch too: a browser that fails to
             # start would otherwise leave the lock held until it went stale,
@@ -638,6 +672,13 @@ class AnnasBrowserSession:
                         reason="protocol_error",
                     )
             finally:
-                self._remaining_at_start = None
-                await page.close()
-                self._process_lock.release()
+                # Two nested finallys, because `page.close()` can raise when
+                # Chrome has crashed or disconnected — and if it did, the lock
+                # release below it never ran, leaving the browser unusable for
+                # everyone until the 600s stale reclaim (Codex on #150). The
+                # release is the one thing here that must happen.
+                try:
+                    self._remaining_at_start = None
+                    await page.close()
+                finally:
+                    self._process_lock.release()

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -122,6 +122,12 @@ def _payload_extension_pattern() -> "re.Pattern[str]":
 
 _FILE_EXTENSION_RE = _payload_extension_pattern()
 
+_ANCHOR_RE = re.compile(
+    r'<a\b[^>]*\bhref="([^"]+)"[^>]*>(.*?)</a>',
+    flags=re.IGNORECASE | re.DOTALL,
+)
+_DOWNLOAD_LABEL_RE = re.compile(r"\b(?:download|save|get\s+file)\b", re.IGNORECASE)
+
 # Any Anna's book link. Used as positive evidence that a page is genuinely
 # Anna's rather than an interstitial standing in front of it.
 _BOOK_LINK_RE = re.compile(r"/md5/[a-f0-9]{32}")
@@ -149,6 +155,7 @@ _CHALLENGE_MARKERS = (
     "enable javascript and cookies",
     "just a moment",
     "ddos-guard protection",
+    "diamwall",
 )
 
 # Anna's own refusal. Deliberately specific: "please wait" and "rate limit"
@@ -299,6 +306,17 @@ def visible_text(html: str) -> str:
     return _WHITESPACE_RE.sub(" ", text).strip()
 
 
+def _has_labelled_payload_link(page_html: str) -> bool:
+    """Recognise an opaque off-site handoff without guessing its extension."""
+    for match in _ANCHOR_RE.finditer(page_html):
+        href = html.unescape(match.group(1))
+        if href.startswith(("http://", "https://")) and _DOWNLOAD_LABEL_RE.search(
+            visible_text(match.group(2))
+        ):
+            return True
+    return False
+
+
 def looks_like_annas_page(html: str) -> bool:
     """Whether this page carries Anna's own navigation, i.e. it really loaded.
 
@@ -315,7 +333,7 @@ def looks_like_annas_page(html: str) -> bool:
     # 20 `/md5/` links), but the payload link is the content we actually came
     # for — so a redesign that drops the navigation must not let a
     # challenge-hop 403 veto a page that handed us the file.
-    return bool(_FILE_EXTENSION_RE.search(html))
+    return bool(_FILE_EXTENSION_RE.search(html) or _has_labelled_payload_link(html))
 
 
 def _classify_page(html: str) -> Optional[str]:
@@ -339,6 +357,26 @@ def _classify_page(html: str) -> Optional[str]:
     for marker in _EXHAUSTED_MARKERS:
         if marker in low:
             return "exhausted"
+    return None
+
+
+def classify_annas_response(html: str, status: Optional[int]) -> Optional[str]:
+    """Classify one settled Anna response using production's precedence rules.
+
+    The first navigation hop can be a 403 even when the challenge succeeds, so
+    settled Anna content outranks status.  Both the browser route and its drift
+    probe use this function; keeping a second branch table in the probe caused
+    repeated review defects on #150.
+    """
+    wall = _classify_page(html)
+    if wall is not None:
+        return wall
+    if looks_like_annas_page(html):
+        return None
+    if status in _REFUSAL_STATUSES:
+        return "refusal"
+    if status is not None and status >= 400:
+        return "http_error"
     return None
 
 
@@ -406,9 +444,11 @@ class AnnasBrowserSession:
                 "playwright is not installed. The browser-resident Anna's route "
                 "needs it:\n"
                 "  uv sync --extra annas-browser\n"
-                "  uv run --extra annas-browser playwright install chrome\n"
+                "  uv run --no-sync playwright install chrome\n"
                 "(`uv run` is required for the second line: uv sync puts the "
-                "console script in .venv/bin without putting it on PATH.) "
+                "console script in .venv/bin without putting it on PATH; "
+                "`--no-sync` preserves whichever dependency tier is already "
+                "installed.) "
                 "Anna's keyed fast_download and every LibGen route are "
                 "unaffected and need none of this.",
             ) from exc
@@ -510,14 +550,8 @@ class AnnasBrowserSession:
         # the settled page has been looked at. A page carrying Anna's own
         # navigation loaded, whatever the first hop said.
         status = getattr(response, "status", None)
-        wall = _classify_page(html)
-        if (
-            wall is None
-            and status is not None
-            and status >= 400
-            and status not in _REFUSAL_STATUSES
-            and not looks_like_annas_page(html)
-        ):
+        outcome = classify_annas_response(html, status)
+        if outcome == "http_error":
             # Anything else in the 4xx/5xx range is a provider error, and it
             # must say so. Returning the error page as ordinary HTML meant the
             # caller found no partner links and raised a **permanent**
@@ -532,11 +566,7 @@ class AnnasBrowserSession:
                 f"error, not a missing edition.",
                 reason="http_error",
             )
-        if (
-            wall is None
-            and status in _REFUSAL_STATUSES
-            and not looks_like_annas_page(html)
-        ):
+        if outcome == "refusal":
             self._limiter.penalise(self.config.annas_browser_backoff_seconds)
             raise ProviderRateLimitedError(
                 PROVIDER,
@@ -547,7 +577,7 @@ class AnnasBrowserSession:
                 f"walking the remaining servers into it.",
                 reason="quota_exhausted",
             )
-        if wall == "challenge":
+        if outcome == "challenge":
             self._limiter.penalise(self.config.annas_browser_backoff_seconds)
             raise ChallengeNotClearedError(
                 PROVIDER,
@@ -564,7 +594,7 @@ class AnnasBrowserSession:
                 # clears this wall, so the person decides when to try again.
                 reason="challenge_required",
             )
-        if wall == "exhausted":
+        if outcome == "exhausted":
             self._limiter.penalise(self.config.annas_browser_backoff_seconds)
             raise ProviderRateLimitedError(
                 PROVIDER,
@@ -602,7 +632,9 @@ class AnnasBrowserSession:
         another Anna's page, and following one would walk the flow in a circle
         while spending rate budget on each lap.
         """
-        for match in re.finditer(r'href="([^"]+)"', page_html):
+        opaque_candidates: List[str] = []
+        labelled_candidates: List[str] = []
+        for match in _ANCHOR_RE.finditer(page_html):
             # `page.content()` serialises attribute separators as entities, so
             # a signed URL with several query parameters arrives carrying
             # `&amp;`. Sent to httpx unchanged that becomes `amp;Signature`,
@@ -613,23 +645,39 @@ class AnnasBrowserSession:
             href = html.unescape(match.group(1))
             if not href.startswith("http"):
                 continue
-            if not _FILE_EXTENSION_RE.search(href):
-                continue
             host = (urlsplit(href).hostname or "").lower()
-            if host and host != base_host:
+            if not host or host == base_host:
+                continue
+            if _FILE_EXTENSION_RE.search(href):
                 return href
+            opaque_candidates.append(href)
+            label = visible_text(match.group(2)).lower()
+            if _DOWNLOAD_LABEL_RE.search(label):
+                labelled_candidates.append(href)
+        if labelled_candidates:
+            return labelled_candidates[0]
+        if len(opaque_candidates) == 1:
+            return opaque_candidates[0]
         return None
 
     async def resolve_download_url(self, md5: str) -> Tuple[str, int]:
         """First working partner URL, for callers that want a single answer."""
-        async for url, remaining in self.iter_download_urls(md5):
-            return url, remaining
-        raise ProviderResponseError(
-            PROVIDER,
-            self.host,
-            f"no partner server yielded a payload link for md5 {md5}",
-            reason="protocol_error",
-        )
+        stream = self.iter_download_urls(md5)
+        try:
+            try:
+                return await anext(stream)
+            except StopAsyncIteration:
+                raise ProviderResponseError(
+                    PROVIDER,
+                    self.host,
+                    f"no partner server yielded a payload link for md5 {md5}",
+                    reason="protocol_error",
+                ) from None
+        finally:
+            # Returning from an async-for does not synchronously close its
+            # generator.  The generator owns the page and process lock, so the
+            # single-result wrapper must close it explicitly before returning.
+            await stream.aclose()
 
     async def iter_download_urls(self, md5: str):
         """Yield one payload URL per working partner server, in Anna's order.
@@ -668,16 +716,26 @@ class AnnasBrowserSession:
             acquire = asyncio.create_task(
                 asyncio.to_thread(self._process_lock.acquire, wait)
             )
+
+            def release_late_lock(task: asyncio.Task) -> None:
+                """Release a lock obtained after its awaiting walk was cancelled."""
+                if task.cancelled():
+                    return
+                try:
+                    acquired = task.result()
+                except BaseException:
+                    return
+                if acquired:
+                    self._process_lock.release()
+
             try:
-                got_lock = await acquire
+                # Cancelling a task that awaits `to_thread()` does not stop the
+                # worker thread.  Shield the task so its eventual True result
+                # remains observable and the callback below can release the
+                # OS lock instead of abandoning it.
+                got_lock = await asyncio.shield(acquire)
             except asyncio.CancelledError:
-                acquire.add_done_callback(
-                    lambda task: (
-                        self._process_lock.release()
-                        if not task.cancelled() and task.result()
-                        else None
-                    )
-                )
+                acquire.add_done_callback(release_late_lock)
                 raise
             if not got_lock:
                 raise BrowserBusyError(

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -1,0 +1,414 @@
+"""Anna's Archive download-link resolution from a browser-resident session.
+
+Anna's free download route sits behind a DDoS-Guard challenge. The route this
+module implements is the one an operator ruling brought into scope (#142, #147):
+a **real browser on the operator's machine** holds the clearance, and this code
+drives that browser to read the links Anna's puts on its own pages. Nothing is
+exported to another client, so #84's finding — DDoS-Guard binds the challenge
+cookie to the issuing IP inside `__ddg9_`, making a transplanted cookie exactly
+as useless as no cookie — does not apply here.
+
+Two facts from the #142/#143 spike shape everything below.
+
+**The browser resolves links; it does not move the file.** The signed URL that
+Anna's partner-server page hands out is fetched successfully *outside* the
+browser (measured: HTTP 206, `bytes 0-4095/4762590`, body starting `%PDF-1.5`).
+So the browser's job ends at a URL, and the transfer stays on the existing httpx
+path in `python_bridge._download_url_to_file`, which already does content-md5
+verification, throughput bounding and atomic staging. Routing bytes through
+Playwright would have meant reimplementing all three, worse.
+
+**Headful is mandatory.** A headless launch fails while holding clearance that
+worked headful minutes earlier from the same profile. This is not a tuning
+parameter, so `launch_headless` exists only to be refused loudly rather than to
+be set.
+
+The politeness layer (#144) is not a separate module because it must not be
+separable: every navigation goes through `_RateLimiter`, one request is in
+flight at a time, and a challenge or refusal backs off rather than retrying
+into the wall. Anna's states its reason for the control plainly — *"browser
+verification for our slow downloads, because otherwise bots and scrapers will
+abuse them"* — and the limiter is what makes this path's claim to be on the
+right side of that true rather than rhetorical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+from urllib.parse import urlsplit
+
+from .config import SourceConfig
+from .errors import (
+    ProviderConfigurationError,
+    ProviderResponseError,
+    ProviderTimeoutError,
+)
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "annas"
+
+# The partner-server links Anna's renders on a book page. Index 0 is the
+# "slow partner server" set; the trailing integer selects which one.
+_SLOW_LINK_RE = re.compile(r"/slow_download/([a-f0-9]{32})/(\d+)/(\d+)")
+
+# A direct file URL, as opposed to another Anna's page. The partner page's
+# payload link points off-site at a CDN node, which is what makes it fetchable
+# outside the browser at all.
+_FILE_EXTENSION_RE = re.compile(r"\.(pdf|epub|djvu|mobi|azw3|cbz|cbr|fb2|txt)\b", re.I)
+
+# Page text that means "the wall answered", not "the book is missing". These
+# must back off rather than retry: retrying into a challenge is the behaviour
+# the rate limit exists to prevent.
+_CHALLENGE_MARKERS = (
+    "checking your browser",
+    "ddos-guard",
+    "verifying you are human",
+    "enable javascript and cookies",
+)
+
+_EXHAUSTED_MARKERS = (
+    "you have downloaded too many",
+    "too many downloads",
+    "please wait",
+    "rate limit",
+)
+
+
+class BrowserUnavailableError(ProviderConfigurationError):
+    """Playwright, or a browser it can drive, is not installed.
+
+    A configuration failure rather than an outage: it is permanent until the
+    operator changes something, so it must not count as evidence that Anna's is
+    unhealthy. `reason` stays `configuration_error` for that reason.
+    """
+
+
+class ChallengeNotClearedError(ProviderResponseError):
+    """The wall answered instead of the page.
+
+    Distinct from an ordinary response error because the correct response is
+    the opposite one: back off and tell the operator to re-establish clearance
+    in the browser, rather than failing over to another host or retrying.
+    """
+
+
+class ProviderRateLimitedError(ProviderResponseError):
+    """Anna's declined further downloads for now — its limit, not ours.
+
+    A wall like the challenge, and handled like one: the walk stops rather than
+    trying the next partner server. Typed because the caller's move differs
+    from an ordinary response error, and because catching it by message would
+    put a string match on the abort path.
+    """
+
+    reason = "quota_exhausted"
+
+
+class DailyLimitReachedError(ProviderResponseError):
+    """This session's own per-day ceiling is spent.
+
+    Ours, not Anna's. Hitting it is the politeness layer working, so it says so
+    plainly rather than presenting as a provider failure.
+    """
+
+    reason = "quota_exhausted"
+
+
+@dataclass
+class _RateLimiter:
+    """Minimum spacing between requests, plus a ceiling on how many there are.
+
+    Deliberately crude. A token bucket would let a burst through after an idle
+    period, and a burst is the exact shape of traffic this exists to prevent —
+    the point is not to average out politely, it is to never be fast.
+    """
+
+    min_interval: float
+    daily_limit: int
+    _last_request: float = 0.0
+    _spent: int = 0
+    _window_started: float = field(default_factory=time.monotonic)
+
+    def _roll_window(self) -> None:
+        if time.monotonic() - self._window_started >= 86400:
+            self._window_started = time.monotonic()
+            self._spent = 0
+
+    @property
+    def remaining_today(self) -> int:
+        self._roll_window()
+        return max(0, self.daily_limit - self._spent)
+
+    async def acquire(self) -> None:
+        """Wait out the interval, or refuse if the day's budget is spent."""
+        self._roll_window()
+        if self._spent >= self.daily_limit:
+            raise DailyLimitReachedError(
+                PROVIDER,
+                "",
+                f"this session's own daily ceiling of {self.daily_limit} "
+                f"requests is spent. This is our limit, not Anna's — the "
+                f"browser route is deliberately bounded (#144). Raise "
+                f"ANNAS_BROWSER_DAILY_LIMIT only with a reason.",
+            )
+        elapsed = time.monotonic() - self._last_request
+        if self._last_request and elapsed < self.min_interval:
+            await asyncio.sleep(self.min_interval - elapsed)
+        self._last_request = time.monotonic()
+        self._spent += 1
+
+    def penalise(self, seconds: float) -> None:
+        """Push the next allowed request out, after a refusal.
+
+        Called on a challenge or a 429/403. Backing off is not the same as
+        waiting: it moves the *floor*, so the next request is late even if the
+        caller asks immediately.
+        """
+        self._last_request = time.monotonic() + max(0.0, seconds - self.min_interval)
+
+
+def _classify_page(text: str) -> Optional[str]:
+    """Name the wall in a page body, or None if it looks like a real page."""
+    low = text.lower()
+    for marker in _CHALLENGE_MARKERS:
+        if marker in low:
+            return "challenge"
+    for marker in _EXHAUSTED_MARKERS:
+        if marker in low:
+            return "exhausted"
+    return None
+
+
+class AnnasBrowserSession:
+    """A serialised, rate-limited handle on one browser-resident Anna's session.
+
+    One instance owns one browser profile. Every public method takes the same
+    lock, so there is exactly one request in flight per session no matter how
+    many callers there are — the repo has already learned what fanning lanes out
+    against a single-session provider costs (#144), and this is the structural
+    version of that lesson rather than a documented convention.
+    """
+
+    def __init__(self, config: SourceConfig):
+        self.config = config
+        self.base_url = config.annas_base_url.rstrip("/")
+        self.host = (urlsplit(self.base_url).hostname or "").lower()
+        self._lock = asyncio.Lock()
+        self._limiter = _RateLimiter(
+            min_interval=config.annas_browser_min_interval,
+            daily_limit=config.annas_browser_daily_limit,
+        )
+        self._playwright = None
+        self._context = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def _ensure_context(self):
+        """Start the browser once, headful, on the operator's own profile."""
+        if self._context is not None:
+            return self._context
+
+        try:
+            from playwright.async_api import async_playwright  # noqa: PLC0415
+        except ImportError as exc:
+            raise BrowserUnavailableError(
+                PROVIDER,
+                self.host,
+                "playwright is not installed. The browser-resident Anna's route "
+                "needs it: install the optional extra with "
+                "`uv sync --extra annas-browser`, then `playwright install "
+                "chrome`. Anna's keyed fast_download and every LibGen route are "
+                "unaffected and need none of this.",
+            ) from exc
+
+        self._playwright = await async_playwright().start()
+        try:
+            self._context = await self._playwright.chromium.launch_persistent_context(
+                self.config.annas_browser_profile_dir,
+                headless=False,
+                channel="chrome",
+                args=["--disable-blink-features=AutomationControlled"],
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced as configuration
+            await self._shutdown_playwright()
+            raise BrowserUnavailableError(
+                PROVIDER,
+                self.host,
+                f"could not start a browser on profile "
+                f"{self.config.annas_browser_profile_dir!r}: {exc}. This route "
+                f"requires a real display — #142 measured headless failing "
+                f"while holding clearance that worked headful from the same "
+                f"profile minutes earlier.",
+            ) from exc
+        return self._context
+
+    async def _shutdown_playwright(self) -> None:
+        if self._playwright is not None:
+            try:
+                await self._playwright.stop()
+            finally:
+                self._playwright = None
+
+    async def close(self) -> None:
+        if self._context is not None:
+            try:
+                await self._context.close()
+            finally:
+                self._context = None
+        await self._shutdown_playwright()
+
+    # -- navigation --------------------------------------------------------
+
+    async def _visit(self, page, url: str) -> str:
+        """Fetch one page politely and return its HTML, or name the wall.
+
+        The settle wait is not a guess dressed as a constant: the challenge hop
+        answers 403 *while succeeding*, so a status check immediately after
+        `goto` reports failure on a run that is about to work. #142 lost a
+        probe to exactly that reading before the wait was long enough. Cold
+        solves measured ~15s and re-solves ~35s, so the budget is configurable
+        and defaults above the slower of the two.
+        """
+        await self._limiter.acquire()
+        try:
+            await page.goto(
+                url,
+                wait_until="domcontentloaded",
+                timeout=self.config.annas_browser_nav_timeout * 1000,
+            )
+        except Exception as exc:  # noqa: BLE001 - normalised below
+            raise ProviderTimeoutError(
+                PROVIDER,
+                self.host,
+                f"navigation to {url} did not complete: {exc}",
+                reason="read_timeout",
+            ) from exc
+
+        await asyncio.sleep(self.config.annas_browser_settle_seconds)
+        html = await page.content()
+
+        wall = _classify_page(html)
+        if wall == "challenge":
+            self._limiter.penalise(self.config.annas_browser_backoff_seconds)
+            raise ChallengeNotClearedError(
+                PROVIDER,
+                self.host,
+                "the DDoS-Guard challenge answered instead of the page. "
+                "Clearance lapses after roughly 20 minutes (#142); solve it "
+                "once in the visible browser window and retry. Backing off "
+                f"{self.config.annas_browser_backoff_seconds:.0f}s rather than "
+                "retrying into the wall.",
+                reason="http_error",
+            )
+        if wall == "exhausted":
+            self._limiter.penalise(self.config.annas_browser_backoff_seconds)
+            raise ProviderRateLimitedError(
+                PROVIDER,
+                self.host,
+                "Anna's declined further downloads for now (its own limit, not "
+                "ours). Backing off rather than retrying.",
+                reason="quota_exhausted",
+            )
+        return html
+
+    # -- the actual job ----------------------------------------------------
+
+    @staticmethod
+    def _slow_download_paths(html: str, md5: str) -> List[str]:
+        """Partner-server links on a book page, in the order Anna's lists them.
+
+        Order is preserved rather than sorted: Anna's puts the servers it
+        expects to work first, and second-guessing that would be inventing
+        knowledge we do not have.
+        """
+        seen = []
+        for match in _SLOW_LINK_RE.finditer(html):
+            if match.group(1).lower() != md5.lower():
+                continue
+            path = match.group(0)
+            if path not in seen:
+                seen.append(path)
+        return seen
+
+    @staticmethod
+    def _direct_file_url(html: str, base_host: str) -> Optional[str]:
+        """The off-site payload link on a partner-server page.
+
+        Constrained to off-site hosts on purpose: every same-host candidate is
+        another Anna's page, and following one would walk the flow in a circle
+        while spending rate budget on each lap.
+        """
+        for match in re.finditer(r'href="([^"]+)"', html):
+            href = match.group(1)
+            if not href.startswith("http"):
+                continue
+            if not _FILE_EXTENSION_RE.search(href):
+                continue
+            host = (urlsplit(href).hostname or "").lower()
+            if host and host != base_host:
+                return href
+        return None
+
+    async def resolve_download_url(self, md5: str) -> Tuple[str, int]:
+        """Walk book page → partner server → signed URL. Returns (url, remaining).
+
+        Returns a URL for the caller to fetch with the ordinary httpx transfer,
+        which already verifies content md5, bounds throughput and stages
+        atomically. The browser deliberately never sees the bytes.
+        """
+        async with self._lock:
+            context = await self._ensure_context()
+            page = await context.new_page()
+            try:
+                book_html = await self._visit(page, f"{self.base_url}/md5/{md5}")
+                candidates = self._slow_download_paths(book_html, md5)
+                if not candidates:
+                    raise ProviderResponseError(
+                        PROVIDER,
+                        self.host,
+                        f"no partner-server link for md5 {md5} on its book "
+                        f"page. The page loaded and the challenge did not "
+                        f"fire, so this is a missing edition or a layout "
+                        f"change — not a wall, and not a reason to retry.",
+                        reason="not_found",
+                    )
+
+                attempts: List[str] = []
+                for path in candidates[: self.config.annas_browser_max_servers]:
+                    try:
+                        partner_html = await self._visit(page, f"{self.base_url}{path}")
+                    except (
+                        ChallengeNotClearedError,
+                        ProviderRateLimitedError,
+                        DailyLimitReachedError,
+                    ):
+                        # A wall answered. Every remaining partner server sits
+                        # behind the same wall, so trying them cannot succeed —
+                        # it can only spend the day's budget proving it, after
+                        # sleeping out the backoff each time (#144: back off on
+                        # a challenge or refusal rather than retrying into it).
+                        raise
+                    except Exception as exc:  # noqa: BLE001 - try the next server
+                        attempts.append(f"{path}: {type(exc).__name__}")
+                        continue
+
+                    url = self._direct_file_url(partner_html, self.host)
+                    if url:
+                        return url, self._limiter.remaining_today
+                    attempts.append(f"{path}: no payload link")
+
+                raise ProviderResponseError(
+                    PROVIDER,
+                    self.host,
+                    "no partner server yielded a payload link — "
+                    + " | ".join(attempts),
+                    reason="protocol_error",
+                )
+            finally:
+                await page.close()

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -442,12 +442,26 @@ class AnnasBrowserSession:
                 self._playwright = None
 
     async def close(self) -> None:
+        """Tear the browser down without turning cleanup into failure.
+
+        `python_bridge.main()` closes the router AFTER printing a successful
+        result, so an exception raised here exits the process nonzero and the
+        Node caller reports a failed download for an artifact already written
+        to disk. Chrome disconnecting mid-transfer — the case the guarded
+        `page.close()` covers — reaches this call for the same reason, so it
+        needs the same treatment: log it, do not raise it (Codex on #150).
+        """
         if self._context is not None:
             try:
                 await self._context.close()
+            except Exception as exc:
+                logger.warning("Anna's browser context did not close: %s", exc)
             finally:
                 self._context = None
-        await self._shutdown_playwright()
+        try:
+            await self._shutdown_playwright()
+        except Exception as exc:
+            logger.warning("Anna's Playwright driver did not stop: %s", exc)
 
     # -- navigation --------------------------------------------------------
 

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -239,7 +239,7 @@ class _RateLimiter:
     def remaining_today(self) -> int:
         return self.usage.remaining(self.daily_limit)
 
-    async def acquire(self) -> int:
+    async def acquire(self) -> Optional[int]:
         """Take a slot from the day's budget, then wait out the interval.
 
         Returns the budget remaining afterwards. The budget check comes first:
@@ -372,9 +372,12 @@ class AnnasBrowserSession:
                 PROVIDER,
                 self.host,
                 "playwright is not installed. The browser-resident Anna's route "
-                "needs it: install the optional extra with "
-                "`uv sync --extra annas-browser`, then `playwright install "
-                "chrome`. Anna's keyed fast_download and every LibGen route are "
+                "needs it:\n"
+                "  uv sync --extra annas-browser\n"
+                "  uv run --extra annas-browser playwright install chrome\n"
+                "(`uv run` is required for the second line: uv sync puts the "
+                "console script in .venv/bin without putting it on PATH.) "
+                "Anna's keyed fast_download and every LibGen route are "
                 "unaffected and need none of this.",
             ) from exc
 
@@ -427,7 +430,7 @@ class AnnasBrowserSession:
         and defaults above the slower of the two.
         """
         self._remaining_today = await self._limiter.acquire()
-        if self._remaining_at_start is None:
+        if self._remaining_at_start is None and self._remaining_today is not None:
             # +1 because acquire() has already taken this resolution's first
             # slot. The number is a true statement: this many were available
             # when the download started.

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -499,6 +499,27 @@ class AnnasBrowserSession:
         wall = _classify_page(html)
         if (
             wall is None
+            and status is not None
+            and status >= 400
+            and status not in _REFUSAL_STATUSES
+            and not looks_like_annas_page(html)
+        ):
+            # Anything else in the 4xx/5xx range is a provider error, and it
+            # must say so. Returning the error page as ordinary HTML meant the
+            # caller found no partner links and raised a **permanent**
+            # `not_found` — so a transient 502 was reported as a missing
+            # edition and never retried (Codex on #150). 401 lands here too,
+            # which is what the refusal-set comment intends: a contract change
+            # surfaced rather than absorbed.
+            raise ProviderResponseError(
+                PROVIDER,
+                self.host,
+                f"HTTP {status} from {url} with no Anna's content — a provider "
+                f"error, not a missing edition.",
+                reason="http_error",
+            )
+        if (
+            wall is None
             and status in _REFUSAL_STATUSES
             and not looks_like_annas_page(html)
         ):

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -44,7 +44,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 from urllib.parse import urlsplit
 
-from .annas_usage import DailyUsage
+from .annas_usage import CrossProcessLock, DailyUsage
 from .config import SourceConfig
 from .errors import (
     ProviderConfigurationError,
@@ -194,6 +194,16 @@ class ProviderRateLimitedError(ProviderResponseError):
     reason = "quota_exhausted"
 
 
+class BrowserBusyError(ProviderResponseError):
+    """Another process already holds the browser.
+
+    Non-retryable by reason, because the generic retry loop would start a
+    fourth and fifth process queueing for the same browser rather than waiting.
+    """
+
+    reason = "configuration_error"
+
+
 class DailyLimitReachedError(ProviderResponseError):
     """This session's own per-day ceiling is spent.
 
@@ -333,7 +343,20 @@ class AnnasBrowserSession:
         )
         self._playwright = None
         self._context = None
+        # Budget as it stood when the current resolution began. Reporting the
+        # budget *after* spending would tell the router `downloads_left == 0`
+        # for a resolution that legitimately used the last slots — and the
+        # router discards such a result and raises QuotaExhaustedError, so the
+        # final fully-budgeted download would fail after paying for itself
+        # (Codex on #150).
         self._remaining_today = config.annas_browser_daily_limit
+        self._remaining_at_start: Optional[int] = None
+        # The in-process lock keeps coroutines in order; this one keeps
+        # *processes* in order, which is the level that actually matters here
+        # since every MCP operation gets its own bridge process.
+        self._process_lock = CrossProcessLock(
+            os.path.join(config.annas_browser_profile_dir, "..", "annas-browser.lock")
+        )
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -404,6 +427,11 @@ class AnnasBrowserSession:
         and defaults above the slower of the two.
         """
         self._remaining_today = await self._limiter.acquire()
+        if self._remaining_at_start is None:
+            # +1 because acquire() has already taken this resolution's first
+            # slot. The number is a true statement: this many were available
+            # when the download started.
+            self._remaining_at_start = self._remaining_today + 1
         try:
             await page.goto(
                 url,
@@ -496,15 +524,53 @@ class AnnasBrowserSession:
         return None
 
     async def resolve_download_url(self, md5: str) -> Tuple[str, int]:
-        """Walk book page → partner server → signed URL. Returns (url, remaining).
+        """First working partner URL, for callers that want a single answer."""
+        async for url, remaining in self.iter_download_urls(md5):
+            return url, remaining
+        raise ProviderResponseError(
+            PROVIDER,
+            self.host,
+            f"no partner server yielded a payload link for md5 {md5}",
+            reason="protocol_error",
+        )
 
-        Returns a URL for the caller to fetch with the ordinary httpx transfer,
-        which already verifies content md5, bounds throughput and stages
-        atomically. The browser deliberately never sees the bytes.
+    async def iter_download_urls(self, md5: str):
+        """Yield one payload URL per working partner server, in Anna's order.
+
+        A stream rather than a single answer because the transfer happens
+        *after* this returns: a syntactically valid URL whose CDN is dead,
+        expired, or serving the wrong bytes is only discovered downstream, and
+        a single return ends the candidate stream before the remaining partner
+        servers are tried (Codex on #150). `ANNAS_BROWSER_MAX_SERVERS`
+        advertises that failover; this is what makes it real.
+
+        The transfer stays on the ordinary httpx path either way — the browser
+        never sees the bytes.
         """
         async with self._lock:
-            context = await self._ensure_context()
-            page = await context.new_page()
+            # A full walk is a couple of navigations plus settle time, so the
+            # wait is generous: queueing behind another download is correct
+            # behaviour, not a fault. `to_thread` keeps the blocking wait off
+            # the event loop.
+            wait = self.config.annas_browser_nav_timeout * 3
+            if not await asyncio.to_thread(self._process_lock.acquire, wait):
+                raise BrowserBusyError(
+                    PROVIDER,
+                    self.host,
+                    f"another process has held the Anna's browser for more "
+                    f"than {wait:.0f}s. One download at a time is deliberate "
+                    f"(#144) and Chrome will not share a profile anyway. Retry "
+                    f"once the other download finishes.",
+                )
+            # The release below must cover launch too: a browser that fails to
+            # start would otherwise leave the lock held until it went stale,
+            # blocking every later download for ten minutes.
+            try:
+                context = await self._ensure_context()
+                page = await context.new_page()
+            except BaseException:
+                self._process_lock.release()
+                raise
             try:
                 book_html = await self._visit(page, f"{self.base_url}/md5/{md5}")
                 candidates = self._slow_download_paths(book_html, md5)
@@ -516,10 +582,17 @@ class AnnasBrowserSession:
                         f"page. The page loaded and the challenge did not "
                         f"fire, so this is a missing edition or a layout "
                         f"change — not a wall, and not a reason to retry.",
+                        # Non-retryable on the Node side too: without that, the
+                        # message saying "not a reason to retry" was followed by
+                        # three retries, each spending another daily slot and
+                        # settle delay on a page that will not change, and each
+                        # counting toward the shared bridge circuit breaker
+                        # (Codex on #150).
                         reason="not_found",
                     )
 
                 attempts: List[str] = []
+                yielded = 0
                 for path in candidates[: self.config.annas_browser_max_servers]:
                     try:
                         partner_html = await self._visit(page, f"{self.base_url}{path}")
@@ -540,15 +613,20 @@ class AnnasBrowserSession:
 
                     url = self._direct_file_url(partner_html, self.host)
                     if url:
-                        return url, self._remaining_today
+                        yielded += 1
+                        yield url, self._remaining_at_start
+                        continue
                     attempts.append(f"{path}: no payload link")
 
-                raise ProviderResponseError(
-                    PROVIDER,
-                    self.host,
-                    "no partner server yielded a payload link — "
-                    + " | ".join(attempts),
-                    reason="protocol_error",
-                )
+                if not yielded:
+                    raise ProviderResponseError(
+                        PROVIDER,
+                        self.host,
+                        "no partner server yielded a payload link — "
+                        + " | ".join(attempts),
+                        reason="protocol_error",
+                    )
             finally:
+                self._remaining_at_start = None
                 await page.close()
+                self._process_lock.release()

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -62,21 +62,44 @@ _SLOW_LINK_RE = re.compile(r"/slow_download/([a-f0-9]{32})/(\d+)/(\d+)")
 # outside the browser at all.
 _FILE_EXTENSION_RE = re.compile(r"\.(pdf|epub|djvu|mobi|azw3|cbz|cbr|fb2|txt)\b", re.I)
 
-# Page text that means "the wall answered", not "the book is missing". These
-# must back off rather than retry: retrying into a challenge is the behaviour
-# the rate limit exists to prevent.
+# Any Anna's book link. Used as positive evidence that a page is genuinely
+# Anna's rather than an interstitial standing in front of it.
+_BOOK_LINK_RE = re.compile(r"/md5/[a-f0-9]{32}")
+
+# Everything that is not rendered prose. Classification runs on visible text
+# only, and that is not a nicety — a live run on 2026-08-23 rejected a
+# perfectly good 295KB book page because every Anna's page carries the literal
+# JavaScript comment `// "text/css" for DDOS-GUARD caching.`, three times on a
+# book page. Matching raw HTML meant the wall detector fired on 100% of
+# successful requests, and no amount of mocked-page unit testing was going to
+# show that.
+_SCRIPT_RE = re.compile(r"<script\b.*?</script>", re.S | re.I)
+_STYLE_RE = re.compile(r"<style\b.*?</style>", re.S | re.I)
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.S)
+_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# Phrases that mean "the wall answered", not "the book is missing". Verified
+# absent from the visible text of known-good book and partner-server pages
+# captured live, which is the bar a marker has to clear before it goes in here:
+# a false positive costs every request, a false negative costs one.
 _CHALLENGE_MARKERS = (
     "checking your browser",
-    "ddos-guard",
     "verifying you are human",
     "enable javascript and cookies",
+    "just a moment",
+    "ddos-guard protection",
 )
 
+# Anna's own refusal. Deliberately specific: "please wait" and "rate limit"
+# were here and are not, because a normal slow-download page legitimately asks
+# the reader to wait, and reading a countdown as an exhausted quota would abort
+# a request that was about to succeed.
 _EXHAUSTED_MARKERS = (
     "you have downloaded too many",
     "too many downloads",
-    "please wait",
-    "rate limit",
+    "download limit reached",
+    "daily download limit",
 )
 
 
@@ -173,9 +196,34 @@ class _RateLimiter:
         self._last_request = time.monotonic() + max(0.0, seconds - self.min_interval)
 
 
-def _classify_page(text: str) -> Optional[str]:
-    """Name the wall in a page body, or None if it looks like a real page."""
-    low = text.lower()
+def visible_text(html: str) -> str:
+    """The prose a reader would see, with scripts, styles and markup removed.
+
+    Public because it is the thing the wall detector is actually about: match
+    raw HTML and Anna's own source comments become evidence of a wall.
+    """
+    text = _SCRIPT_RE.sub(" ", html)
+    text = _STYLE_RE.sub(" ", text)
+    text = _COMMENT_RE.sub(" ", text)
+    text = _TAG_RE.sub(" ", text)
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _classify_page(html: str) -> Optional[str]:
+    """Name the wall in a page, or None if it looks like a real page.
+
+    Two guards, because a false positive here is far more expensive than a
+    false negative: it makes every request fail, and it fails them with a
+    message telling the operator to go solve a challenge that is not there.
+
+    1. Only visible text is searched (see `visible_text`).
+    2. A page carrying this site's own navigation links is a real page whatever
+       else it says. A challenge interstitial has no book links in it, so their
+       presence is positive evidence that cannot coexist with a wall.
+    """
+    if _SLOW_LINK_RE.search(html) or _BOOK_LINK_RE.search(html):
+        return None
+    low = visible_text(html).lower()
     for marker in _CHALLENGE_MARKERS:
         if marker in low:
             return "challenge"

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -35,13 +35,16 @@ right side of that true rather than rhetorical.
 from __future__ import annotations
 
 import asyncio
+import html
 import logging
+import os
 import re
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional, Tuple
 from urllib.parse import urlsplit
 
+from .annas_usage import DailyUsage
 from .config import SourceConfig
 from .errors import (
     ProviderConfigurationError,
@@ -60,7 +63,65 @@ _SLOW_LINK_RE = re.compile(r"/slow_download/([a-f0-9]{32})/(\d+)/(\d+)")
 # A direct file URL, as opposed to another Anna's page. The partner page's
 # payload link points off-site at a CDN node, which is what makes it fetchable
 # outside the browser at all.
-_FILE_EXTENSION_RE = re.compile(r"\.(pdf|epub|djvu|mobi|azw3|cbz|cbr|fb2|txt)\b", re.I)
+# A mirror of `filename_utils.SAFE_DOCUMENT_EXTENSIONS`, used only when that
+# module cannot be imported. Guarded by a test that compares the two.
+_FALLBACK_EXTENSIONS = frozenset(
+    {
+        "azw",
+        "azw3",
+        "cbr",
+        "cbz",
+        "djv",
+        "djvu",
+        "doc",
+        "docx",
+        "epub",
+        "fb2",
+        "lit",
+        "mobi",
+        "odt",
+        "pdf",
+        "rtf",
+        "txt",
+    }
+)
+
+
+def _payload_extension_pattern() -> "re.Pattern[str]":
+    """Build the file-link pattern from the project's own extension vocabulary.
+
+    A hand-written allowlist here silently failed every Anna's result in a
+    format it happened to omit — `rtf`, `lit`, `djv`, `azw`, `doc`, `docx` and
+    `odt` were all missing, and each produced a protocol error on a partner
+    page that had a perfectly good link on it (Codex on #150). Deriving it from
+    `filename_utils.SAFE_DOCUMENT_EXTENSIONS` means a format added there cannot
+    be forgotten here.
+    """
+    extensions = None
+    for module in ("filename_utils", "lib.filename_utils"):
+        try:
+            extensions = __import__(
+                module, fromlist=["SAFE_DOCUMENT_EXTENSIONS"]
+            ).SAFE_DOCUMENT_EXTENSIONS
+            break
+        except Exception:  # noqa: BLE001 - fall through to the mirror
+            continue
+    if extensions is None:
+        # A partial environment must not make this module unimportable at all.
+        # `_FALLBACK_EXTENSIONS` mirrors the same set and
+        # `test_the_fallback_mirrors_the_source_of_truth` fails if the two ever
+        # diverge, so the mirror cannot rot the way the hand-written allowlist
+        # this replaced did.
+        logger.debug("filename_utils unavailable; using the mirrored extension set")
+        extensions = _FALLBACK_EXTENSIONS
+    # Longest first, so `.azw3` cannot be shadowed by `.azw`.
+    alternatives = "|".join(
+        re.escape(ext) for ext in sorted(extensions, key=len, reverse=True)
+    )
+    return re.compile(rf"\.({alternatives})\b", re.I)
+
+
+_FILE_EXTENSION_RE = _payload_extension_pattern()
 
 # Any Anna's book link. Used as positive evidence that a page is genuinely
 # Anna's rather than an interstitial standing in front of it.
@@ -150,41 +211,47 @@ class _RateLimiter:
     Deliberately crude. A token bucket would let a burst through after an idle
     period, and a burst is the exact shape of traffic this exists to prevent —
     the point is not to average out politely, it is to never be fast.
+
+    Spacing and backoff are in-process, which is correct: they govern one
+    session's own pacing. The **daily ceiling is not**, and cannot be. Every MCP
+    operation starts a fresh `python_bridge.py`, so a counter living in this
+    object resets to zero on every download and the advertised ceiling would
+    never be reached (Codex on #150). It is delegated to `DailyUsage`, which
+    keeps the count in a locked file beside the browser profile.
     """
 
     min_interval: float
     daily_limit: int
+    usage: "DailyUsage"
     _last_request: float = 0.0
-    _spent: int = 0
-    _window_started: float = field(default_factory=time.monotonic)
-
-    def _roll_window(self) -> None:
-        if time.monotonic() - self._window_started >= 86400:
-            self._window_started = time.monotonic()
-            self._spent = 0
 
     @property
     def remaining_today(self) -> int:
-        self._roll_window()
-        return max(0, self.daily_limit - self._spent)
+        return self.usage.remaining(self.daily_limit)
 
-    async def acquire(self) -> None:
-        """Wait out the interval, or refuse if the day's budget is spent."""
-        self._roll_window()
-        if self._spent >= self.daily_limit:
+    async def acquire(self) -> int:
+        """Take a slot from the day's budget, then wait out the interval.
+
+        Returns the budget remaining afterwards. The budget check comes first:
+        sleeping twenty seconds only to then refuse would be the wrong order to
+        find out.
+        """
+        allowed, remaining = self.usage.spend(self.daily_limit)
+        if not allowed:
             raise DailyLimitReachedError(
                 PROVIDER,
                 "",
                 f"this session's own daily ceiling of {self.daily_limit} "
                 f"requests is spent. This is our limit, not Anna's — the "
-                f"browser route is deliberately bounded (#144). Raise "
+                f"browser route is deliberately bounded (#144). It resets 24 "
+                f"hours after the first request of the current window. Raise "
                 f"ANNAS_BROWSER_DAILY_LIMIT only with a reason.",
             )
         elapsed = time.monotonic() - self._last_request
         if self._last_request and elapsed < self.min_interval:
             await asyncio.sleep(self.min_interval - elapsed)
         self._last_request = time.monotonic()
-        self._spent += 1
+        return remaining
 
     def penalise(self, seconds: float) -> None:
         """Push the next allowed request out, after a refusal.
@@ -251,9 +318,15 @@ class AnnasBrowserSession:
         self._limiter = _RateLimiter(
             min_interval=config.annas_browser_min_interval,
             daily_limit=config.annas_browser_daily_limit,
+            usage=DailyUsage(
+                os.path.join(
+                    config.annas_browser_profile_dir, "..", "annas-browser-usage.json"
+                )
+            ),
         )
         self._playwright = None
         self._context = None
+        self._remaining_today = config.annas_browser_daily_limit
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -323,7 +396,7 @@ class AnnasBrowserSession:
         solves measured ~15s and re-solves ~35s, so the budget is configurable
         and defaults above the slower of the two.
         """
-        await self._limiter.acquire()
+        self._remaining_today = await self._limiter.acquire()
         try:
             await page.goto(
                 url,
@@ -352,7 +425,12 @@ class AnnasBrowserSession:
                 "once in the visible browser window and retry. Backing off "
                 f"{self.config.annas_browser_backoff_seconds:.0f}s rather than "
                 "retrying into the wall.",
-                reason="http_error",
+                # NOT http_error: that reads as retryable, and the Node retry
+                # layer would spawn three fresh bridge processes whose limiters
+                # have each forgotten this backoff — walking straight back into
+                # the wall on the retry delays alone (Codex on #150). A person
+                # clears this wall, so the person decides when to try again.
+                reason="challenge_required",
             )
         if wall == "exhausted":
             self._limiter.penalise(self.config.annas_browser_backoff_seconds)
@@ -385,15 +463,22 @@ class AnnasBrowserSession:
         return seen
 
     @staticmethod
-    def _direct_file_url(html: str, base_host: str) -> Optional[str]:
+    def _direct_file_url(page_html: str, base_host: str) -> Optional[str]:
         """The off-site payload link on a partner-server page.
 
         Constrained to off-site hosts on purpose: every same-host candidate is
         another Anna's page, and following one would walk the flow in a circle
         while spending rate budget on each lap.
         """
-        for match in re.finditer(r'href="([^"]+)"', html):
-            href = match.group(1)
+        for match in re.finditer(r'href="([^"]+)"', page_html):
+            # `page.content()` serialises attribute separators as entities, so
+            # a signed URL with several query parameters arrives carrying
+            # `&amp;`. Sent to httpx unchanged that becomes `amp;Signature`,
+            # which invalidates the signature and 403s a perfectly good link
+            # (Codex on #150). The live URL that verified this route happened
+            # to be path-signed and had no `&` in it at all, which is exactly
+            # how a bug like this survives a green end-to-end run.
+            href = html.unescape(match.group(1))
             if not href.startswith("http"):
                 continue
             if not _FILE_EXTENSION_RE.search(href):
@@ -448,7 +533,7 @@ class AnnasBrowserSession:
 
                     url = self._direct_file_url(partner_html, self.host)
                     if url:
-                        return url, self._limiter.remaining_today
+                        return url, self._remaining_today
                     attempts.append(f"{path}: no payload link")
 
                 raise ProviderResponseError(

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -645,7 +645,27 @@ class AnnasBrowserSession:
             wait = self.config.download_timeout + (
                 self.config.annas_browser_nav_timeout * 3
             )
-            if not await asyncio.to_thread(self._process_lock.acquire, wait):
+            # `to_thread` keeps running after the awaiting coroutine is
+            # cancelled — and the enclosing download deadline can fire before
+            # this wait expires. The abandoned worker would then acquire the
+            # lock with nobody left to release it, wedging the browser until
+            # the stale reclaim (Codex on #150). Release it on the way out if
+            # it was taken after we stopped caring.
+            acquire = asyncio.create_task(
+                asyncio.to_thread(self._process_lock.acquire, wait)
+            )
+            try:
+                got_lock = await acquire
+            except asyncio.CancelledError:
+                acquire.add_done_callback(
+                    lambda task: (
+                        self._process_lock.release()
+                        if not task.cancelled() and task.result()
+                        else None
+                    )
+                )
+                raise
+            if not got_lock:
                 raise BrowserBusyError(
                     PROVIDER,
                     self.host,
@@ -725,8 +745,16 @@ class AnnasBrowserSession:
                 # release below it never ran, leaving the browser unusable for
                 # everyone until the 600s stale reclaim (Codex on #150). The
                 # release is the one thing here that must happen.
+                self._remaining_at_start = None
                 try:
-                    self._remaining_at_start = None
                     await page.close()
+                except Exception as exc:  # noqa: BLE001
+                    # Chrome can disconnect while the *external* transfer is
+                    # still running, so this raises as the candidate stream is
+                    # closed — after `_download_url_to_file` has published the
+                    # file. Propagating it turned a completed download into a
+                    # failed one, discarding bytes already on disk for a
+                    # browser we no longer need (Codex on #150).
+                    logger.warning("Anna's browser page did not close: %s", exc)
                 finally:
                     self._process_lock.release()

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -39,7 +39,6 @@ import html
 import logging
 import os
 import re
-import time
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 from urllib.parse import urlsplit
@@ -233,7 +232,6 @@ class _RateLimiter:
     min_interval: float
     daily_limit: int
     usage: "DailyUsage"
-    _last_request: float = 0.0
 
     @property
     def remaining_today(self) -> int:
@@ -246,7 +244,7 @@ class _RateLimiter:
         sleeping twenty seconds only to then refuse would be the wrong order to
         find out.
         """
-        allowed, remaining = self.usage.spend(self.daily_limit)
+        allowed, remaining, wait = self.usage.spend(self.daily_limit, self.min_interval)
         if not allowed:
             raise DailyLimitReachedError(
                 PROVIDER,
@@ -257,20 +255,22 @@ class _RateLimiter:
                 f"hours after the first request of the current window. Raise "
                 f"ANNAS_BROWSER_DAILY_LIMIT only with a reason.",
             )
-        elapsed = time.monotonic() - self._last_request
-        if self._last_request and elapsed < self.min_interval:
-            await asyncio.sleep(self.min_interval - elapsed)
-        self._last_request = time.monotonic()
+        # The wait was computed and the next slot reserved inside the lock, so
+        # sleeping it here cannot race another process into the same slot.
+        if wait > 0:
+            await asyncio.sleep(wait)
         return remaining
 
     def penalise(self, seconds: float) -> None:
-        """Push the next allowed request out, after a refusal.
+        """Push the earliest allowed request out, after a refusal.
 
         Called on a challenge or a 429/403. Backing off is not the same as
         waiting: it moves the *floor*, so the next request is late even if the
-        caller asks immediately.
+        caller asks immediately — and the floor is shared state, because a
+        backoff that died with its process was true of one call and false of
+        the next one an operator made.
         """
-        self._last_request = time.monotonic() + max(0.0, seconds - self.min_interval)
+        self.usage.penalise(seconds)
 
 
 def visible_text(html: str) -> str:

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -43,7 +43,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 from urllib.parse import urlsplit
 
-from .annas_usage import CrossProcessLock, DailyUsage
+from .annas_usage import CrossProcessLock, DailyUsage, UsageCounterUnavailableError
 from .config import SourceConfig
 from .errors import (
     ProviderConfigurationError,
@@ -244,7 +244,15 @@ class _RateLimiter:
         sleeping twenty seconds only to then refuse would be the wrong order to
         find out.
         """
-        allowed, remaining, wait = self.usage.spend(self.daily_limit, self.min_interval)
+        try:
+            allowed, remaining, wait = self.usage.spend(
+                self.daily_limit, self.min_interval
+            )
+        except UsageCounterUnavailableError as exc:
+            # A configuration_error, not an outage: permanent until the
+            # operator changes something, so it must not count as evidence
+            # Anna's is unhealthy, and it must not be retried.
+            raise ProviderConfigurationError(PROVIDER, "", str(exc)) from None
         if not allowed:
             raise DailyLimitReachedError(
                 PROVIDER,

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -299,6 +299,25 @@ def visible_text(html: str) -> str:
     return _WHITESPACE_RE.sub(" ", text).strip()
 
 
+def looks_like_annas_page(html: str) -> bool:
+    """Whether this page carries Anna's own navigation, i.e. it really loaded.
+
+    Positive evidence, and the only thing that can safely override a refusal
+    status: **the DDoS-Guard challenge hop answers 403 while succeeding.**
+    `page.goto()` returns that first response, so on a perfectly good run the
+    status is 403 and the settled page is the book. #142 lost a probe to this
+    reading before, and a live run lost it again here — a status check with no
+    content guard rejected every successful request.
+    """
+    if _SLOW_LINK_RE.search(html) or _BOOK_LINK_RE.search(html):
+        return True
+    # A partner page carries Anna's navigation in practice (a live capture had
+    # 20 `/md5/` links), but the payload link is the content we actually came
+    # for — so a redesign that drops the navigation must not let a
+    # challenge-hop 403 veto a page that handed us the file.
+    return bool(_FILE_EXTENSION_RE.search(html))
+
+
 def _classify_page(html: str) -> Optional[str]:
     """Name the wall in a page, or None if it looks like a real page.
 
@@ -311,7 +330,7 @@ def _classify_page(html: str) -> Optional[str]:
        else it says. A challenge interstitial has no book links in it, so their
        presence is positive evidence that cannot coexist with a wall.
     """
-    if _SLOW_LINK_RE.search(html) or _BOOK_LINK_RE.search(html):
+    if looks_like_annas_page(html):
         return None
     low = visible_text(html).lower()
     for marker in _CHALLENGE_MARKERS:
@@ -472,9 +491,17 @@ class AnnasBrowserSession:
         # #150). The status is the plainest statement Anna's can make; it is
         # only consulted after the challenge markers, so a challenge served with
         # a refusal status still reads as a challenge.
+        # `page.goto()` returns the FIRST response, and the challenge hop
+        # answers 403 while succeeding — so the status alone says nothing until
+        # the settled page has been looked at. A page carrying Anna's own
+        # navigation loaded, whatever the first hop said.
         status = getattr(response, "status", None)
         wall = _classify_page(html)
-        if wall is None and status in _REFUSAL_STATUSES:
+        if (
+            wall is None
+            and status in _REFUSAL_STATUSES
+            and not looks_like_annas_page(html)
+        ):
             self._limiter.penalise(self.config.annas_browser_backoff_seconds)
             raise ProviderRateLimitedError(
                 PROVIDER,

--- a/lib/sources/annas_browser.py
+++ b/lib/sources/annas_browser.py
@@ -318,6 +318,13 @@ class AnnasBrowserSession:
         self._limiter = _RateLimiter(
             min_interval=config.annas_browser_min_interval,
             daily_limit=config.annas_browser_daily_limit,
+            # Beside the profile rather than inside it, deliberately: the
+            # budget belongs to the operator, not to a browser profile. Two
+            # profiles under one directory share one day's allowance, which is
+            # the honest reading of "30 requests per day" — a per-profile
+            # counter would let anyone multiply the ceiling by making a second
+            # profile, which is the same hole as the per-process counter this
+            # replaced.
             usage=DailyUsage(
                 os.path.join(
                     config.annas_browser_profile_dir, "..", "annas-browser-usage.json"

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -418,8 +418,20 @@ class DailyUsage:
         try:
             window_started, spent, next_allowed = self._read()
             now = time.time()
-            if now - window_started >= 86400 or now < window_started:
+            # Forward past 24h: a genuine new window. Backward past the
+            # window start: an NTP correction, NOT a new day — resetting there
+            # granted a second full allowance inside one real 24-hour period,
+            # repeatedly, for as long as the clock kept being corrected (Codex
+            # on #150). Re-anchor the window instead, keeping the count.
+            if now - window_started >= 86400:
                 window_started, spent = now, 0
+            elif now < window_started:
+                logger.warning(
+                    "Clock moved backwards past the usage window start; "
+                    "re-anchoring without resetting the %d requests already spent",
+                    spent,
+                )
+                window_started = now
             if spent >= limit:
                 return False, 0, 0.0
             start_at = max(now, next_allowed)

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -194,30 +194,50 @@ class DailyUsage:
 
     # -- state -------------------------------------------------------------
 
-    def _read(self) -> Tuple[float, int]:
+    def _read(self) -> Tuple[float, int, float]:
+        """`(window_started, spent, next_allowed)`, all wall-clock seconds.
+
+        `next_allowed` is the earliest a request may start. It lives here
+        rather than in the limiter for the same reason the count does: every
+        MCP operation is a fresh bridge process, so an in-memory timestamp
+        makes the minimum interval and the backoff hold *within* one call and
+        vanish between calls — which is the normal case, not the edge case.
+        """
         try:
             raw = json.loads(self.path.read_text())
-            return float(raw["window_started"]), int(raw["spent"])
+            return (
+                float(raw["window_started"]),
+                int(raw["spent"]),
+                float(raw.get("next_allowed", 0.0)),
+            )
         except (OSError, ValueError, KeyError, TypeError):
             # A corrupt or absent file starts a fresh window. It must not raise
             # — an unreadable counter that took the whole route down would make
             # the politeness layer a liability rather than a guard.
-            return time.time(), 0
+            return time.time(), 0, 0.0
 
-    def _write(self, window_started: float, spent: int) -> None:
+    def _write(self, window_started: float, spent: int, next_allowed: float) -> None:
         temporary = self.path.with_suffix(self.path.suffix + ".tmp")
         temporary.parent.mkdir(parents=True, exist_ok=True)
         temporary.write_text(
-            json.dumps({"window_started": window_started, "spent": spent})
+            json.dumps(
+                {
+                    "window_started": window_started,
+                    "spent": spent,
+                    "next_allowed": next_allowed,
+                }
+            )
         )
         os.replace(temporary, self.path)
 
     # -- the operations the limiter needs ---------------------------------
 
-    def spend(self, limit: int) -> Tuple[bool, Optional[int]]:
+    def spend(
+        self, limit: int, min_interval: float = 0.0
+    ) -> Tuple[bool, Optional[int], float]:
         """Take one request from today's budget.
 
-        Returns `(allowed, remaining_after)`, where `remaining_after` is
+        Returns `(allowed, remaining_after, wait_seconds)`, where `remaining_after` is
         **None** when the count could not be read — unknown, not zero. A
         sentinel that looks like a number gets treated as one: `-1` reached
         `QuotaInfo.downloads_left`, the router read it as exhausted, and the
@@ -238,23 +258,48 @@ class DailyUsage:
                 "not counted against the daily ceiling",
                 self.path,
             )
-            return True, None
+            return True, None, min_interval
         try:
-            window_started, spent = self._read()
+            window_started, spent, next_allowed = self._read()
             now = time.time()
             if now - window_started >= 86400 or now < window_started:
                 window_started, spent = now, 0
             if spent >= limit:
-                return False, 0
-            spent += 1
-            self._write(window_started, spent)
-            return True, max(0, limit - spent)
+                return False, 0, 0.0
+            start_at = max(now, next_allowed)
+            # The next slot is reserved *before* the wait, under the lock, so
+            # two processes queueing at once get consecutive slots rather than
+            # both computing the same start time and going together.
+            self._write(window_started, spent + 1, start_at + min_interval)
+            return True, max(0, limit - (spent + 1)), max(0.0, start_at - now)
+        finally:
+            self._release()
+
+    def penalise(self, seconds: float) -> None:
+        """Push the earliest allowed request out, across processes.
+
+        A backoff held in memory expired the moment the bridge process did, so
+        "back off five minutes rather than retrying into the wall" was true of
+        one call and false of the next one the operator made (#144).
+        """
+        if not self._acquire():
+            logger.warning(
+                "Could not lock the Anna's usage counter at %s; a backoff of "
+                "%.0fs applies to this process only",
+                self.path,
+                seconds,
+            )
+            return
+        try:
+            window_started, spent, next_allowed = self._read()
+            floor = time.time() + max(0.0, seconds)
+            self._write(window_started, spent, max(next_allowed, floor))
         finally:
             self._release()
 
     def remaining(self, limit: int) -> int:
         """Budget left, without spending any. Never blocks on the lock."""
-        window_started, spent = self._read()
+        window_started, spent, _ = self._read()
         now = time.time()
         if now - window_started >= 86400 or now < window_started:
             return limit

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -27,7 +27,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,42 @@ class CrossProcessLock:
 
     def __init__(self, path: str, stale_after: float = 600.0):
         self.path = Path(path)
+        self.owner_path = self.path / "owner"
         self.stale_after = stale_after
+
+    def _owner_pid(self) -> Optional[int]:
+        try:
+            return int(self.owner_path.read_text().strip())
+        except (OSError, ValueError):
+            return None
+
+    def _owner_is_alive(self) -> bool:
+        """Whether the process that took this lock still exists.
+
+        Age alone is not evidence of staleness here: a payload transfer may
+        legitimately run for far longer than `stale_after` (the download budget
+        allows 25 minutes) while the holder sits suspended, still owning the
+        Chrome profile. Reclaiming on age would then launch a second Chrome
+        against a profile in use — defeating the serialisation and breaking
+        both downloads (Codex on #150). Liveness is the question that was
+        actually being asked.
+        """
+        pid = self._owner_pid()
+        if pid is None:
+            # No owner recorded: an older lock, or one whose write was
+            # interrupted. Fall back to age, which is what this class did
+            # before liveness existed.
+            return False
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # Alive, owned by another user. Not ours to reclaim.
+            return True
+        except OSError:
+            return True
+        return True
 
     def acquire(self, timeout: float) -> bool:
         deadline = time.monotonic() + timeout
@@ -64,17 +99,31 @@ class CrossProcessLock:
             try:
                 self.path.parent.mkdir(parents=True, exist_ok=True)
                 os.mkdir(self.path)
+                try:
+                    self.owner_path.write_text(str(os.getpid()))
+                except OSError:  # pragma: no cover - lock still held, just anonymous
+                    logger.debug(
+                        "Could not record the lock owner at %s", self.owner_path
+                    )
                 return True
             except FileExistsError:
+                if self._owner_is_alive():
+                    # Held by a running process. Wait however long the caller
+                    # allows; a live holder is never stale, whatever its age.
+                    if time.monotonic() >= deadline:
+                        return False
+                    time.sleep(0.25)
+                    continue
                 try:
                     age = time.time() - self.path.stat().st_mtime
                 except OSError:
                     age = 0.0
                 if age > self.stale_after:
                     logger.warning(
-                        "Reclaiming a stale browser lock (%.0fs old) at %s",
-                        age,
+                        "Reclaiming a browser lock at %s: owner is gone and the "
+                        "lock is %.0fs old",
                         self.path,
+                        age,
                     )
                     self.release()
                     continue
@@ -87,6 +136,10 @@ class CrossProcessLock:
                 return True
 
     def release(self) -> None:
+        try:
+            self.owner_path.unlink()
+        except OSError:
+            pass
         try:
             os.rmdir(self.path)
         except OSError:
@@ -161,12 +214,19 @@ class DailyUsage:
 
     # -- the operations the limiter needs ---------------------------------
 
-    def spend(self, limit: int) -> Tuple[bool, int]:
+    def spend(self, limit: int) -> Tuple[bool, Optional[int]]:
         """Take one request from today's budget.
 
-        Returns `(allowed, remaining_after)`. The whole read-modify-write runs
-        under the lock, because the interesting failure is two bridge processes
-        each reading `limit - 1` and each deciding it may proceed.
+        Returns `(allowed, remaining_after)`, where `remaining_after` is
+        **None** when the count could not be read — unknown, not zero. A
+        sentinel that looks like a number gets treated as one: `-1` reached
+        `QuotaInfo.downloads_left`, the router read it as exhausted, and the
+        fail-open path spent browser requests and then threw the result away
+        (Codex on #150).
+
+        The whole read-modify-write runs under the lock, because the
+        interesting failure is two bridge processes each reading `limit - 1`
+        and each deciding it may proceed.
         """
         if not self._acquire():
             # Failing open here is deliberate and narrow: the alternative is
@@ -178,7 +238,7 @@ class DailyUsage:
                 "not counted against the daily ceiling",
                 self.path,
             )
-            return True, -1
+            return True, None
         try:
             window_started, spent = self._read()
             now = time.time()

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -39,6 +39,60 @@ _LOCK_POLL = 0.02
 _STALE_LOCK_AGE = 30.0
 
 
+class CrossProcessLock:
+    """One holder at a time, across processes, for a named resource.
+
+    An `asyncio.Lock` serialises coroutines inside one event loop, and every
+    MCP operation runs in a **separate** `python_bridge.py` process — so two
+    overlapping downloads each build their own session, their own lock, and
+    navigate simultaneously (Codex on #150). Chrome would then also refuse the
+    second launch against a profile the first one owns, producing a confusing
+    browser error instead of a clear one.
+
+    Same atomic-`mkdir` mechanism as the usage counter, with a much longer
+    timeout: a browser walk legitimately takes a couple of minutes, so waiting
+    is the correct behaviour rather than a symptom.
+    """
+
+    def __init__(self, path: str, stale_after: float = 600.0):
+        self.path = Path(path)
+        self.stale_after = stale_after
+
+    def acquire(self, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                os.mkdir(self.path)
+                return True
+            except FileExistsError:
+                try:
+                    age = time.time() - self.path.stat().st_mtime
+                except OSError:
+                    age = 0.0
+                if age > self.stale_after:
+                    logger.warning(
+                        "Reclaiming a stale browser lock (%.0fs old) at %s",
+                        age,
+                        self.path,
+                    )
+                    self.release()
+                    continue
+                if time.monotonic() >= deadline:
+                    return False
+                time.sleep(0.25)
+            except OSError:
+                # Same reasoning as the counter: a lock we cannot take must not
+                # block the operator's own downloads outright.
+                return True
+
+    def release(self) -> None:
+        try:
+            os.rmdir(self.path)
+        except OSError:
+            pass
+
+
 class DailyUsage:
     """Persistent count of requests spent in the current 24-hour window."""
 

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -25,11 +25,56 @@ import errno
 import json
 import logging
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+def _process_exists(pid: int) -> bool:
+    """Whether a process id is live, without signalling it.
+
+    **`os.kill(pid, 0)` is not a liveness probe on Windows.** CPython maps any
+    signal other than the console-control values onto `TerminateProcess`, so
+    the "harmless" zero signal *kills* the process it was meant to ask about
+    (Codex on #150). Here that would mean a second download terminating the
+    bridge holding the browser lock, and then waiting behind a lock whose owner
+    it had just destroyed.
+
+    POSIX keeps the cheap check. Windows uses `OpenProcess`, which is the
+    read-only question actually being asked.
+    """
+    if sys.platform == "win32":  # pragma: no cover - exercised on Windows only
+        import ctypes  # noqa: PLC0415
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            code = ctypes.c_ulong()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                # Cannot tell; treat as alive rather than reclaim a lock we do
+                # not understand.
+                return True
+            return code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Alive, owned by another user. Not ours to reclaim.
+        return True
+    except OSError:
+        return True
+    return True
+
 
 # How long to wait for another process to finish its read-modify-write. The
 # critical section is two file operations, so anything beyond this means a
@@ -37,6 +82,13 @@ logger = logging.getLogger(__name__)
 _LOCK_TIMEOUT = 5.0
 _LOCK_POLL = 0.02
 _STALE_LOCK_AGE = 30.0
+
+
+class UsageCounterUnavailableError(RuntimeError):
+    """The daily counter cannot be locked, so the ceiling cannot be enforced.
+
+    Raised rather than swallowed: see the reasoning in `DailyUsage.spend`.
+    """
 
 
 class CrossProcessLock:
@@ -82,16 +134,7 @@ class CrossProcessLock:
             # interrupted. Fall back to age, which is what this class did
             # before liveness existed.
             return False
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            # Alive, owned by another user. Not ours to reclaim.
-            return True
-        except OSError:
-            return True
-        return True
+        return _process_exists(pid)
 
     def acquire(self, timeout: float) -> bool:
         deadline = time.monotonic() + timeout
@@ -249,16 +292,23 @@ class DailyUsage:
         and each deciding it may proceed.
         """
         if not self._acquire():
-            # Failing open here is deliberate and narrow: the alternative is
-            # that a permissions problem or a wedged lock silently blocks the
-            # operator's own downloads. It is logged, and the in-process
-            # spacing and backoff still apply.
-            logger.warning(
-                "Could not lock the Anna's usage counter at %s; this request is "
-                "not counted against the daily ceiling",
-                self.path,
+            # Fail CLOSED. An earlier version allowed the request uncounted, on
+            # the reasoning that a lock problem should not block the operator.
+            # That was wrong in the way that matters: an unlockable path is not
+            # transient — every later process takes the same branch, so the
+            # ceiling is gone permanently and silently, and this route's scope
+            # is conditional on the ceiling being real (Codex on #150).
+            #
+            # A refusal is visible, diagnosable, and fixable in one command. An
+            # unbounded browser route against an anti-abuse control is neither.
+            raise UsageCounterUnavailableError(
+                f"cannot lock the Anna's daily-usage counter at {self.path}. "
+                f"The browser route refuses to run without an enforceable "
+                f"ceiling (#144) — an uncounted request would remove the limit "
+                f"for every later call too, not just this one. Check that the "
+                f"directory is writable, or set ANNAS_BROWSER_PROFILE_DIR "
+                f"somewhere that is."
             )
-            return True, None, min_interval
         try:
             window_started, spent, next_allowed = self._read()
             now = time.time()

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -33,6 +33,27 @@ from typing import Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
+def _process_start_time(pid: int) -> Optional[float]:
+    """Process start time in seconds since boot, or None if unavailable.
+
+    Linux only, from `/proc/<pid>/stat` field 22. Used to tell a live lock
+    owner from an unrelated process that happens to have inherited its PID
+    after a reboot — without it, a reused PID makes a stale lock look live
+    forever and no download can ever take the browser again (Codex on #150).
+    """
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as handle:
+            fields = handle.read().rsplit(b")", 1)[1].split()
+        ticks = float(fields[19])  # field 22, zero-indexed after the comm split
+    except (OSError, IndexError, ValueError):
+        return None
+    try:
+        hertz = os.sysconf("SC_CLK_TCK") or 100
+    except (OSError, ValueError):
+        hertz = 100
+    return ticks / hertz
+
+
 def _process_exists(pid: int) -> bool:
     """Whether a process id is live, without signalling it.
 
@@ -82,6 +103,21 @@ def _process_exists(pid: int) -> bool:
 _LOCK_TIMEOUT = 5.0
 _LOCK_POLL = 0.02
 _STALE_LOCK_AGE = 30.0
+
+# How many multiples of `stale_after` a PID-alive lock is trusted for on
+# platforms that cannot report process start times. Generous, because a live
+# holder really can hold for a whole download; finite, because a PID reused
+# after a reboot must not wedge the browser forever.
+_PID_TRUST_CEILING = 8
+
+
+def _system_uptime() -> Optional[float]:
+    """Seconds since boot, or None where unavailable."""
+    try:
+        with open("/proc/uptime", "rb") as handle:
+            return float(handle.read().split()[0])
+    except (OSError, IndexError, ValueError):
+        return None
 
 
 class UsageCounterUnavailableError(RuntimeError):
@@ -134,7 +170,38 @@ class CrossProcessLock:
             # interrupted. Fall back to age, which is what this class did
             # before liveness existed.
             return False
-        return _process_exists(pid)
+        if not _process_exists(pid):
+            return False
+
+        # A live PID is not proof of ownership. After a reboot or an unclean
+        # shutdown the directory survives and its PID can belong to an
+        # unrelated long-lived process, which would make the lock look live
+        # forever (Codex on #150). Where the platform can tell us, a process
+        # that started AFTER the lock was created cannot be its owner.
+        started = _process_start_time(pid)
+        if started is not None:
+            try:
+                lock_age = time.time() - self.path.stat().st_mtime
+            except OSError:
+                return True
+            uptime = _system_uptime()
+            if uptime is not None and (uptime - started) < lock_age:
+                logger.warning(
+                    "Lock at %s names PID %d, but that process is younger than "
+                    "the lock — treating it as stale rather than live",
+                    self.path,
+                    pid,
+                )
+                return False
+            return True
+
+        # No start time available (non-Linux). Trust the PID, but not forever:
+        # cap it so a reused PID cannot wedge the browser permanently.
+        try:
+            lock_age = time.time() - self.path.stat().st_mtime
+        except OSError:
+            return True
+        return lock_age < (self.stale_after * _PID_TRUST_CEILING)
 
     def acquire(self, timeout: float) -> bool:
         deadline = time.monotonic() + timeout
@@ -150,6 +217,7 @@ class CrossProcessLock:
                     )
                 return True
             except FileExistsError:
+                observed_owner = self._owner_pid()
                 if self._owner_is_alive():
                     # Held by a running process. Wait however long the caller
                     # allows; a live holder is never stale, whatever its age.
@@ -162,13 +230,18 @@ class CrossProcessLock:
                 except OSError:
                     age = 0.0
                 if age > self.stale_after:
+                    # Ownership-aware: two processes can both see the same
+                    # stale lock, and if the first reclaims and recreates it,
+                    # a blind `release()` from the second would delete the NEW
+                    # owner's lock and hand the browser to two holders at once
+                    # (Codex on #150). Only remove what we actually observed.
                     logger.warning(
                         "Reclaiming a browser lock at %s: owner is gone and the "
                         "lock is %.0fs old",
                         self.path,
                         age,
                     )
-                    self.release()
+                    self._release_if_unchanged(observed_owner)
                     continue
                 if time.monotonic() >= deadline:
                     return False
@@ -186,6 +259,18 @@ class CrossProcessLock:
                     "Cannot create the browser lock at %s: %s", self.path, exc
                 )
                 return False
+
+    def _release_if_unchanged(self, observed_owner: Optional[int]) -> None:
+        """Remove the lock only if it still names the owner we saw.
+
+        Between observing a stale lock and reclaiming it, another process may
+        have reclaimed and re-taken it. Removing that one would leave two
+        holders believing they own the browser.
+        """
+        if self._owner_pid() != observed_owner:
+            logger.info("Not reclaiming %s: another process took it first", self.path)
+            return
+        self.release()
 
     def release(self) -> None:
         try:
@@ -262,11 +347,23 @@ class DailyUsage:
                 int(raw["spent"]),
                 float(raw.get("next_allowed", 0.0)),
             )
-        except (OSError, ValueError, KeyError, TypeError):
-            # A corrupt or absent file starts a fresh window. It must not raise
-            # — an unreadable counter that took the whole route down would make
-            # the politeness layer a liability rather than a guard.
+        except FileNotFoundError:
+            # No file yet: a genuinely fresh window, which is the ordinary
+            # first-run case.
             return time.time(), 0, 0.0
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            # A file that EXISTS and cannot be read is a different situation
+            # entirely. Resetting `spent` to zero there hands out a fresh
+            # thirty requests, and the next write replaces the real count — so
+            # a corrupt or unreadable state file silently raised the ceiling
+            # instead of enforcing it (Codex on #150). Refuse, as with an
+            # unlockable counter.
+            raise UsageCounterUnavailableError(
+                f"the Anna's daily-usage counter at {self.path} exists but "
+                f"cannot be read ({type(exc).__name__}: {exc}). Refusing rather "
+                f"than starting a fresh allowance on top of an unknown count. "
+                f"Delete the file to reset the day deliberately."
+            ) from None
 
     def _write(self, window_started: float, spent: int, next_allowed: float) -> None:
         temporary = self.path.with_suffix(self.path.suffix + ".tmp")

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -1,0 +1,147 @@
+"""A daily request budget that survives the process it was spent in.
+
+Every MCP operation starts a fresh `python_bridge.py`, so a counter held in a
+`_RateLimiter` instance resets to zero on every call. A 30-per-day ceiling
+stored that way is not a limit — it is a number in a docstring, and an operator
+could issue unbounded downloads while the code claimed otherwise (Codex on
+#150). Anna's browser route is in scope *on the condition* that the limits are
+real, so this is the difference between the politeness claim being true and
+being rhetorical.
+
+The state is a small JSON file next to the browser profile, guarded by an
+exclusive lock file so two concurrent bridge processes cannot both read 29 and
+both write 30. The lock is a directory rather than `fcntl`: `os.mkdir` is
+atomic on POSIX and Windows alike, needs no third-party dependency, and this
+project supports both.
+
+Nothing here is a security boundary. An operator who wants more can edit the
+file or raise `ANNAS_BROWSER_DAILY_LIMIT`; the point is that they have to
+decide to, rather than getting it by accident because the counter forgot.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+# How long to wait for another process to finish its read-modify-write. The
+# critical section is two file operations, so anything beyond this means a
+# crashed process left the directory behind rather than a genuine queue.
+_LOCK_TIMEOUT = 5.0
+_LOCK_POLL = 0.02
+_STALE_LOCK_AGE = 30.0
+
+
+class DailyUsage:
+    """Persistent count of requests spent in the current 24-hour window."""
+
+    def __init__(self, state_path: str):
+        self.path = Path(state_path)
+        self.lock_path = Path(str(state_path) + ".lock")
+
+    # -- locking -----------------------------------------------------------
+
+    def _acquire(self) -> bool:
+        deadline = time.monotonic() + _LOCK_TIMEOUT
+        while True:
+            try:
+                self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+                os.mkdir(self.lock_path)
+                return True
+            except FileExistsError:
+                # A process that died mid-write must not wedge the limiter
+                # shut. Waiting forever would be a denial of the operator's own
+                # tool; ignoring the lock entirely would defeat it.
+                try:
+                    age = time.time() - self.lock_path.stat().st_mtime
+                except OSError:
+                    age = 0.0
+                if age > _STALE_LOCK_AGE:
+                    logger.warning(
+                        "Removing a stale Anna's usage lock (%.0fs old) at %s",
+                        age,
+                        self.lock_path,
+                    )
+                    self._release()
+                    continue
+                if time.monotonic() >= deadline:
+                    return False
+                time.sleep(_LOCK_POLL)
+            except OSError as exc:
+                if exc.errno in (errno.EACCES, errno.EROFS):
+                    return False
+                raise
+
+    def _release(self) -> None:
+        try:
+            os.rmdir(self.lock_path)
+        except OSError:
+            pass
+
+    # -- state -------------------------------------------------------------
+
+    def _read(self) -> Tuple[float, int]:
+        try:
+            raw = json.loads(self.path.read_text())
+            return float(raw["window_started"]), int(raw["spent"])
+        except (OSError, ValueError, KeyError, TypeError):
+            # A corrupt or absent file starts a fresh window. It must not raise
+            # — an unreadable counter that took the whole route down would make
+            # the politeness layer a liability rather than a guard.
+            return time.time(), 0
+
+    def _write(self, window_started: float, spent: int) -> None:
+        temporary = self.path.with_suffix(self.path.suffix + ".tmp")
+        temporary.parent.mkdir(parents=True, exist_ok=True)
+        temporary.write_text(
+            json.dumps({"window_started": window_started, "spent": spent})
+        )
+        os.replace(temporary, self.path)
+
+    # -- the operations the limiter needs ---------------------------------
+
+    def spend(self, limit: int) -> Tuple[bool, int]:
+        """Take one request from today's budget.
+
+        Returns `(allowed, remaining_after)`. The whole read-modify-write runs
+        under the lock, because the interesting failure is two bridge processes
+        each reading `limit - 1` and each deciding it may proceed.
+        """
+        if not self._acquire():
+            # Failing open here is deliberate and narrow: the alternative is
+            # that a permissions problem or a wedged lock silently blocks the
+            # operator's own downloads. It is logged, and the in-process
+            # spacing and backoff still apply.
+            logger.warning(
+                "Could not lock the Anna's usage counter at %s; this request is "
+                "not counted against the daily ceiling",
+                self.path,
+            )
+            return True, -1
+        try:
+            window_started, spent = self._read()
+            now = time.time()
+            if now - window_started >= 86400 or now < window_started:
+                window_started, spent = now, 0
+            if spent >= limit:
+                return False, 0
+            spent += 1
+            self._write(window_started, spent)
+            return True, max(0, limit - spent)
+        finally:
+            self._release()
+
+    def remaining(self, limit: int) -> int:
+        """Budget left, without spending any. Never blocks on the lock."""
+        window_started, spent = self._read()
+        now = time.time()
+        if now - window_started >= 86400 or now < window_started:
+            return limit
+        return max(0, limit - spent)

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -173,6 +173,11 @@ class DailyUsage:
     def __init__(self, state_path: str):
         self.path = Path(state_path)
         self.lock_path = Path(str(state_path) + ".lock")
+        # The durable floor is authoritative across processes.  This monotonic
+        # fallback covers the one process that observed a wall when contention
+        # prevented it from writing that floor; the previous warning claimed
+        # such a fallback existed when no state actually recorded it.
+        self._local_penalty_until = 0.0
         # The same lock as the browser session uses, on a different path. It
         # used to be a second hand-rolled copy of the mkdir scheme, with its
         # own staleness age and its own version of the reclamation race.
@@ -308,7 +313,8 @@ class DailyUsage:
                 next_allowed = max(0.0, next_allowed - rollback)
             if spent >= limit:
                 return False, 0, 0.0
-            start_at = max(now, next_allowed)
+            local_wait = max(0.0, self._local_penalty_until - time.monotonic())
+            start_at = max(now, next_allowed, now + local_wait)
             # The next slot is reserved *before* the wait, under the lock, so
             # two processes queueing at once get consecutive slots rather than
             # both computing the same start time and going together.
@@ -324,17 +330,22 @@ class DailyUsage:
         "back off five minutes rather than retrying into the wall" was true of
         one call and false of the next one the operator made (#144).
         """
+        delay = max(0.0, seconds)
+        self._local_penalty_until = max(
+            self._local_penalty_until, time.monotonic() + delay
+        )
+        floor = time.time() + delay
         if not self._acquire():
             logger.warning(
                 "Could not lock the Anna's usage counter at %s; a backoff of "
-                "%.0fs applies to this process only",
+                "%.0fs is enforced in this process but could not be persisted "
+                "for the next one",
                 self.path,
-                seconds,
+                delay,
             )
             return
         try:
             window_started, spent, next_allowed = self._read()
-            floor = time.time() + max(0.0, seconds)
             self._write(window_started, spent, max(next_allowed, floor))
         finally:
             self._release()

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -10,9 +10,22 @@ being rhetorical.
 
 The state is a small JSON file next to the browser profile, guarded by an
 exclusive lock file so two concurrent bridge processes cannot both read 29 and
-both write 30. The lock is a directory rather than `fcntl`: `os.mkdir` is
-atomic on POSIX and Windows alike, needs no third-party dependency, and this
-project supports both.
+both write 30.
+
+The lock was an atomic `os.mkdir`, chosen because it works the same on POSIX
+and Windows. That bought atomic *creation* and no atomic *reclamation*: a
+holder that dies leaves its directory behind, and every scheme for cleaning
+one up is check-then-act — read the owner, decide it is dead, delete. Two
+processes can pass that check together, and the second then deletes the lock
+the first has already retaken, leaving two holders of one Chrome profile
+(Codex on #150, twice). The PID files, liveness probes and staleness ages that
+grew around it were all attempts to shrink that window rather than close it.
+
+It is now an OS-held advisory lock — `fcntl.flock` on POSIX, `msvcrt.locking`
+on Windows — because the kernel releases it when the holder dies. There is no
+stale lock to reclaim, so the race has no window to occur in, and roughly
+eighty lines of PID bookkeeping are gone with it. Both platforms are still
+supported and nothing was added to the dependency set.
 
 Nothing here is a security boundary. An operator who wants more can edit the
 file or raise `ANNAS_BROWSER_DAILY_LIMIT`; the point is that they have to
@@ -21,7 +34,6 @@ decide to, rather than getting it by accident because the counter forgot.
 
 from __future__ import annotations
 
-import errno
 import json
 import logging
 import os
@@ -33,91 +45,34 @@ from typing import Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
-def _process_start_time(pid: int) -> Optional[float]:
-    """Process start time in seconds since boot, or None if unavailable.
-
-    Linux only, from `/proc/<pid>/stat` field 22. Used to tell a live lock
-    owner from an unrelated process that happens to have inherited its PID
-    after a reboot — without it, a reused PID makes a stale lock look live
-    forever and no download can ever take the browser again (Codex on #150).
-    """
-    try:
-        with open(f"/proc/{pid}/stat", "rb") as handle:
-            fields = handle.read().rsplit(b")", 1)[1].split()
-        ticks = float(fields[19])  # field 22, zero-indexed after the comm split
-    except (OSError, IndexError, ValueError):
-        return None
-    try:
-        hertz = os.sysconf("SC_CLK_TCK") or 100
-    except (OSError, ValueError):
-        hertz = 100
-    return ticks / hertz
-
-
-def _process_exists(pid: int) -> bool:
-    """Whether a process id is live, without signalling it.
-
-    **`os.kill(pid, 0)` is not a liveness probe on Windows.** CPython maps any
-    signal other than the console-control values onto `TerminateProcess`, so
-    the "harmless" zero signal *kills* the process it was meant to ask about
-    (Codex on #150). Here that would mean a second download terminating the
-    bridge holding the browser lock, and then waiting behind a lock whose owner
-    it had just destroyed.
-
-    POSIX keeps the cheap check. Windows uses `OpenProcess`, which is the
-    read-only question actually being asked.
-    """
-    if sys.platform == "win32":  # pragma: no cover - exercised on Windows only
-        import ctypes  # noqa: PLC0415
-
-        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-        STILL_ACTIVE = 259
-        kernel32 = ctypes.windll.kernel32
-        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-        if not handle:
-            return False
-        try:
-            code = ctypes.c_ulong()
-            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
-                # Cannot tell; treat as alive rather than reclaim a lock we do
-                # not understand.
-                return True
-            return code.value == STILL_ACTIVE
-        finally:
-            kernel32.CloseHandle(handle)
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        # Alive, owned by another user. Not ours to reclaim.
-        return True
-    except OSError:
-        return True
-    return True
-
-
 # How long to wait for another process to finish its read-modify-write. The
 # critical section is two file operations, so anything beyond this means a
 # crashed process left the directory behind rather than a genuine queue.
 _LOCK_TIMEOUT = 5.0
 _LOCK_POLL = 0.02
-_STALE_LOCK_AGE = 30.0
-
-# How many multiples of `stale_after` a PID-alive lock is trusted for on
-# platforms that cannot report process start times. Generous, because a live
-# holder really can hold for a whole download; finite, because a PID reused
-# after a reboot must not wedge the browser forever.
-_PID_TRUST_CEILING = 8
 
 
-def _system_uptime() -> Optional[float]:
-    """Seconds since boot, or None where unavailable."""
-    try:
-        with open("/proc/uptime", "rb") as handle:
-            return float(handle.read().split()[0])
-    except (OSError, IndexError, ValueError):
-        return None
+if sys.platform == "win32":  # pragma: no cover - exercised on Windows only
+    import msvcrt  # noqa: PLC0415
+
+    def _try_lock(fd: int) -> None:
+        """Claim byte 0 exclusively, or raise OSError."""
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+
+    def _unlock(fd: int) -> None:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl  # noqa: PLC0415
+
+    def _try_lock(fd: int) -> None:
+        """Claim the whole file exclusively, or raise OSError."""
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _unlock(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
 
 
 class UsageCounterUnavailableError(RuntimeError):
@@ -137,150 +92,79 @@ class CrossProcessLock:
     second launch against a profile the first one owns, producing a confusing
     browser error instead of a clear one.
 
-    Same atomic-`mkdir` mechanism as the usage counter, with a much longer
-    timeout: a browser walk legitimately takes a couple of minutes, so waiting
-    is the correct behaviour rather than a symptom.
+    The claim is an OS advisory lock on an open file descriptor, so the kernel
+    drops it when the holder exits — crash, kill -9 or clean return alike.
+    That is the whole reason it replaced the lock directory this class used to
+    manage by hand: there is no orphaned lock, therefore no staleness to judge,
+    no owner PID to trust, and no check-then-act window in which two processes
+    can both decide they are entitled to reclaim.
+
+    Waiting is the correct behaviour here rather than a symptom: a browser walk
+    legitimately takes a couple of minutes, so callers pass a generous timeout.
+
+    The pid written into the file is diagnostics only. Nothing reads it to make
+    a decision — that was the old design, and it is what went wrong.
     """
 
-    def __init__(self, path: str, stale_after: float = 600.0):
+    def __init__(self, path: str):
         self.path = Path(path)
-        self.owner_path = self.path / "owner"
-        self.stale_after = stale_after
-
-    def _owner_pid(self) -> Optional[int]:
-        try:
-            return int(self.owner_path.read_text().strip())
-        except (OSError, ValueError):
-            return None
-
-    def _owner_is_alive(self) -> bool:
-        """Whether the process that took this lock still exists.
-
-        Age alone is not evidence of staleness here: a payload transfer may
-        legitimately run for far longer than `stale_after` (the download budget
-        allows 25 minutes) while the holder sits suspended, still owning the
-        Chrome profile. Reclaiming on age would then launch a second Chrome
-        against a profile in use — defeating the serialisation and breaking
-        both downloads (Codex on #150). Liveness is the question that was
-        actually being asked.
-        """
-        pid = self._owner_pid()
-        if pid is None:
-            # No owner recorded: an older lock, or one whose write was
-            # interrupted. Fall back to age, which is what this class did
-            # before liveness existed.
-            return False
-        if not _process_exists(pid):
-            return False
-
-        # A live PID is not proof of ownership. After a reboot or an unclean
-        # shutdown the directory survives and its PID can belong to an
-        # unrelated long-lived process, which would make the lock look live
-        # forever (Codex on #150). Where the platform can tell us, a process
-        # that started AFTER the lock was created cannot be its owner.
-        started = _process_start_time(pid)
-        if started is not None:
-            try:
-                lock_age = time.time() - self.path.stat().st_mtime
-            except OSError:
-                return True
-            uptime = _system_uptime()
-            if uptime is not None and (uptime - started) < lock_age:
-                logger.warning(
-                    "Lock at %s names PID %d, but that process is younger than "
-                    "the lock — treating it as stale rather than live",
-                    self.path,
-                    pid,
-                )
-                return False
-            return True
-
-        # No start time available (non-Linux). Trust the PID, but not forever:
-        # cap it so a reused PID cannot wedge the browser permanently.
-        try:
-            lock_age = time.time() - self.path.stat().st_mtime
-        except OSError:
-            return True
-        return lock_age < (self.stale_after * _PID_TRUST_CEILING)
+        self._fd: Optional[int] = None
 
     def acquire(self, timeout: float) -> bool:
+        """Block up to `timeout` seconds for the lock. False if not taken.
+
+        Fails CLOSED on an unusable lock path, for the same reason the counter
+        does: returning success would mean "no lock exists, proceed anyway",
+        two bridge processes would launch Chrome against one profile, and the
+        serialisation this class exists for would be gone (Codex on #150). An
+        unwritable path does not heal itself, so allowing the first request
+        allows every later one.
+        """
+        if self._fd is not None:
+            # Re-entrant acquisition would make the paired release() drop a
+            # lock the caller still believes it holds.
+            raise RuntimeError(f"lock at {self.path} is already held by this object")
         deadline = time.monotonic() + timeout
         while True:
             try:
                 self.path.parent.mkdir(parents=True, exist_ok=True)
-                os.mkdir(self.path)
-                try:
-                    self.owner_path.write_text(str(os.getpid()))
-                except OSError:  # pragma: no cover - lock still held, just anonymous
-                    logger.debug(
-                        "Could not record the lock owner at %s", self.owner_path
-                    )
-                return True
-            except FileExistsError:
-                observed_owner = self._owner_pid()
-                if self._owner_is_alive():
-                    # Held by a running process. Wait however long the caller
-                    # allows; a live holder is never stale, whatever its age.
-                    if time.monotonic() >= deadline:
-                        return False
-                    time.sleep(0.25)
-                    continue
-                try:
-                    age = time.time() - self.path.stat().st_mtime
-                except OSError:
-                    age = 0.0
-                if age > self.stale_after:
-                    # Ownership-aware: two processes can both see the same
-                    # stale lock, and if the first reclaims and recreates it,
-                    # a blind `release()` from the second would delete the NEW
-                    # owner's lock and hand the browser to two holders at once
-                    # (Codex on #150). Only remove what we actually observed.
-                    logger.warning(
-                        "Reclaiming a browser lock at %s: owner is gone and the "
-                        "lock is %.0fs old",
-                        self.path,
-                        age,
-                    )
-                    self._release_if_unchanged(observed_owner)
-                    continue
+                fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o644)
+            except OSError as exc:
+                logger.warning("Cannot open the lock file at %s: %s", self.path, exc)
+                return False
+            try:
+                _try_lock(fd)
+            except OSError:
+                os.close(fd)
                 if time.monotonic() >= deadline:
                     return False
-                time.sleep(0.25)
-            except OSError as exc:
-                # Fail CLOSED, for the same reason the counter does. Returning
-                # success here means "no lock exists, proceed anyway" — so two
-                # bridge processes both launch Chrome against one profile and
-                # the serialisation this class exists for is gone, usually
-                # surfacing as a confusing profile-lock error rather than as
-                # the policy violation it is (Codex on #150). An unwritable
-                # lock path does not heal itself, so allowing the first request
-                # allows every later one.
-                logger.warning(
-                    "Cannot create the browser lock at %s: %s", self.path, exc
-                )
-                return False
-
-    def _release_if_unchanged(self, observed_owner: Optional[int]) -> None:
-        """Remove the lock only if it still names the owner we saw.
-
-        Between observing a stale lock and reclaiming it, another process may
-        have reclaimed and re-taken it. Removing that one would leave two
-        holders believing they own the browser.
-        """
-        if self._owner_pid() != observed_owner:
-            logger.info("Not reclaiming %s: another process took it first", self.path)
-            return
-        self.release()
+                time.sleep(_LOCK_POLL if timeout <= _LOCK_TIMEOUT else 0.25)
+                continue
+            except Exception:
+                os.close(fd)
+                raise
+            self._fd = fd
+            try:
+                os.ftruncate(fd, 0)
+                os.write(fd, str(os.getpid()).encode())
+            except OSError:  # pragma: no cover - diagnostics only
+                logger.debug("Could not record the lock owner in %s", self.path)
+            return True
 
     def release(self) -> None:
+        """Drop the lock. Safe to call when not held."""
+        fd, self._fd = self._fd, None
+        if fd is None:
+            return
         try:
-            self.owner_path.unlink()
-        except OSError:
+            _unlock(fd)
+        except OSError:  # pragma: no cover - the close below releases it anyway
             pass
-        try:
-            os.rmdir(self.path)
-        except OSError:
-            pass
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
 class DailyUsage:
@@ -289,45 +173,24 @@ class DailyUsage:
     def __init__(self, state_path: str):
         self.path = Path(state_path)
         self.lock_path = Path(str(state_path) + ".lock")
+        # The same lock as the browser session uses, on a different path. It
+        # used to be a second hand-rolled copy of the mkdir scheme, with its
+        # own staleness age and its own version of the reclamation race.
+        self._lock = CrossProcessLock(self.lock_path)
 
     # -- locking -----------------------------------------------------------
 
     def _acquire(self) -> bool:
-        deadline = time.monotonic() + _LOCK_TIMEOUT
-        while True:
-            try:
-                self.lock_path.parent.mkdir(parents=True, exist_ok=True)
-                os.mkdir(self.lock_path)
-                return True
-            except FileExistsError:
-                # A process that died mid-write must not wedge the limiter
-                # shut. Waiting forever would be a denial of the operator's own
-                # tool; ignoring the lock entirely would defeat it.
-                try:
-                    age = time.time() - self.lock_path.stat().st_mtime
-                except OSError:
-                    age = 0.0
-                if age > _STALE_LOCK_AGE:
-                    logger.warning(
-                        "Removing a stale Anna's usage lock (%.0fs old) at %s",
-                        age,
-                        self.lock_path,
-                    )
-                    self._release()
-                    continue
-                if time.monotonic() >= deadline:
-                    return False
-                time.sleep(_LOCK_POLL)
-            except OSError as exc:
-                if exc.errno in (errno.EACCES, errno.EROFS):
-                    return False
-                raise
+        """Take the counter lock, or report failure so the caller can refuse.
+
+        The critical section is two file operations, so `_LOCK_TIMEOUT` beyond
+        it means genuine contention rather than a crashed holder — a crashed
+        holder no longer leaves anything behind to wait for.
+        """
+        return self._lock.acquire(_LOCK_TIMEOUT)
 
     def _release(self) -> None:
-        try:
-            os.rmdir(self.lock_path)
-        except OSError:
-            pass
+        self._lock.release()
 
     # -- state -------------------------------------------------------------
 
@@ -426,12 +289,23 @@ class DailyUsage:
             if now - window_started >= 86400:
                 window_started, spent = now, 0
             elif now < window_started:
+                # `next_allowed` is an ABSOLUTE timestamp on the pre-correction
+                # clock, so re-anchoring the window alone leaves it stranded in
+                # the future: a one-hour NTP correction turned "wait 20s" into
+                # "wait an hour and 20s" (Codex on #150). Shift it by the same
+                # delta the clock moved, which preserves whatever real delay
+                # was left — including a long `penalise()` backoff, which must
+                # survive this or the rollback would quietly cancel it.
+                rollback = window_started - now
                 logger.warning(
-                    "Clock moved backwards past the usage window start; "
-                    "re-anchoring without resetting the %d requests already spent",
+                    "Clock moved backwards %.0fs past the usage window start; "
+                    "re-anchoring without resetting the %d requests already "
+                    "spent, and shifting the request floor by the same amount",
+                    rollback,
                     spent,
                 )
                 window_started = now
+                next_allowed = max(0.0, next_allowed - rollback)
             if spent >= limit:
                 return False, 0, 0.0
             start_at = max(now, next_allowed)

--- a/lib/sources/annas_usage.py
+++ b/lib/sources/annas_usage.py
@@ -173,10 +173,19 @@ class CrossProcessLock:
                 if time.monotonic() >= deadline:
                     return False
                 time.sleep(0.25)
-            except OSError:
-                # Same reasoning as the counter: a lock we cannot take must not
-                # block the operator's own downloads outright.
-                return True
+            except OSError as exc:
+                # Fail CLOSED, for the same reason the counter does. Returning
+                # success here means "no lock exists, proceed anyway" — so two
+                # bridge processes both launch Chrome against one profile and
+                # the serialisation this class exists for is gone, usually
+                # surfacing as a confusing profile-lock error rather than as
+                # the policy violation it is (Codex on #150). An unwritable
+                # lock path does not heal itself, so allowing the first request
+                # allows every later one.
+                logger.warning(
+                    "Cannot create the browser lock at %s: %s", self.path, exc
+                )
+                return False
 
     def release(self) -> None:
         try:

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -80,6 +80,26 @@ DEFAULT_ANNAS_BASE_URL = "https://annas-archive.gl"
 DEFAULT_LIBGEN_MIRROR = "li"
 
 
+# --- Anna's browser-resident route (#143) and its politeness layer (#144) ---
+#
+# The defaults are chosen to be slow. #95 fixed the intended scale — 10-15 books
+# in a typical four-hour reading session, 30 at the outside — and these numbers
+# are that scale expressed as limits rather than as a note in a document.
+# Raising them is an operator decision with a reason, not tuning.
+DEFAULT_ANNAS_BROWSER_MIN_INTERVAL = 20.0  # seconds between requests
+DEFAULT_ANNAS_BROWSER_DAILY_LIMIT = 30  # requests, not books: a book costs ~2
+DEFAULT_ANNAS_BROWSER_BACKOFF = 300.0  # after a challenge or a refusal
+# Settling, not guessing: the challenge hop answers 403 while succeeding, and
+# #142 measured ~15s for a cold solve and ~35s for a re-solve. Below the slower
+# of those, a working run reads as a failure.
+DEFAULT_ANNAS_BROWSER_SETTLE = 40.0
+DEFAULT_ANNAS_BROWSER_NAV_TIMEOUT = 60.0
+DEFAULT_ANNAS_BROWSER_MAX_SERVERS = 3
+DEFAULT_ANNAS_BROWSER_PROFILE_DIR = os.path.expanduser(
+    "~/.cache/zlibrary-mcp/annas-browser-profile"
+)
+
+
 @dataclass
 class SourceConfig:
     """Configuration for book source adapters.
@@ -109,6 +129,14 @@ class SourceConfig:
     download_timeout: float = DEFAULT_DOWNLOAD_TIMEOUT
     preflight_enabled: bool = True
     preflight_timeout: float = DEFAULT_PREFLIGHT_TIMEOUT
+    annas_browser_enabled: bool = False
+    annas_browser_profile_dir: str = DEFAULT_ANNAS_BROWSER_PROFILE_DIR
+    annas_browser_min_interval: float = DEFAULT_ANNAS_BROWSER_MIN_INTERVAL
+    annas_browser_daily_limit: int = DEFAULT_ANNAS_BROWSER_DAILY_LIMIT
+    annas_browser_backoff_seconds: float = DEFAULT_ANNAS_BROWSER_BACKOFF
+    annas_browser_settle_seconds: float = DEFAULT_ANNAS_BROWSER_SETTLE
+    annas_browser_nav_timeout: float = DEFAULT_ANNAS_BROWSER_NAV_TIMEOUT
+    annas_browser_max_servers: int = DEFAULT_ANNAS_BROWSER_MAX_SERVERS
 
     @property
     def has_annas_key(self) -> bool:
@@ -131,6 +159,24 @@ def _positive_float(name: str, default: float) -> float:
     except ValueError:
         return default
     return value if math.isfinite(value) and value > 0 else default
+
+
+def _positive_int(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back on nonsense.
+
+    Same reasoning as `_positive_float`: a malformed ceiling must not become no
+    ceiling. For the politeness limits (#144) that matters more than for a
+    timeout — a typo removing the daily cap would make this path exactly the
+    thing Anna's operates its wall against.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
 
 
 def get_source_config() -> SourceConfig:
@@ -160,5 +206,34 @@ def get_source_config() -> SourceConfig:
         == "true",
         preflight_timeout=_positive_float(
             "BOOK_SOURCE_PREFLIGHT_TIMEOUT", DEFAULT_PREFLIGHT_TIMEOUT
+        ),
+        # Opt-in, and it stays opt-in. The route needs a real display and a
+        # human to solve the challenge once, so a server that switched it on by
+        # default would hang waiting for a window nobody can see.
+        annas_browser_enabled=os.environ.get("ANNAS_BROWSER_ENABLED", "false")
+        .strip()
+        .lower()
+        in ("1", "true", "yes"),
+        annas_browser_profile_dir=(
+            os.environ.get("ANNAS_BROWSER_PROFILE_DIR", "").strip()
+            or DEFAULT_ANNAS_BROWSER_PROFILE_DIR
+        ),
+        annas_browser_min_interval=_positive_float(
+            "ANNAS_BROWSER_MIN_INTERVAL", DEFAULT_ANNAS_BROWSER_MIN_INTERVAL
+        ),
+        annas_browser_daily_limit=_positive_int(
+            "ANNAS_BROWSER_DAILY_LIMIT", DEFAULT_ANNAS_BROWSER_DAILY_LIMIT
+        ),
+        annas_browser_backoff_seconds=_positive_float(
+            "ANNAS_BROWSER_BACKOFF", DEFAULT_ANNAS_BROWSER_BACKOFF
+        ),
+        annas_browser_settle_seconds=_positive_float(
+            "ANNAS_BROWSER_SETTLE", DEFAULT_ANNAS_BROWSER_SETTLE
+        ),
+        annas_browser_nav_timeout=_positive_float(
+            "ANNAS_BROWSER_NAV_TIMEOUT", DEFAULT_ANNAS_BROWSER_NAV_TIMEOUT
+        ),
+        annas_browser_max_servers=_positive_int(
+            "ANNAS_BROWSER_MAX_SERVERS", DEFAULT_ANNAS_BROWSER_MAX_SERVERS
         ),
     )

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -245,7 +245,14 @@ def get_source_config() -> SourceConfig:
         .strip()
         .lower()
         in ("1", "true", "yes"),
-        annas_browser_profile_dir=(
+        # expanduser applies to the OVERRIDE too, not just the default. The
+        # value arrives from an MCP client's JSON `env` block, where no shell
+        # has expanded anything, so a perfectly ordinary `~/.cache/...` stays
+        # literal and Chrome, the usage counter and the process lock all land
+        # in a `./~/` directory beside the server's cwd — losing the clearance
+        # the operator solved by hand, or failing outright on a read-only
+        # install (Codex on #150).
+        annas_browser_profile_dir=os.path.expanduser(
             os.environ.get("ANNAS_BROWSER_PROFILE_DIR", "").strip()
             or DEFAULT_ANNAS_BROWSER_PROFILE_DIR
         ),

--- a/lib/sources/errors.py
+++ b/lib/sources/errors.py
@@ -30,6 +30,9 @@ REASON_TEXT = {
     "protocol_error": "returned a malformed response",
     "integrity_mismatch": "returned bytes that did not match the requested digest",
     "configuration_error": "cannot run with the supplied configuration",
+    "challenge_required": (
+        "answered with a browser-verification challenge that a person must clear"
+    ),
     "unknown": "failed for an unclassified reason",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ scholar = [
 # and deliberately not in `dev`: it needs a real display and a human to solve
 # the DDoS-Guard challenge once, so it cannot run in CI and must never become a
 # requirement for the credential-free LibGen path that most users install for.
-# After `uv sync --extra annas-browser`, run `playwright install chrome`.
+# After syncing a tier with `--extra annas-browser`, run
+# `uv run --no-sync playwright install chrome` so uv does not change that tier.
 annas-browser = [
     "playwright>=1.55.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,15 @@ ocr = [
     "pillow>=11.0.0",
 ]
 
+# Anna's Archive browser-resident download route (#143). Deliberately optional
+# and deliberately not in `dev`: it needs a real display and a human to solve
+# the DDoS-Guard challenge once, so it cannot run in CI and must never become a
+# requirement for the credential-free LibGen path that most users install for.
+# After `uv sync --extra annas-browser`, run `playwright install chrome`.
+annas-browser = [
+    "playwright>=1.55.0",
+]
+
 # Development and testing
 dev = [
     "pytest>=8.4.0",

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -341,12 +341,69 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
 
     partner_links = AnnasBrowserSession._slow_download_paths(body, ANNAS_DOM_CANARY_MD5)
     if partner_links:
+        # Stopping here would leave the second half of the flow unmonitored: a
+        # partner-page redesign breaks every download while this row stays
+        # green (Codex on #150). One extra request, against the first server
+        # Anna's lists, through the same extractor production uses.
+        try:
+            partner = await client.get(f"{ANNAS_BASE_URL}{partner_links[0]}")
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                name="annas-archive:download-dom",
+                ok=False,
+                detail=(
+                    f"book page intact ({len(partner_links)} partner links) but "
+                    f"{partner_links[0]} could not be fetched: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                required=False,
+            )
+
+        partner_body = partner.text
+        partner_walled = _block_detail(partner) or any(
+            marker in visible_text(partner_body).lower()
+            for marker in (
+                "checking your browser",
+                "just a moment",
+                "verifying you are human",
+            )
+        )
+        if partner_walled:
+            return ProbeResult(
+                name="annas-archive:download-dom",
+                ok=False,
+                blocked=True,
+                detail=(
+                    f"book page intact ({len(partner_links)} partner links) but "
+                    f"the partner page answered with browser verification, so "
+                    f"payload-link extraction is UNVERIFIED from this network — "
+                    f"not evidence that it drifted"
+                ),
+                required=False,
+            )
+
+        annas_host = (urlsplit(ANNAS_BASE_URL).hostname or "").lower()
+        payload = AnnasBrowserSession._direct_file_url(partner_body, annas_host)
+        if not payload:
+            return ProbeResult(
+                name="annas-archive:download-dom",
+                ok=False,
+                detail=(
+                    f"book page intact ({len(partner_links)} partner links) but "
+                    f"{partner_links[0]} yielded NO off-site payload link "
+                    f"(HTTP {partner.status_code}, {len(partner_body)} bytes) — "
+                    f"partner-page drift, and every browser download fails"
+                ),
+                required=False,
+            )
+
         return ProbeResult(
             name="annas-archive:download-dom",
             ok=True,
             detail=(
-                f"{len(partner_links)} partner-server link(s) in the expected "
-                f"shape on the canary book page (first: {partner_links[0]})"
+                f"{len(partner_links)} partner-server link(s) on the canary book "
+                f"page, and {partner_links[0]} yielded a payload link on "
+                f"{urlsplit(payload).hostname or '?'}"
             ),
             required=False,
         )
@@ -666,14 +723,26 @@ async def run_probes() -> list[ProbeResult]:
         follow_redirects=True,
         headers={"User-Agent": "zlibrary-mcp-upstream-check"},
     ) as client:
-        zlib_results, annas, libgen, libgen_download = await asyncio.gather(
+        (
+            zlib_results,
+            annas,
+            annas_download_dom,
+            libgen,
+            libgen_download,
+        ) = await asyncio.gather(
             probe_zlibrary_eapi(client),
             probe_annas(client),
             probe_annas_download_dom(client),
             probe_libgen(client),
             probe_libgen_download(client),
         )
-    return [*zlib_results, annas, libgen, libgen_download]
+    return [
+        *zlib_results,
+        annas,
+        annas_download_dom,
+        libgen,
+        libgen_download,
+    ]
 
 
 def actionable_failures(results: list[ProbeResult]) -> list[ProbeResult]:

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -122,6 +122,28 @@ class ProbeResult:
         return "FAIL" if self.required else "WARN"
 
 
+def _annas_block_detail(resp: httpx.Response) -> Optional[str]:
+    """A block report for Anna's, naming Anna's.
+
+    `_block_detail` hardcodes the Z-Library domain and tells the operator to
+    set `ZLIBRARY_EAPI_DOMAIN`. Reusing it here reported a Z-Library host and
+    an irrelevant remedy for an Anna's wall — actively misleading in the exact
+    anti-bot scenario this probe exists to distinguish (Codex on #150).
+    """
+    body_is_diamwall = "diamwall" in resp.text.lower()
+    if not body_is_diamwall and resp.status_code not in WALLED_STATUS_CODES:
+        return None
+    wall = "DiamWall anti-bot wall" if body_is_diamwall else "network-level block"
+    host = urlsplit(ANNAS_BASE_URL).hostname or "annas-archive"
+    return (
+        f"{wall} (HTTP {resp.status_code}) — {host} refuses this network's "
+        f"clients. From a datacenter or CI address this is expected IP "
+        f"blocking, not upstream drift. The browser-resident route (#143) "
+        f"clears Anna's wall with a real browser; this probe deliberately does "
+        f"not, so it cannot verify the DOM shape from here"
+    )
+
+
 def _block_detail(resp: httpx.Response) -> Optional[str]:
     """Detect a network-level block in a response, returning a report line.
 
@@ -301,7 +323,7 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
     """
     from lib.sources.annas_browser import (  # noqa: PLC0415
         AnnasBrowserSession,
-        visible_text,
+        _classify_page,
     )
 
     url = f"{ANNAS_BASE_URL}/md5/{ANNAS_DOM_CANARY_MD5}"
@@ -315,16 +337,12 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
             required=False,
         )
 
-    walled = _block_detail(resp)
+    walled = _annas_block_detail(resp)
     body = resp.text
-    challenged = any(
-        marker in visible_text(body).lower()
-        for marker in (
-            "checking your browser",
-            "just a moment",
-            "verifying you are human",
-        )
-    )
+    # The production classifier, not a copy of some of its markers: a partial
+    # copy reported a 200 challenge page as DOM drift, sending the maintainer
+    # to look for a layout change that is not there (Codex on #150).
+    challenged = _classify_page(body) == "challenge"
     if walled or challenged:
         return ProbeResult(
             name="annas-archive:download-dom",
@@ -361,13 +379,8 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
             )
 
         partner_body = partner.text
-        partner_walled = _block_detail(partner) or any(
-            marker in visible_text(partner_body).lower()
-            for marker in (
-                "checking your browser",
-                "just a moment",
-                "verifying you are human",
-            )
+        partner_walled = (
+            _annas_block_detail(partner) or _classify_page(partner_body) == "challenge"
         )
         if partner_walled:
             return ProbeResult(

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -122,6 +122,18 @@ class ProbeResult:
         return "FAIL" if self.required else "WARN"
 
 
+def _looks_like_html(sample: bytes) -> bool:
+    """Whether a body opens like an HTML document rather than a file.
+
+    The same question `_download_url_to_file` asks before accepting bytes: a
+    CDN soft block, login page or interstitial arrives with HTTP 200 and an
+    HTML body, and production refuses it. A status-only check would have
+    reported the handoff healthy on exactly that response.
+    """
+    head = sample[:512].lstrip().lower()
+    return head.startswith(b"<!doctype html") or head.startswith(b"<html")
+
+
 def _annas_block_detail(resp: httpx.Response) -> Optional[str]:
     """A block report for Anna's, naming Anna's.
 
@@ -130,10 +142,29 @@ def _annas_block_detail(resp: httpx.Response) -> Optional[str]:
     an irrelevant remedy for an Anna's wall — actively misleading in the exact
     anti-bot scenario this probe exists to distinguish (Codex on #150).
     """
+    from lib.sources.annas_browser import _REFUSAL_STATUSES  # noqa: PLC0415
+
     body_is_diamwall = "diamwall" in resp.text.lower()
-    if not body_is_diamwall and resp.status_code not in WALLED_STATUS_CODES:
+    # Anna's refusal statuses, not Z-Library's wall statuses. Reusing
+    # WALLED_STATUS_CODES (307/403/513/517) missed a bare 429 or 503, so
+    # throttling fell through to the missing-link branch and was reported as
+    # DOM drift — sending a maintainer to look for a layout change while Anna's
+    # was simply saying slow down (Codex on #150). `_REFUSAL_STATUSES` is what
+    # the production route already uses for exactly this question.
+    throttled = resp.status_code in _REFUSAL_STATUSES
+    if (
+        not body_is_diamwall
+        and not throttled
+        and resp.status_code not in WALLED_STATUS_CODES
+    ):
         return None
-    wall = "DiamWall anti-bot wall" if body_is_diamwall else "network-level block"
+    wall = (
+        "DiamWall anti-bot wall"
+        if body_is_diamwall
+        else "throttled or refused"
+        if throttled
+        else "network-level block"
+    )
     host = urlsplit(ANNAS_BASE_URL).hostname or "annas-archive"
     return (
         f"{wall} (HTTP {resp.status_code}) — {host} refuses this network's "
@@ -326,10 +357,14 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
         _classify_page,
     )
     from lib.sources.annas_usage import (  # noqa: PLC0415
+        CrossProcessLock,
         DailyUsage,
         UsageCounterUnavailableError,
     )
-    from lib.sources.config import get_source_config  # noqa: PLC0415
+    from lib.sources.config import (  # noqa: PLC0415
+        DEFAULT_BROWSER_USER_AGENT,
+        get_source_config,
+    )
 
     # This probe is real traffic to Anna's free route, so it is metered by the
     # same counter the production path uses. Uncounted health checks would let
@@ -338,192 +373,263 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
     # politeness layer would cover the feature and not the tool that exercises
     # it (Codex on #150).
     browser_config = get_source_config()
-    usage = DailyUsage(
-        os.path.join(
-            browser_config.annas_browser_profile_dir, "..", "annas-browser-usage.json"
-        )
-    )
-
-    async def metered() -> Optional[ProbeResult]:
-        """Take a slot, or return the row explaining why the probe did not run."""
-        try:
-            allowed, _remaining, wait = usage.spend(
-                browser_config.annas_browser_daily_limit,
-                browser_config.annas_browser_min_interval,
-            )
-        except UsageCounterUnavailableError as exc:
-            return ProbeResult(
-                name="annas-archive:download-dom",
-                ok=False,
-                detail=f"not probed: {exc}",
-                required=False,
-            )
-        if not allowed:
-            return ProbeResult(
-                name="annas-archive:download-dom",
-                ok=False,
-                detail=(
-                    "not probed: today's Anna's browser-route budget is spent. "
-                    "The health check is metered by the same counter as the "
-                    "route it checks (#144), so it yields to real downloads "
-                    "rather than competing with them."
-                ),
-                required=False,
-            )
-        if wait > 0:
-            await asyncio.sleep(wait)
-        return None
-
-    skipped = await metered()
-    if skipped is not None:
-        return skipped
-
-    url = f"{ANNAS_BASE_URL}/md5/{ANNAS_DOM_CANARY_MD5}"
-    try:
-        resp = await client.get(url)
-    except Exception as exc:  # noqa: BLE001
+    profile = browser_config.annas_browser_profile_dir
+    usage = DailyUsage(os.path.join(profile, "..", "annas-browser-usage.json"))
+    # The same lock the browser route takes. Without it the probe could issue
+    # requests while a download already had one in flight, so `npm run doctor`
+    # would break the one-request-at-a-time guarantee it exists to report on
+    # (Codex on #150). A short wait: a health check should yield to a real
+    # download rather than queue behind it for twenty-five minutes.
+    browser_lock = CrossProcessLock(os.path.join(profile, "..", "annas-browser.lock"))
+    if not await asyncio.to_thread(browser_lock.acquire, 5.0):
         return ProbeResult(
             name="annas-archive:download-dom",
             ok=False,
-            detail=f"{type(exc).__name__}: {exc}",
-            required=False,
-        )
-
-    walled = _annas_block_detail(resp)
-    body = resp.text
-    # The production classifier, not a copy of some of its markers: a partial
-    # copy reported a 200 challenge page as DOM drift, sending the maintainer
-    # to look for a layout change that is not there (Codex on #150).
-    challenged = _classify_page(body) == "challenge"
-    if walled or challenged:
-        return ProbeResult(
-            name="annas-archive:download-dom",
-            ok=False,
-            blocked=True,
             detail=(
-                "browser verification answered instead of the book page, so the "
-                "partner-link DOM shape is UNVERIFIED from this network — not "
-                "evidence that it drifted. The browser route (#143) clears this "
-                "wall with a real browser; this probe deliberately does not. "
-                + (walled or "challenge interstitial served")
+                "not probed: a browser download holds the Anna's session. The "
+                "health check yields rather than competing with real traffic."
             ),
             required=False,
         )
 
-    partner_links = AnnasBrowserSession._slow_download_paths(body, ANNAS_DOM_CANARY_MD5)
-    if partner_links:
-        # Stopping here would leave the second half of the flow unmonitored: a
-        # partner-page redesign breaks every download while this row stays
-        # green (Codex on #150). One extra request, against the first server
-        # Anna's lists, through the same extractor production uses.
+    async def walk() -> ProbeResult:
+        async def metered() -> Optional[ProbeResult]:
+            """Take a slot, or return the row explaining why the probe did not run."""
+            try:
+                allowed, _remaining, wait = usage.spend(
+                    browser_config.annas_browser_daily_limit,
+                    browser_config.annas_browser_min_interval,
+                )
+            except UsageCounterUnavailableError as exc:
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    detail=f"not probed: {exc}",
+                    required=False,
+                )
+            if not allowed:
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    detail=(
+                        "not probed: today's Anna's browser-route budget is spent. "
+                        "The health check is metered by the same counter as the "
+                        "route it checks (#144), so it yields to real downloads "
+                        "rather than competing with them."
+                    ),
+                    required=False,
+                )
+            if wait > 0:
+                await asyncio.sleep(wait)
+            return None
+
         skipped = await metered()
         if skipped is not None:
             return skipped
 
+        url = f"{ANNAS_BASE_URL}/md5/{ANNAS_DOM_CANARY_MD5}"
         try:
-            partner = await client.get(f"{ANNAS_BASE_URL}{partner_links[0]}")
+            resp = await client.get(url)
         except Exception as exc:  # noqa: BLE001
             return ProbeResult(
                 name="annas-archive:download-dom",
                 ok=False,
-                detail=(
-                    f"book page intact ({len(partner_links)} partner links) but "
-                    f"{partner_links[0]} could not be fetched: "
-                    f"{type(exc).__name__}: {exc}"
-                ),
+                detail=f"{type(exc).__name__}: {exc}",
                 required=False,
             )
 
-        partner_body = partner.text
-        partner_walled = (
-            _annas_block_detail(partner) or _classify_page(partner_body) == "challenge"
-        )
-        if partner_walled:
+        walled = _annas_block_detail(resp)
+        body = resp.text
+        # The production classifier, not a copy of some of its markers: a partial
+        # copy reported a 200 challenge page as DOM drift, sending the maintainer
+        # to look for a layout change that is not there (Codex on #150).
+        challenged = _classify_page(body) == "challenge"
+        if walled or challenged:
+            # Production penalises on a wall; a probe that does not would let the
+            # next doctor run or download hit Anna's again after only the spacing
+            # interval, and the advertised five-minute backoff would apply to the
+            # feature but not to the tool exercising it (Codex on #150).
+            usage.penalise(browser_config.annas_browser_backoff_seconds)
             return ProbeResult(
                 name="annas-archive:download-dom",
                 ok=False,
                 blocked=True,
                 detail=(
-                    f"book page intact ({len(partner_links)} partner links) but "
-                    f"the partner page answered with browser verification, so "
-                    f"payload-link extraction is UNVERIFIED from this network — "
-                    f"not evidence that it drifted"
+                    "browser verification answered instead of the book page, so the "
+                    "partner-link DOM shape is UNVERIFIED from this network — not "
+                    "evidence that it drifted. The browser route (#143) clears this "
+                    "wall with a real browser; this probe deliberately does not. "
+                    + (walled or "challenge interstitial served")
                 ),
                 required=False,
             )
 
-        annas_host = (urlsplit(ANNAS_BASE_URL).hostname or "").lower()
-        payload = AnnasBrowserSession._direct_file_url(partner_body, annas_host)
-        if not payload:
+        partner_links = AnnasBrowserSession._slow_download_paths(
+            body, ANNAS_DOM_CANARY_MD5
+        )
+        if partner_links:
+            # Stopping here would leave the second half of the flow unmonitored: a
+            # partner-page redesign breaks every download while this row stays
+            # green (Codex on #150). One extra request, against the first server
+            # Anna's lists, through the same extractor production uses.
+            skipped = await metered()
+            if skipped is not None:
+                return skipped
+
+            try:
+                partner = await client.get(f"{ANNAS_BASE_URL}{partner_links[0]}")
+            except Exception as exc:  # noqa: BLE001
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    detail=(
+                        f"book page intact ({len(partner_links)} partner links) but "
+                        f"{partner_links[0]} could not be fetched: "
+                        f"{type(exc).__name__}: {exc}"
+                    ),
+                    required=False,
+                )
+
+            partner_body = partner.text
+            partner_walled = (
+                _annas_block_detail(partner)
+                or _classify_page(partner_body) == "challenge"
+            )
+            if partner_walled:
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    blocked=True,
+                    detail=(
+                        f"book page intact ({len(partner_links)} partner links) but "
+                        f"the partner page answered with browser verification, so "
+                        f"payload-link extraction is UNVERIFIED from this network — "
+                        f"not evidence that it drifted"
+                    ),
+                    required=False,
+                )
+
+            annas_host = (urlsplit(ANNAS_BASE_URL).hostname or "").lower()
+            payload = AnnasBrowserSession._direct_file_url(partner_body, annas_host)
+            if not payload:
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    detail=(
+                        f"book page intact ({len(partner_links)} partner links) but "
+                        f"{partner_links[0]} yielded NO off-site payload link "
+                        f"(HTTP {partner.status_code}, {len(partner_body)} bytes) — "
+                        f"partner-page drift, and every browser download fails"
+                    ),
+                    required=False,
+                )
+
+            # Extraction is not the end of the flow — the browser hands the URL to
+            # httpx, and that handoff is the part this route depends on. A signed
+            # URL that starts requiring browser cookies or a referrer would still
+            # extract cleanly while every production transfer failed (Codex on
+            # #150). Four kilobytes, from the CDN rather than from Anna's, so it
+            # costs Anna's nothing and is not metered.
+            payload_host = urlsplit(payload).hostname or "?"
+            try:
+                # Streamed and stopped after the first chunk. A plain `get()`
+                # buffers the WHOLE file when a CDN ignores `Range`, so a
+                # "four-kilobyte probe" could pull a 30MB book on every doctor
+                # run (Codex on #150).
+                #
+                # With production's User-Agent, too: the shared doctor client
+                # identifies as `zlibrary-mcp-upstream-check`, so a CDN that
+                # admits the browser UA and blocks that one would have this
+                # probe report the handoff broken while
+                # `_download_url_to_file` succeeded.
+                async with client.stream(
+                    "GET",
+                    payload,
+                    headers={
+                        "Range": "bytes=0-4095",
+                        "User-Agent": DEFAULT_BROWSER_USER_AGENT,
+                    },
+                ) as response:
+                    probe_status = response.status_code
+                    sample = b""
+                    async for chunk in response.aiter_bytes(4096):
+                        sample = chunk
+                        break
+            except Exception as exc:  # noqa: BLE001
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    detail=(
+                        f"payload link extracted from {partner_links[0]} but "
+                        f"{payload_host} could not be reached: "
+                        f"{type(exc).__name__}: {exc} — the browser-to-httpx "
+                        f"handoff is what every download depends on"
+                    ),
+                    required=False,
+                )
+
+            if probe_status not in (200, 206):
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    detail=(
+                        f"payload link extracted but {payload_host} answered HTTP "
+                        f"{probe_status} to a plain ranged GET — the URL no "
+                        f"longer works outside the browser, so extraction being "
+                        f"healthy says nothing about downloads"
+                    ),
+                    required=False,
+                )
+
+            # Status alone is not the production check. `_download_url_to_file`
+            # rejects an HTML body served at HTTP 200 — a soft block, a login
+            # page, an interstitial — and verifies content md5. A probe that
+            # stopped at the status would report the handoff healthy on exactly
+            # the response production refuses (Codex on #150).
+            if _looks_like_html(sample):
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    detail=(
+                        f"payload link extracted and {payload_host} answered "
+                        f"HTTP {probe_status}, but the body is HTML rather than "
+                        f"file bytes — a soft block or interstitial, which "
+                        f"production rejects. Extraction is healthy and the "
+                        f"transfer is not"
+                    ),
+                    required=False,
+                )
+
             return ProbeResult(
                 name="annas-archive:download-dom",
-                ok=False,
+                ok=True,
                 detail=(
-                    f"book page intact ({len(partner_links)} partner links) but "
-                    f"{partner_links[0]} yielded NO off-site payload link "
-                    f"(HTTP {partner.status_code}, {len(partner_body)} bytes) — "
-                    f"partner-page drift, and every browser download fails"
+                    f"{len(partner_links)} partner-server link(s) on the canary book "
+                    f"page; {partner_links[0]} yielded a payload link on "
+                    f"{payload_host}, which served HTTP {probe_status} and "
+                    f"{len(sample)} bytes of non-HTML body to plain httpx"
                 ),
                 required=False,
             )
-
-        # Extraction is not the end of the flow — the browser hands the URL to
-        # httpx, and that handoff is the part this route depends on. A signed
-        # URL that starts requiring browser cookies or a referrer would still
-        # extract cleanly while every production transfer failed (Codex on
-        # #150). Four kilobytes, from the CDN rather than from Anna's, so it
-        # costs Anna's nothing and is not metered.
-        payload_host = urlsplit(payload).hostname or "?"
-        try:
-            probe = await client.get(payload, headers={"Range": "bytes=0-4095"})
-        except Exception as exc:  # noqa: BLE001
-            return ProbeResult(
-                name="annas-archive:download-dom",
-                ok=False,
-                detail=(
-                    f"payload link extracted from {partner_links[0]} but "
-                    f"{payload_host} could not be reached: "
-                    f"{type(exc).__name__}: {exc} — the browser-to-httpx "
-                    f"handoff is what every download depends on"
-                ),
-                required=False,
-            )
-
-        if probe.status_code not in (200, 206):
-            return ProbeResult(
-                name="annas-archive:download-dom",
-                ok=False,
-                detail=(
-                    f"payload link extracted but {payload_host} answered HTTP "
-                    f"{probe.status_code} to a plain ranged GET — the URL no "
-                    f"longer works outside the browser, so extraction being "
-                    f"healthy says nothing about downloads"
-                ),
-                required=False,
-            )
-
         return ProbeResult(
             name="annas-archive:download-dom",
-            ok=True,
+            ok=False,
             detail=(
-                f"{len(partner_links)} partner-server link(s) on the canary book "
-                f"page; {partner_links[0]} yielded a payload link on "
-                f"{payload_host}, which served HTTP {probe.status_code} "
-                f"({len(probe.content)} bytes) to plain httpx"
+                f"book page loaded (HTTP {resp.status_code}, {len(body)} bytes) with "
+                f"NO /slow_download/<md5>/<n>/<n> links — the browser download route "
+                f"extracts those, so this is DOM drift and every #143 download will "
+                f"fail while search keeps working"
             ),
             required=False,
         )
-    return ProbeResult(
-        name="annas-archive:download-dom",
-        ok=False,
-        detail=(
-            f"book page loaded (HTTP {resp.status_code}, {len(body)} bytes) with "
-            f"NO /slow_download/<md5>/<n>/<n> links — the browser download route "
-            f"extracts those, so this is DOM drift and every #143 download will "
-            f"fail while search keeps working"
-        ),
-        required=False,
-    )
+
+    try:
+        return await walk()
+    finally:
+        # Every return path above is inside `walk()`, so the lock is released
+        # once, here, whatever happens — including the several early returns
+        # that report a wall or drift.
+        browser_lock.release()
 
 
 # Headroom over the adapter's own worst case. The canary's deadline exists to

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -122,16 +122,42 @@ class ProbeResult:
         return "FAIL" if self.required else "WARN"
 
 
-def _looks_like_html(sample: bytes) -> bool:
-    """Whether a body opens like an HTML document rather than a file.
+# The openings `_download_url_to_file` treats as an HTML error page rather than
+# file bytes. `<html`/`<!doctype` alone missed a fragment beginning `<head>`,
+# `<body>`, `<script>` or a comment — all of which production rejects and a
+# narrower probe reported as a healthy transfer (Codex on #150).
+_HTML_OPENINGS = (
+    b"<!doctype",
+    b"<html",
+    b"<head",
+    b"<body",
+    b"<script",
+    b"<!--",
+    b"<?xml",
+)
 
-    The same question `_download_url_to_file` asks before accepting bytes: a
-    CDN soft block, login page or interstitial arrives with HTTP 200 and an
-    HTML body, and production refuses it. A status-only check would have
-    reported the handoff healthy on exactly that response.
+
+def _payload_rejection(sample: bytes, content_type: str) -> Optional[str]:
+    """Why production would refuse these bytes, or None if it would accept them.
+
+    Mirrors the guards in `python_bridge.py::_download_url_to_file`: an empty
+    body, an HTML content type, or an HTML-looking opening are all rejected
+    there, so a probe that accepted them would report the browser-to-httpx
+    handoff healthy on exactly the responses that fail in production.
     """
+    if not sample:
+        return "an empty body"
+    if "html" in (content_type or "").lower():
+        return f"content-type {content_type!r}"
     head = sample[:512].lstrip().lower()
-    return head.startswith(b"<!doctype html") or head.startswith(b"<html")
+    if any(head.startswith(opening) for opening in _HTML_OPENINGS):
+        return "an HTML body rather than file bytes"
+    return None
+
+
+def _looks_like_html(sample: bytes) -> bool:
+    """Kept for the tests that assert the opening set directly."""
+    return _payload_rejection(sample, "") is not None
 
 
 def _annas_block_detail(resp: httpx.Response) -> Optional[str]:
@@ -443,7 +469,11 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
         # The production classifier, not a copy of some of its markers: a partial
         # copy reported a 200 challenge page as DOM drift, sending the maintainer
         # to look for a layout change that is not there (Codex on #150).
-        challenged = _classify_page(body) == "challenge"
+        #
+        # Both of its verdicts, not just one: it also returns "exhausted" for
+        # Anna's own download-limit text on an ordinary HTTP 200, and dropping
+        # that meant throttling read as DOM drift and skipped the backoff.
+        challenged = _classify_page(body) in ("challenge", "exhausted")
         if walled or challenged:
             # Production penalises on a wall; a probe that does not would let the
             # next doctor run or download hit Anna's again after only the spacing
@@ -551,6 +581,7 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
                     },
                 ) as response:
                     probe_status = response.status_code
+                    probe_content_type = response.headers.get("content-type", "")
                     sample = b""
                     async for chunk in response.aiter_bytes(4096):
                         sample = chunk
@@ -586,15 +617,15 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
             # page, an interstitial — and verifies content md5. A probe that
             # stopped at the status would report the handoff healthy on exactly
             # the response production refuses (Codex on #150).
-            if _looks_like_html(sample):
+            rejection = _payload_rejection(sample, probe_content_type)
+            if rejection is not None:
                 return ProbeResult(
                     name="annas-archive:download-dom",
                     ok=False,
                     detail=(
                         f"payload link extracted and {payload_host} answered "
-                        f"HTTP {probe_status}, but the body is HTML rather than "
-                        f"file bytes — a soft block or interstitial, which "
-                        f"production rejects. Extraction is healthy and the "
+                        f"HTTP {probe_status}, but production would refuse the "
+                        f"response: {rejection}. Extraction is healthy and the "
                         f"transfer is not"
                     ),
                     required=False,

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -325,6 +325,58 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
         AnnasBrowserSession,
         _classify_page,
     )
+    from lib.sources.annas_usage import (  # noqa: PLC0415
+        DailyUsage,
+        UsageCounterUnavailableError,
+    )
+    from lib.sources.config import get_source_config  # noqa: PLC0415
+
+    # This probe is real traffic to Anna's free route, so it is metered by the
+    # same counter the production path uses. Uncounted health checks would let
+    # repeated `npm run doctor` runs bypass the 20-second spacing and the
+    # 30-request ceiling that are the condition of this route's scope — the
+    # politeness layer would cover the feature and not the tool that exercises
+    # it (Codex on #150).
+    browser_config = get_source_config()
+    usage = DailyUsage(
+        os.path.join(
+            browser_config.annas_browser_profile_dir, "..", "annas-browser-usage.json"
+        )
+    )
+
+    async def metered() -> Optional[ProbeResult]:
+        """Take a slot, or return the row explaining why the probe did not run."""
+        try:
+            allowed, _remaining, wait = usage.spend(
+                browser_config.annas_browser_daily_limit,
+                browser_config.annas_browser_min_interval,
+            )
+        except UsageCounterUnavailableError as exc:
+            return ProbeResult(
+                name="annas-archive:download-dom",
+                ok=False,
+                detail=f"not probed: {exc}",
+                required=False,
+            )
+        if not allowed:
+            return ProbeResult(
+                name="annas-archive:download-dom",
+                ok=False,
+                detail=(
+                    "not probed: today's Anna's browser-route budget is spent. "
+                    "The health check is metered by the same counter as the "
+                    "route it checks (#144), so it yields to real downloads "
+                    "rather than competing with them."
+                ),
+                required=False,
+            )
+        if wait > 0:
+            await asyncio.sleep(wait)
+        return None
+
+    skipped = await metered()
+    if skipped is not None:
+        return skipped
 
     url = f"{ANNAS_BASE_URL}/md5/{ANNAS_DOM_CANARY_MD5}"
     try:
@@ -364,6 +416,10 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
         # partner-page redesign breaks every download while this row stays
         # green (Codex on #150). One extra request, against the first server
         # Anna's lists, through the same extractor production uses.
+        skipped = await metered()
+        if skipped is not None:
+            return skipped
+
         try:
             partner = await client.get(f"{ANNAS_BASE_URL}{partner_links[0]}")
         except Exception as exc:  # noqa: BLE001
@@ -411,13 +467,49 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
                 required=False,
             )
 
+        # Extraction is not the end of the flow — the browser hands the URL to
+        # httpx, and that handoff is the part this route depends on. A signed
+        # URL that starts requiring browser cookies or a referrer would still
+        # extract cleanly while every production transfer failed (Codex on
+        # #150). Four kilobytes, from the CDN rather than from Anna's, so it
+        # costs Anna's nothing and is not metered.
+        payload_host = urlsplit(payload).hostname or "?"
+        try:
+            probe = await client.get(payload, headers={"Range": "bytes=0-4095"})
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                name="annas-archive:download-dom",
+                ok=False,
+                detail=(
+                    f"payload link extracted from {partner_links[0]} but "
+                    f"{payload_host} could not be reached: "
+                    f"{type(exc).__name__}: {exc} — the browser-to-httpx "
+                    f"handoff is what every download depends on"
+                ),
+                required=False,
+            )
+
+        if probe.status_code not in (200, 206):
+            return ProbeResult(
+                name="annas-archive:download-dom",
+                ok=False,
+                detail=(
+                    f"payload link extracted but {payload_host} answered HTTP "
+                    f"{probe.status_code} to a plain ranged GET — the URL no "
+                    f"longer works outside the browser, so extraction being "
+                    f"healthy says nothing about downloads"
+                ),
+                required=False,
+            )
+
         return ProbeResult(
             name="annas-archive:download-dom",
             ok=True,
             detail=(
                 f"{len(partner_links)} partner-server link(s) on the canary book "
-                f"page, and {partner_links[0]} yielded a payload link on "
-                f"{urlsplit(payload).hostname or '?'}"
+                f"page; {partner_links[0]} yielded a payload link on "
+                f"{payload_host}, which served HTTP {probe.status_code} "
+                f"({len(probe.content)} bytes) to plain httpx"
             ),
             required=False,
         )

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -38,6 +38,7 @@ from bs4 import BeautifulSoup
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "zlibrary" / "src"))
 from lib.sources.config import get_source_config  # noqa: E402
+from lib.download_validation import payload_rejection as _payload_rejection  # noqa: E402
 from lib.sources.libgen import FALLBACK_MIRRORS as LIBGEN_FALLBACK_MIRRORS  # noqa: E402
 from lib.sources.libgen import _nginx_stub as _libgen_nginx_stub  # noqa: E402
 from lib.sources.libgen import get_user_agent as libgen_user_agent  # noqa: E402
@@ -122,45 +123,19 @@ class ProbeResult:
         return "FAIL" if self.required else "WARN"
 
 
-# The openings `_download_url_to_file` treats as an HTML error page rather than
-# file bytes. `<html`/`<!doctype` alone missed a fragment beginning `<head>`,
-# `<body>`, `<script>` or a comment — all of which production rejects and a
-# narrower probe reported as a healthy transfer (Codex on #150).
-_HTML_OPENINGS = (
-    b"<!doctype",
-    b"<html",
-    b"<head",
-    b"<body",
-    b"<script",
-    b"<!--",
-    b"<?xml",
-)
-
-
-def _payload_rejection(sample: bytes, content_type: str) -> Optional[str]:
-    """Why production would refuse these bytes, or None if it would accept them.
-
-    Mirrors the guards in `python_bridge.py::_download_url_to_file`: an empty
-    body, an HTML content type, or an HTML-looking opening are all rejected
-    there, so a probe that accepted them would report the browser-to-httpx
-    handoff healthy on exactly the responses that fail in production.
-    """
-    if not sample:
-        return "an empty body"
-    if "html" in (content_type or "").lower():
-        return f"content-type {content_type!r}"
-    head = sample[:512].lstrip().lower()
-    if any(head.startswith(opening) for opening in _HTML_OPENINGS):
-        return "an HTML body rather than file bytes"
-    return None
-
-
 def _looks_like_html(sample: bytes) -> bool:
     """Kept for the tests that assert the opening set directly."""
     return _payload_rejection(sample, "") is not None
 
 
-def _annas_block_detail(resp: httpx.Response) -> Optional[str]:
+def _annas_response_outcome(resp: httpx.Response) -> Optional[str]:
+    """Apply the same settled-page precedence as the production browser route."""
+    from lib.sources.annas_browser import classify_annas_response  # noqa: PLC0415
+
+    return classify_annas_response(resp.text, resp.status_code)
+
+
+def _annas_block_detail(resp: httpx.Response, outcome: Optional[str]) -> Optional[str]:
     """A block report for Anna's, naming Anna's.
 
     `_block_detail` hardcodes the Z-Library domain and tells the operator to
@@ -168,28 +143,16 @@ def _annas_block_detail(resp: httpx.Response) -> Optional[str]:
     an irrelevant remedy for an Anna's wall — actively misleading in the exact
     anti-bot scenario this probe exists to distinguish (Codex on #150).
     """
-    from lib.sources.annas_browser import _REFUSAL_STATUSES  # noqa: PLC0415
-
-    body_is_diamwall = "diamwall" in resp.text.lower()
-    # Anna's refusal statuses, not Z-Library's wall statuses. Reusing
-    # WALLED_STATUS_CODES (307/403/513/517) missed a bare 429 or 503, so
-    # throttling fell through to the missing-link branch and was reported as
-    # DOM drift — sending a maintainer to look for a layout change while Anna's
-    # was simply saying slow down (Codex on #150). `_REFUSAL_STATUSES` is what
-    # the production route already uses for exactly this question.
-    throttled = resp.status_code in _REFUSAL_STATUSES
-    if (
-        not body_is_diamwall
-        and not throttled
-        and resp.status_code not in WALLED_STATUS_CODES
-    ):
+    if outcome not in {"challenge", "exhausted", "refusal"}:
         return None
     wall = (
         "DiamWall anti-bot wall"
-        if body_is_diamwall
+        if "diamwall" in resp.text.lower()
+        else "browser challenge"
+        if outcome == "challenge"
+        else "provider download limit"
+        if outcome == "exhausted"
         else "throttled or refused"
-        if throttled
-        else "network-level block"
     )
     host = urlsplit(ANNAS_BASE_URL).hostname or "annas-archive"
     return (
@@ -378,10 +341,7 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
     matters — that partner-server links are still on the book page in the shape
     the extractor looks for.
     """
-    from lib.sources.annas_browser import (  # noqa: PLC0415
-        AnnasBrowserSession,
-        _classify_page,
-    )
+    from lib.sources.annas_browser import AnnasBrowserSession  # noqa: PLC0415
     from lib.sources.annas_usage import (  # noqa: PLC0415
         CrossProcessLock,
         DailyUsage,
@@ -449,6 +409,36 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
                 await asyncio.sleep(wait)
             return None
 
+        def wall_result(response: httpx.Response, stage: str) -> Optional[ProbeResult]:
+            outcome = _annas_response_outcome(response)
+            if outcome == "http_error":
+                return ProbeResult(
+                    name="annas-archive:download-dom",
+                    ok=False,
+                    detail=(
+                        f"{stage} answered with HTTP error {response.status_code}. "
+                        "Production treats that as a provider failure, so the DOM "
+                        "shape is unverified rather than drifted; no browser-wall "
+                        "backoff was applied."
+                    ),
+                    required=False,
+                )
+            detail = _annas_block_detail(response, outcome)
+            if detail is None:
+                return None
+            usage.penalise(browser_config.annas_browser_backoff_seconds)
+            return ProbeResult(
+                name="annas-archive:download-dom",
+                ok=False,
+                blocked=True,
+                detail=(
+                    f"{stage} answered with a browser wall or provider limit, so "
+                    "its DOM shape is UNVERIFIED from this network — not evidence "
+                    f"that it drifted. {detail}"
+                ),
+                required=False,
+            )
+
         skipped = await metered()
         if skipped is not None:
             return skipped
@@ -464,35 +454,10 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
                 required=False,
             )
 
-        walled = _annas_block_detail(resp)
         body = resp.text
-        # The production classifier, not a copy of some of its markers: a partial
-        # copy reported a 200 challenge page as DOM drift, sending the maintainer
-        # to look for a layout change that is not there (Codex on #150).
-        #
-        # Both of its verdicts, not just one: it also returns "exhausted" for
-        # Anna's own download-limit text on an ordinary HTTP 200, and dropping
-        # that meant throttling read as DOM drift and skipped the backoff.
-        challenged = _classify_page(body) in ("challenge", "exhausted")
-        if walled or challenged:
-            # Production penalises on a wall; a probe that does not would let the
-            # next doctor run or download hit Anna's again after only the spacing
-            # interval, and the advertised five-minute backoff would apply to the
-            # feature but not to the tool exercising it (Codex on #150).
-            usage.penalise(browser_config.annas_browser_backoff_seconds)
-            return ProbeResult(
-                name="annas-archive:download-dom",
-                ok=False,
-                blocked=True,
-                detail=(
-                    "browser verification answered instead of the book page, so the "
-                    "partner-link DOM shape is UNVERIFIED from this network — not "
-                    "evidence that it drifted. The browser route (#143) clears this "
-                    "wall with a real browser; this probe deliberately does not. "
-                    + (walled or "challenge interstitial served")
-                ),
-                required=False,
-            )
+        blocked = wall_result(resp, "the book page")
+        if blocked is not None:
+            return blocked
 
         partner_links = AnnasBrowserSession._slow_download_paths(
             body, ANNAS_DOM_CANARY_MD5
@@ -521,23 +486,9 @@ async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
                 )
 
             partner_body = partner.text
-            partner_walled = (
-                _annas_block_detail(partner)
-                or _classify_page(partner_body) == "challenge"
-            )
-            if partner_walled:
-                return ProbeResult(
-                    name="annas-archive:download-dom",
-                    ok=False,
-                    blocked=True,
-                    detail=(
-                        f"book page intact ({len(partner_links)} partner links) but "
-                        f"the partner page answered with browser verification, so "
-                        f"payload-link extraction is UNVERIFIED from this network — "
-                        f"not evidence that it drifted"
-                    ),
-                    required=False,
-                )
+            blocked = wall_result(partner, "the partner page")
+            if blocked is not None:
+                return blocked
 
             annas_host = (urlsplit(ANNAS_BASE_URL).hostname or "").lower()
             payload = AnnasBrowserSession._direct_file_url(partner_body, annas_host)

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -278,6 +278,91 @@ async def probe_annas(client: httpx.AsyncClient) -> ProbeResult:
         )
 
 
+# A book that has been on Anna's for years and is not going anywhere. The probe
+# needs a page that reliably exists; a missing edition would read as DOM drift.
+ANNAS_DOM_CANARY_MD5 = "e2055de39f1c745d606301917fe66344"
+
+
+async def probe_annas_download_dom(client: httpx.AsyncClient) -> ProbeResult:
+    """Check the two DOM shapes the browser download route (#143) depends on.
+
+    `probe_annas` only exercises `/search`. Anna's could change the book page or
+    the partner-server page and every browser download would fail while the
+    doctor still reported the adapter healthy (Codex on #150) — the precise
+    reachability-vs-capability gap this script exists to close.
+
+    This probe deliberately runs over plain httpx, not the browser. It cannot
+    clear the challenge and does not try: from a walled network it reports BLOCK
+    and says outright that the shape is unverified, which is honest and
+    actionable. From a network Anna's serves, it checks the thing that actually
+    matters — that partner-server links are still on the book page in the shape
+    the extractor looks for.
+    """
+    from lib.sources.annas_browser import (  # noqa: PLC0415
+        AnnasBrowserSession,
+        visible_text,
+    )
+
+    url = f"{ANNAS_BASE_URL}/md5/{ANNAS_DOM_CANARY_MD5}"
+    try:
+        resp = await client.get(url)
+    except Exception as exc:  # noqa: BLE001
+        return ProbeResult(
+            name="annas-archive:download-dom",
+            ok=False,
+            detail=f"{type(exc).__name__}: {exc}",
+            required=False,
+        )
+
+    walled = _block_detail(resp)
+    body = resp.text
+    challenged = any(
+        marker in visible_text(body).lower()
+        for marker in (
+            "checking your browser",
+            "just a moment",
+            "verifying you are human",
+        )
+    )
+    if walled or challenged:
+        return ProbeResult(
+            name="annas-archive:download-dom",
+            ok=False,
+            blocked=True,
+            detail=(
+                "browser verification answered instead of the book page, so the "
+                "partner-link DOM shape is UNVERIFIED from this network — not "
+                "evidence that it drifted. The browser route (#143) clears this "
+                "wall with a real browser; this probe deliberately does not. "
+                + (walled or "challenge interstitial served")
+            ),
+            required=False,
+        )
+
+    partner_links = AnnasBrowserSession._slow_download_paths(body, ANNAS_DOM_CANARY_MD5)
+    if partner_links:
+        return ProbeResult(
+            name="annas-archive:download-dom",
+            ok=True,
+            detail=(
+                f"{len(partner_links)} partner-server link(s) in the expected "
+                f"shape on the canary book page (first: {partner_links[0]})"
+            ),
+            required=False,
+        )
+    return ProbeResult(
+        name="annas-archive:download-dom",
+        ok=False,
+        detail=(
+            f"book page loaded (HTTP {resp.status_code}, {len(body)} bytes) with "
+            f"NO /slow_download/<md5>/<n>/<n> links — the browser download route "
+            f"extracts those, so this is DOM drift and every #143 download will "
+            f"fail while search keeps working"
+        ),
+        required=False,
+    )
+
+
 # Headroom over the adapter's own worst case. The canary's deadline exists to
 # catch a hang the adapter failed to bound, so it must sit ABOVE every budget
 # the adapter is entitled to spend — otherwise a slow-but-legitimate failover
@@ -584,6 +669,7 @@ async def run_probes() -> list[ProbeResult]:
         zlib_results, annas, libgen, libgen_download = await asyncio.gather(
             probe_zlibrary_eapi(client),
             probe_annas(client),
+            probe_annas_download_dom(client),
             probe_libgen(client),
             probe_libgen_download(client),
         )

--- a/src/lib/python-bridge.ts
+++ b/src/lib/python-bridge.ts
@@ -34,6 +34,10 @@ const PERMANENT_CALLER_REASONS = new Set([
   'configuration_error',
   'quota_exhausted',
   'challenge_required',
+  // The provider answered correctly and the answer will not change. Retrying
+  // spends another Anna's daily slot and settle delay per attempt on a page
+  // that already told us the edition is not there (Codex on #150).
+  'not_found',
 ]);
 
 function everyFailureHasReason(details: any, predicate: (reason: unknown) => boolean): boolean {

--- a/src/lib/python-bridge.ts
+++ b/src/lib/python-bridge.ts
@@ -23,7 +23,18 @@ const UNREACHABLE_REASONS = new Set([
   'connect_error',
   'tls_error',
 ]);
-const PERMANENT_CALLER_REASONS = new Set(['configuration_error', 'quota_exhausted']);
+// Reasons where retrying cannot help, because the next attempt needs the
+// caller to change something rather than the provider to recover.
+// `challenge_required` is here for a sharper reason than the other two: a
+// browser-verification wall is cleared by a *person*, and each generic retry
+// spawns a fresh bridge process whose rate limiter has forgotten the backoff —
+// so retrying walks straight back into the wall three times, which is the
+// behaviour Anna's politeness layer exists to prevent (Codex on #150).
+const PERMANENT_CALLER_REASONS = new Set([
+  'configuration_error',
+  'quota_exhausted',
+  'challenge_required',
+]);
 
 function everyFailureHasReason(details: any, predicate: (reason: unknown) => boolean): boolean {
   if (!details || typeof details !== 'object') return false;

--- a/uv.lock
+++ b/uv.lock
@@ -806,7 +806,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -941,6 +941,92 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/67/07ecd6d85c0f253363cbc4ac9e7dd048ca571a267fbccfea084d6009ac3b/greenlet-3.5.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:816230f469381ad0a43abc9fa8dda5a699e32fb78958dde32ded93213b70a667", size = 292971, upload-time = "2026-08-10T13:28:09.837Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/426733bc24247ee17bb76df90f550c299ff5f8572b2bdd7cacb5c53fd994/greenlet-3.5.5-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5433cf291e0ef9114bd14d0d824db6e5e4a43033234bca48181a9597acca07b", size = 609290, upload-time = "2026-08-10T14:14:32.273Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/dc/17d3a5acceb2fd0bbc9682a228117b719cdfb68085e6dbb33fa325755f27/greenlet-3.5.5-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:19d59f068887d8c5907fc177f27683413ace3011b6ed646c0b309266e74a6502", size = 622650, upload-time = "2026-08-10T14:27:22.004Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3f/b31e6bd6adb8f80492efb6a47e8f9cd0e7335db5aac2795b1876d5afcfee/greenlet-3.5.5-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:86c5113d698cb8d927b2750bb1f1d59eefe3a37e0e0217491aee29a7f84ef52c", size = 629560, upload-time = "2026-08-10T14:30:04.733Z" },
+    { url = "https://files.pythonhosted.org/packages/51/91/00b3c0566316c6f383ea16ee05388ec4f57f6e0afa49e72ae471eda8c47f/greenlet-3.5.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ff00e12102358292087274dfb1669132387ff6e7920ebf9d85f4826ce0d3a56", size = 622819, upload-time = "2026-08-10T13:40:46.562Z" },
+    { url = "https://files.pythonhosted.org/packages/18/5e/58c561efde575c4ca070030e2e0513e8d1b07b76d8a2d84a9bcef1becd42/greenlet-3.5.5-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:c69bed34470abfcd456984fdadaa18e62169af4480335c45f3c32d1d9c12e638", size = 425489, upload-time = "2026-08-10T14:29:59.768Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/78/52de4f7ac9152ad1dbc8f437895c1e573d30ee1e1427e0f91a280e2417b6/greenlet-3.5.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:523bb8e27614d77101ea7a8cf59f8d91219b72d5c29f6a038c92b50828bfa8d0", size = 1582164, upload-time = "2026-08-10T14:15:02.645Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ff/c3855a00c2417e8f61c7b9f0bc4f8f599c6928f5c15681ad251e78a91e05/greenlet-3.5.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f1e2db190db51c17433eee424803818cf0670bf049d9cfe0dd07be111d1aa7c4", size = 1648807, upload-time = "2026-08-10T13:40:27.471Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/d29ff6a79dbd1ec1fe74c155d25d4c5a85e221d6b9ffc2cc7a709e7c8c39/greenlet-3.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:740e544169527b82695ce76af2f7ad6f030904658f2f3921a1d245771fb88cfc", size = 322832, upload-time = "2026-08-10T13:28:10.85Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a3/07297917485ee2ca85bc3c8dc6ed85ad3fffcf424047fba62671dba68e97/greenlet-3.5.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:be63afcbbccfad3dd95a1ba12ada84dab2ef32031973d80b5b92df67fa763a61", size = 294165, upload-time = "2026-08-10T13:25:17.987Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/6f732f9314cda54c5fd48a7620c7160f4f286967e8045ad94b9d66ce80b7/greenlet-3.5.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a268024ce2d7d2b04694bf1594058981a9fa663d1df4b762dee499211ed7c1c", size = 613610, upload-time = "2026-08-10T14:14:33.829Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c0/b27589e25d220289edcd4d582b2b17b83058d1a56d53d971b6ea1a34f10d/greenlet-3.5.5-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35cbb8bf55ace57fbccb4fb8622c4521713acd8691e77f4696d416ea7ca527da", size = 625481, upload-time = "2026-08-10T14:27:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/39/82/5c873dbb4fb001d22fbbd50e80d4c1b0181ddae106856132160f84b94e88/greenlet-3.5.5-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:abc8bc8d9f935cd685457545b6a53863a877fdc12c2c0f5ee9beee18d9db139c", size = 633329, upload-time = "2026-08-10T14:30:06.062Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2d/f2c928218ac52f26d7a2c188c171d1b7e728b23782cb3347e7b4fce1493a/greenlet-3.5.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cc6df89ec5302337adc9cf096221cbed2510fd444b0e0f1586cf0470740864", size = 624562, upload-time = "2026-08-10T13:40:48.064Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/f7df98e72a8eb4a7edfec5a08d6d1a4ab53a52c95ba0b2ea6c10b8dd9bd0/greenlet-3.5.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:3134291427bb0f3526e9d90311988caf336eb43730e95244997a4fb15f45144f", size = 428145, upload-time = "2026-08-10T14:30:01.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4a/92fc51d5d35912f4f06eec037ba347985defd0be47463a010a325634d9d2/greenlet-3.5.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d9b454c5fc48aeaa7c4337813dbf513a6870468e426438a04d922c6d0fe63db", size = 1584909, upload-time = "2026-08-10T14:15:04.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/58/ed98b80ac5738c149a5258544843c45601ade1fd70f61740cdaead6351b3/greenlet-3.5.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03551ed792cb1b4fc0277a0c60dfd8c343894a0ba06fe60dcd22f568b433da39", size = 1651184, upload-time = "2026-08-10T13:40:28.879Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/be/b582ceb80cefdf9d8da34078714e4b12b3d16f509dee0f65e40a5cc8fc7d/greenlet-3.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:ab3df3dffb58bf70564e93a5cec7941e4d9faa5a36cc4234a10d3131afe04f53", size = 323280, upload-time = "2026-08-10T13:26:07.495Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/18/5313c4c58598c38b0373c013e4ff2b3e6d258aaaa338f373335ebecdaddd/greenlet-3.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:2b70a766135540c472ac1393d57c2e1b4a2eb85bf526a1e41e6d096173a8cee5", size = 307785, upload-time = "2026-08-10T13:28:34.874Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/30/87c212b5c684d0e72974f1063b7a9687631e8985902c06e1016542c874e7/greenlet-3.5.5-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ca5d6ae0739e5764f2cfcfaa562ac5a990cbdaedca93251c5e3cf07c362371f", size = 629504, upload-time = "2026-08-10T14:30:07.967Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2c/eb487fafc9f50ffff2b1e0b697f70fb34bf150821c08ab225aacf5583a7e/greenlet-3.5.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1b5ed9162c0c098e0bbc2cf88a94f433c1b8926f831745252e099e5d83e17759", size = 432462, upload-time = "2026-08-10T14:30:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/8cef5f724ec0d4add2af8961d504535ec60c3cca9e464f6d03bdba29d85b/greenlet-3.5.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b79fd2a5bc099b5e744f34c4c9a58954a5f4cb7529fb4b6e8446057d61b6edaa", size = 294730, upload-time = "2026-08-10T13:27:51.206Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4b/8e7aa3f514273aecff30a16ab1bac09ff54cfc7e6860fdd8058c37ff2499/greenlet-3.5.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:634cf15a233a949136879dd388e25d3296e16f3f1e217d2456797b8579ebc6ed", size = 614536, upload-time = "2026-08-10T14:14:36.589Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/4e95e9dd5a8a397dc6a6345dd7f1935113d0fca4f85e89d3976da9cd988d/greenlet-3.5.5-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:499adea519f748407fc6806d20eedabac2884fd73b9f38d81236e190ba20dfef", size = 626924, upload-time = "2026-08-10T14:27:27.048Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/eaa476d6bf3816828d0d70e80dcc36bf30a058233bd889e707e693f6e860/greenlet-3.5.5-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7278591501941bb2456af102bb9cd59aab48c6cfd6e2dd68fa1290bb0c49a42", size = 632726, upload-time = "2026-08-10T14:30:09.874Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5d/398a1c71fa7a277deeb376c999979de6786f08fc2d5747a0b9d6e11738dd/greenlet-3.5.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2eabb980975cba5b93a95f6f69287d05fc05ac955bfd6a320a7c083eeb52c0b0", size = 623906, upload-time = "2026-08-10T13:40:50.501Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/0cc2849ede68579291e9c59b3ab6ec1958f98681cca5b14d8fc75bf674a4/greenlet-3.5.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:4dfc7c4470354e7b09184d1a3a985761053a2fd694ddb5b5c80242afc2c8c90b", size = 434966, upload-time = "2026-08-10T14:30:03.729Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1b/745450fc5ea9e0cb17d840d248f284db3363de736d362c7d2d883e3eadba/greenlet-3.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03115c2e0a371999bf8ae616aa8d653f96641d4705c457aebaa187276e9f7537", size = 1581430, upload-time = "2026-08-10T14:15:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/d51b296e3191bb15d3d81ec375af1909e4466c0f395d744ed475801798a9/greenlet-3.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4441153ffba21b90d3ca89fe3d31f5c093ae6c0bf0cfdfc98f54cde22f95b62e", size = 1645684, upload-time = "2026-08-10T13:40:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/12/63/369f1a1625e64e9e31df3963c6044056e3fdfa3fa3fdba3c54ffefa6e987/greenlet-3.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:95c5b1f4b3a193f8a0c2de4bfdcb48d119f7f1063941f1de1f2168051b3e52dd", size = 324075, upload-time = "2026-08-10T13:26:58.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/78/649cb5c09d4d81f6dd1444e75474a7206784743283a21d24171562ac4899/greenlet-3.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:1af90aa4bc129883b340cdd6957a3bc74f60528a4993bbd1f53aaebe1d9981cc", size = 308260, upload-time = "2026-08-10T13:27:50.795Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/52/f005d579acde46c3d1cc3cab1c9f3d5708c8a3006a4120e8cf5da801afe9/greenlet-3.5.5-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d98ef6f92e67c6dbf299dbfd8facc1b0d2d9cedf91e325e73b3d0373fe4309d8", size = 677863, upload-time = "2026-08-10T14:30:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/a75f8a2bdcef3c358a3147cdc9db3aa83755f0a038f766ab0bedb66f512c/greenlet-3.5.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:159df1942d88e8f784cbb38d6f18bdb365cd11319cfbb3e89623de2b97892d53", size = 480554, upload-time = "2026-08-10T14:30:05.171Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ac/0d7887aa4bbfc9eba075cc428244dfc96f623478454d5ec81180d0d6bd5a/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e9ec2e7c98e895fcea0c5cc57b2606cf86ece6d0a56578f3eb225e2af4f0387", size = 681587, upload-time = "2026-08-10T14:30:13.519Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/8d58ba1c429b0383e3219a3d0e0bba241d0444d8ed05b73349953c7d7c7b/greenlet-3.5.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:102817506f6090b5176c746a82603341a549b40e5c3d5b72a4c672228a918c41", size = 510175, upload-time = "2026-08-10T14:30:07.047Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
 ]
 
 [[package]]
@@ -1851,6 +1937,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2084,6 +2189,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -2921,6 +3038,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+annas-browser = [
+    { name = "playwright" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2959,6 +3079,7 @@ requires-dist = [
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
     { name = "pdf2image", marker = "extra == 'ocr'", specifier = ">=1.16.0" },
     { name = "pillow", marker = "extra == 'ocr'", specifier = ">=11.0.0" },
+    { name = "playwright", marker = "extra == 'annas-browser'", specifier = ">=1.55.0" },
     { name = "pymupdf", specifier = ">=1.26.0" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
@@ -2968,7 +3089,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "zlibrary", editable = "zlibrary" },
 ]
-provides-extras = ["ocr", "dev"]
+provides-extras = ["ocr", "annas-browser", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Implements Anna's key-free download route and its politeness layer, together. Closes #143 and #144.

Depends on #147 for the doctrine change that puts this route in scope. **#147 should land first** — otherwise this ships code the canonical contract still calls permanently out of scope.

## The shape, and why

**The browser resolves links. It does not move the file.**

The #143 spike measured that the signed URL a partner-server page hands out is fetchable *outside* the browser — HTTP 206, `bytes 0-4095/4762590`, body starting `%PDF-1.5`. That single measurement is what makes this design small: the browser's job ends at a URL, and the transfer stays on the existing httpx path in `_download_url_to_file`, which already verifies content md5, bounds throughput and stages atomically.

#143's requirements list is worth checking against that:

| #143 asks for | Where it lives |
|---|---|
| Bound **throughput**, not per-chunk gaps (a node that connects and sends zero bytes) | already in `_download_url_to_file` |
| Verify by **content md5**, never by size | already in `_download_url_to_file` |
| Resume rather than restart | already in `_download_url_to_file` |

Streaming through Playwright would have meant reimplementing all three, worse, in a module with no test coverage of them. So the requirement is met by *not* building that.

**Headful is not a setting.** #142 measured a headless launch failing while holding clearance that worked headful from the same profile minutes earlier. `headless=False` is passed unconditionally; a failed launch says why rather than degrading silently.

## #144 is in the same commit, and the same module, on purpose

The doctrine change putting this route in scope is explicitly conditional on the limits shipping *with* it rather than after. Making them separable would have made that condition a promise instead of a fact. So:

- **Every navigation goes through the limiter.** There is no path to the network that skips it.
- **One request in flight per session**, enforced by a lock. This repo has already paid for fanning lanes out against a single-session provider; that is a lock now, not a convention someone has to remember.
- **A challenge or a refusal aborts the walk and backs off.** It does not try the next partner server — they sit behind the same wall, so trying them can only spend the day's budget proving it, five minutes at a time.
- **A per-day ceiling** bounds the whole thing even if left running.

Defaults are #95's stated scale expressed as limits: 20s spacing, 30 requests/day (a book costs about two), 5-minute backoff. `test_defaults_are_slow_on_purpose` asserts they stay that way — a future change "tuning" them for test speed would quietly remove the condition the scope rests on, and that failure would be invisible.

## Four failure kinds, four types

Distinguished by type rather than message, because the right response differs for each:

| Type | Means | Right move |
|---|---|---|
| `ChallengeNotClearedError` | the wall answered | stop; operator re-solves in the visible window |
| `ProviderRateLimitedError` | Anna's own limit | stop; it applies session-wide |
| `DailyLimitReachedError` | **our** ceiling | stop; the limiter working, not a provider fault |
| `not_found` | page loaded, no wall, no link | stop; retrying is pointless |
| `BrowserUnavailableError` | playwright absent | `configuration_error` — permanent until the operator acts, so not evidence Anna's is unhealthy |

The first two were originally one, and a test caught it: the exhausted case fell through to `except Exception` and tried the next server, sleeping out a full 300-second backoff before each. The test that found it ran for five minutes.

## Opt-in, and optional

`ANNAS_BROWSER_ENABLED` defaults to false and playwright is an extra (`uv sync --extra annas-browser`). The route needs a display and a human — a server reaching for it unasked would hang on a window nobody can see — and a credential-free LibGen user must never be made to install a browser to keep the path they came for.

## Limits of the testing

Playwright is mocked, per the repo invariant that unit tests mock every third-party call. The boundary is stated in the test module rather than left implied: these 26 tests pin link selection, wall classification, rate limiting and error typing. **They say nothing about whether a real browser clears a real challenge.** #142 measured that separately, and only a live run can.

Two follow-ups I did not fold in:

- `.env.example` is not updated — the file is outside what I can edit here. The variables are documented in `README.md` and `.claude/ARCHITECTURE.md`.
- CI's `uv sync --all-extras` will now install the playwright *package* (not its browsers). Harmless — the tests mock it — but it interacts with #114's optional-dependency tiering, so whichever lands second should check the boundary tests.

**Verified**: 1316 passed, 3 skipped, 7 xfailed.