### PR TITLE
fix(sources): keyed-download errors must not chain the key-bearing request (#137)

### DIFF
--- a/__tests__/python/test_annas_adapter.py
+++ b/__tests__/python/test_annas_adapter.py
@@ -466,15 +466,33 @@ class TestAnnasArchiveFastDownload:
             ({"downloads_done_today": 2}, None),
             ({"downloads_per_day": 25, "downloads_done_today": 2}, None),
             (
-                {"downloads_left": 5, "downloads_per_day": 25, "downloads_done_today": 20},
-                QuotaInfo(downloads_left=5, downloads_per_day=25, downloads_done_today=20),
+                {
+                    "downloads_left": 5,
+                    "downloads_per_day": 25,
+                    "downloads_done_today": 20,
+                },
+                QuotaInfo(
+                    downloads_left=5, downloads_per_day=25, downloads_done_today=20
+                ),
             ),
             (
-                {"downloads_left": 0, "downloads_per_day": 25, "downloads_done_today": 25},
-                QuotaInfo(downloads_left=0, downloads_per_day=25, downloads_done_today=25),
+                {
+                    "downloads_left": 0,
+                    "downloads_per_day": 25,
+                    "downloads_done_today": 25,
+                },
+                QuotaInfo(
+                    downloads_left=0, downloads_per_day=25, downloads_done_today=25
+                ),
             ),
         ],
-        ids=["empty_dict", "partial_done_today", "partial_per_day_and_done", "full_quota_positive", "full_quota_zero"],
+        ids=[
+            "empty_dict",
+            "partial_done_today",
+            "partial_per_day_and_done",
+            "full_quota_positive",
+            "full_quota_zero",
+        ],
     )
     async def test_get_download_url_handles_empty_or_partial_quota_info(
         self, account_info, expected_quota
@@ -482,7 +500,7 @@ class TestAnnasArchiveFastDownload:
         """Empty or partial quota info with valid download_url should not default to 0."""
         from lib.sources.annas import AnnasArchiveAdapter
         from lib.sources.config import SourceConfig
-        from lib.sources.models import QuotaInfo, SourceType
+        from lib.sources.models import SourceType
 
         adapter = AnnasArchiveAdapter(
             SourceConfig(
@@ -1009,3 +1027,117 @@ class TestAnnasMetadataExtraction:
         )
 
         assert result.extra["publisher"] == "Oxford University Press, 1977"
+
+
+class TestKeyedDownloadTracebacksCannotCarryTheKey:
+    """The fast-download API takes ANNAS_SECRET_KEY as a URL query parameter.
+
+    So `httpx` exceptions raised on that request carry the key inside
+    `.request.url`, and chaining one as `__cause__` puts it into every
+    formatted traceback — logs, crash reports, an error surfaced to an MCP
+    client. The adapter's own message already says what went wrong.
+
+    Recovered from the unlanded `fix/106-envelope-followup` stack (#137); the
+    fix was written, verified, and never merged.
+    """
+
+    SECRET = "s3cr3t-key-that-must-not-appear"
+
+    def _adapter(self):
+        from lib.sources.annas import AnnasArchiveAdapter
+        from lib.sources.config import SourceConfig
+
+        return AnnasArchiveAdapter(
+            SourceConfig(
+                annas_secret_key=self.SECRET,
+                annas_base_url="https://annas-archive.org",
+                preflight_enabled=False,
+            )
+        )
+
+    @staticmethod
+    def _formatted(exc: BaseException) -> str:
+        import traceback
+
+        return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+    @pytest.mark.asyncio
+    async def test_an_http_error_does_not_chain_the_keyed_request(self, mocker):
+        import httpx
+
+        adapter = self._adapter()
+        url = f"https://annas-archive.org/dyn/api/fast_download.json?key={self.SECRET}"
+        request = httpx.Request("GET", url)
+        response = httpx.Response(403, request=request)
+
+        mocker.patch.object(
+            adapter,
+            "_fetch",
+            side_effect=httpx.HTTPStatusError(
+                "403", request=request, response=response
+            ),
+        )
+        mocker.patch.object(adapter, "_preflight", return_value=None)
+
+        with pytest.raises(Exception) as excinfo:
+            await adapter.get_download_url("a" * 32)
+
+        assert excinfo.value.__cause__ is None, (
+            "chaining the httpx error puts the key-bearing request URL into "
+            "the traceback"
+        )
+        assert self.SECRET not in self._formatted(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_an_unexpected_error_does_not_chain_it_either(self, mocker):
+        """The catch-all path is the one most likely to be forgotten."""
+        import httpx
+
+        adapter = self._adapter()
+        url = f"https://annas-archive.org/dyn/api/fast_download.json?key={self.SECRET}"
+        request = httpx.Request("GET", url)
+
+        mocker.patch.object(
+            adapter,
+            "_fetch",
+            side_effect=httpx.ConnectError("boom", request=request),
+        )
+        mocker.patch.object(adapter, "_preflight", return_value=None)
+
+        with pytest.raises(Exception) as excinfo:
+            await adapter.get_download_url("a" * 32)
+
+        assert excinfo.value.__cause__ is None
+        assert self.SECRET not in self._formatted(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_search_still_chains_its_cause(self, mocker):
+        """Search sends no key, so it keeps the diagnostic chain.
+
+        Suppressing causes everywhere would trade a real leak for a real loss
+        of debuggability. The distinction is whether the request carried the
+        secret, not whether the code path is an error path.
+        """
+        import httpx
+
+        adapter = self._adapter()
+        mocker.patch.object(adapter, "_preflight", return_value=None)
+        mocker.patch.object(
+            adapter,
+            "_fetch",
+            side_effect=httpx.ConnectError(
+                "boom",
+                request=httpx.Request(
+                    "GET", "https://annas-archive.org/search?q=anything"
+                ),
+            ),
+        )
+
+        with pytest.raises(Exception) as excinfo:
+            await adapter.search("anything")
+
+        assert excinfo.value.__cause__ is not None, (
+            "the search request carries no secret, so its cause is pure "
+            "diagnostic value and must not be suppressed along with the "
+            "download path's"
+        )

--- a/__tests__/python/test_annas_adapter.py
+++ b/__tests__/python/test_annas_adapter.py
@@ -1043,6 +1043,15 @@ class TestKeyedDownloadTracebacksCannotCarryTheKey:
 
     SECRET = "s3cr3t-key-that-must-not-appear"
 
+    # A TRUSTED host, deliberately. `annas-archive.org` is absent from
+    # ANNAS_TRUSTED_HOSTS, so the adapter refuses before `_fetch` is ever
+    # called — and these tests then passed on that early
+    # ProviderConfigurationError without reaching the raise sites they exist to
+    # guard. Verified by reverting the three `from None` changes: all three
+    # tests stayed green (Codex on #151). A security regression test that
+    # passes against the unfixed code is worse than none.
+    HOST = "annas-archive.gl"
+
     def _adapter(self):
         from lib.sources.annas import AnnasArchiveAdapter
         from lib.sources.config import SourceConfig
@@ -1050,7 +1059,7 @@ class TestKeyedDownloadTracebacksCannotCarryTheKey:
         return AnnasArchiveAdapter(
             SourceConfig(
                 annas_secret_key=self.SECRET,
-                annas_base_url="https://annas-archive.org",
+                annas_base_url="https://annas-archive.gl",
                 preflight_enabled=False,
             )
         )
@@ -1066,7 +1075,7 @@ class TestKeyedDownloadTracebacksCannotCarryTheKey:
         import httpx
 
         adapter = self._adapter()
-        url = f"https://annas-archive.org/dyn/api/fast_download.json?key={self.SECRET}"
+        url = f"https://annas-archive.gl/dyn/api/fast_download.json?key={self.SECRET}"
         request = httpx.Request("GET", url)
         response = httpx.Response(403, request=request)
 
@@ -1094,7 +1103,7 @@ class TestKeyedDownloadTracebacksCannotCarryTheKey:
         import httpx
 
         adapter = self._adapter()
-        url = f"https://annas-archive.org/dyn/api/fast_download.json?key={self.SECRET}"
+        url = f"https://annas-archive.gl/dyn/api/fast_download.json?key={self.SECRET}"
         request = httpx.Request("GET", url)
 
         mocker.patch.object(
@@ -1128,7 +1137,7 @@ class TestKeyedDownloadTracebacksCannotCarryTheKey:
             side_effect=httpx.ConnectError(
                 "boom",
                 request=httpx.Request(
-                    "GET", "https://annas-archive.org/search?q=anything"
+                    "GET", "https://annas-archive.gl/search?q=anything"
                 ),
             ),
         )

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -416,10 +416,17 @@ class AnnasArchiveAdapter(SourceAdapter):
                     self.host,
                     f"ANNAS_SECRET_KEY rejected by fast-download endpoint "
                     f"(HTTP {exc.response.status_code})",
-                ) from exc
-            raise self._as_source_error(exc) from exc
+                    # `from None`, not `from exc`, on every path out of this
+                    # method: the fast-download API takes ANNAS_SECRET_KEY as a
+                    # URL *query parameter*, and httpx exceptions carry
+                    # `.request.url`. A chained cause therefore puts the key
+                    # into any formatted traceback — logs, crash reports, an
+                    # error surfaced to an MCP client. The adapter's own
+                    # message already says what went wrong without it.
+                ) from None
+            raise self._as_source_error(exc) from None
         except Exception as exc:
-            raise self._as_source_error(exc) from exc
+            raise self._as_source_error(exc) from None
 
         if not isinstance(data, dict):
             raise ProviderResponseError(
@@ -459,7 +466,10 @@ class AnnasArchiveAdapter(SourceAdapter):
                     "account_fast_download_info must be an object",
                     reason="protocol_error",
                 )
-            if "downloads_left" in account_info and account_info["downloads_left"] is not None:
+            if (
+                "downloads_left" in account_info
+                and account_info["downloads_left"] is not None
+            ):
                 quota_info = QuotaInfo(
                     downloads_left=account_info["downloads_left"],
                     downloads_per_day=account_info.get("downloads_per_day", 0),


### PR DESCRIPTION
Anna's fast-download API takes `ANNAS_SECRET_KEY` as a URL **query parameter**:

```
https://annas-archive.org/dyn/api/fast_download.json?md5=...&key=<SECRET>&domain_index=1
```

`httpx` exceptions carry `.request.url`. So chaining one as `__cause__` puts the key into every formatted traceback that failure reaches — application logs, a crash report, an error surfaced to an MCP client. Three raise sites in `get_download_url` did that.

## The fix

`from None` on all three. The adapter's own message already says what went wrong — *"ANNAS_SECRET_KEY rejected by fast-download endpoint (HTTP 403)"* — without the request that carried it.

**`search` keeps `from exc`, deliberately.** It sends no key, so its cause is pure diagnostic value, and suppressing chains everywhere would trade a real leak for a real loss of debuggability. The line is *whether the request carried the secret*, not whether the code path is an error path. A test holds that line, so a later sweep cannot quietly extend the suppression.

## Tests assert both halves

`__cause__ is None`, **and** the sentinel key absent from `traceback.format_exception` output. The first alone would pass a version that formatted the URL into the message instead — which is the same leak through a different door.

## Provenance

This was written and verified on `fix/106-envelope-followup`, the unlanded stack #137 tracks, and never merged. I found it while assessing whether that branch's work was superseded by #131: two of its four commits are in master, two are not, and this is one of the two.

It lands on its own rather than waiting for the rest, because it is the only piece whose absence has a security consequence and it is eight lines. The remainder of that branch — response-envelope hardening — still needs the squash re-litigation #137 describes, and #137 stays open for it.

**Verified**: full fast Python suite green; three new tests covering the HTTP-error path, the catch-all path, and search's retained chain.