### PR TITLE
fix(sources): bound the whole walk with one deadline, not the mirror list (#152)

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -89,12 +89,12 @@ keep working. See `docs/api.md` for the full response shapes.
 
 | Module | Responsibility |
 |--------|---------------|
-| `base.py` | `SourceAdapter` ABC: `search()`, `get_download_url(md5)`, `close()` |
+| `base.py` | `SourceAdapter` ABC: `search()`, `get_download_url(md5)`, `close()` — each takes the walk's shared `deadline` |
 | `models.py` | `UnifiedBookResult`, `DownloadResult` (shared result shapes) |
-| `config.py` | `MAX_LIBGEN_MIRROR_ATTEMPTS`, `worst_case_search_seconds()`, and `SourceConfig` from env (`ANNAS_SECRET_KEY`, `ANNAS_BASE_URL`, `LIBGEN_MIRROR`, `LIBGEN_USER_AGENT`, `BOOK_SOURCE_DEFAULT`, `BOOK_SOURCE_FALLBACK_ENABLED`) |
+| `config.py` | `DEFAULT_WALK_BUDGET`, `worst_case_search_seconds()`, `worst_case_download_seconds()`, and `SourceConfig` from env (`ANNAS_SECRET_KEY`, `ANNAS_BASE_URL`, `LIBGEN_MIRROR`, `LIBGEN_USER_AGENT`, `BOOK_SOURCE_DEFAULT`, `BOOK_SOURCE_FALLBACK_ENABLED`) |
 | `annas.py` | Anna's Archive adapter — HTML scraping (BeautifulSoup); DOM-fragile surface |
 | `libgen.py` | LibGen adapter (fallback source) |
-| `router.py` | `SourceRouter`: Anna's primary when key configured, LibGen fallback on error/quota exhaustion; source selection `auto`/`annas`/`libgen` |
+| `router.py` | `SourceRouter`: Anna's primary when key configured, LibGen fallback on error/quota exhaustion; source selection `auto`/`annas`/`libgen`. Creates one `WalkDeadline` per walk and every provider and mirror spends it |
 
 Exposed through the `search_multi_source` tool. Z-Library itself does **not** yet
 route through `SourceRouter` — promoting it to a `SourceAdapter` is planned work.

--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -91,7 +91,7 @@ keep working. See `docs/api.md` for the full response shapes.
 |--------|---------------|
 | `base.py` | `SourceAdapter` ABC: `search()`, `get_download_url(md5)`, `close()` |
 | `models.py` | `UnifiedBookResult`, `DownloadResult` (shared result shapes) |
-| `config.py` | `SourceConfig` from env (`ANNAS_SECRET_KEY`, `ANNAS_BASE_URL`, `LIBGEN_MIRROR`, `LIBGEN_USER_AGENT`, `BOOK_SOURCE_DEFAULT`, `BOOK_SOURCE_FALLBACK_ENABLED`) |
+| `config.py` | `MAX_LIBGEN_MIRROR_ATTEMPTS`, `worst_case_search_seconds()`, and `SourceConfig` from env (`ANNAS_SECRET_KEY`, `ANNAS_BASE_URL`, `LIBGEN_MIRROR`, `LIBGEN_USER_AGENT`, `BOOK_SOURCE_DEFAULT`, `BOOK_SOURCE_FALLBACK_ENABLED`) |
 | `annas.py` | Anna's Archive adapter — HTML scraping (BeautifulSoup); DOM-fragile surface |
 | `libgen.py` | LibGen adapter (fallback source) |
 | `router.py` | `SourceRouter`: Anna's primary when key configured, LibGen fallback on error/quota exhaustion; source selection `auto`/`annas`/`libgen` |

--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -654,9 +654,9 @@ class TestLibgenSearchProbeUsesProductionAdapter:
         deadline = check_upstream.libgen_probe_timeout(
             get_source_config(), LibgenAdapter.MIN_REQUEST_INTERVAL
         )
-        # 3 mirrors x (2 x 5s preflight phases + 45s total + 2s rate limit)
+        # 3 mirrors x (5s aggregate preflight + 45s total + 2s rate limit)
         assert deadline >= 165
-        assert deadline == pytest.approx(3 * 57 + check_upstream.LIBGEN_PROBE_MARGIN)
+        assert deadline == pytest.approx(3 * 52 + check_upstream.LIBGEN_PROBE_MARGIN)
 
     def test_probe_deadline_follows_operator_tuning(self, check_upstream, monkeypatch):
         """An operator who raises the per-provider budget must not thereby make
@@ -667,7 +667,7 @@ class TestLibgenSearchProbeUsesProductionAdapter:
         monkeypatch.setenv("BOOK_SOURCE_PREFLIGHT_TIMEOUT", "20")
         deadline = check_upstream.libgen_probe_timeout(get_source_config(), 2.0)
         assert deadline == pytest.approx(
-            3 * (180 + 2 + 40) + check_upstream.LIBGEN_PROBE_MARGIN
+            3 * (180 + 2 + 20) + check_upstream.LIBGEN_PROBE_MARGIN
         )
 
     def test_probe_passes_the_computed_deadline_to_wait_for(self, check_upstream):

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -9,7 +9,9 @@ reason, and an explicitly requested source is never silently swapped.
 
 import asyncio
 import math
+import os
 import socket
+import subprocess
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -99,6 +101,68 @@ class TestConfigTimeouts:
         monkeypatch.setenv("BOOK_SOURCE_CONNECT_TIMEOUT", bad)
         config = get_source_config()
         assert config.connect_timeout == 10.0
+
+    def test_env_walk_budget_fits_the_env_resolved_node_bridge_timeout(
+        self, monkeypatch
+    ):
+        """A Python override cannot outlive the Node process that owns it.
+
+        Production mutation caught: accept ``BOOK_SOURCE_WALK_BUDGET`` without
+        comparing it to the process's resolved ``PYTHON_BRIDGE_TIMEOUT`` and
+        bridge margin.  A 300-second walk would then be SIGTERM'd by a
+        240-second Node bridge before it could return attributed failures.
+        """
+        from lib.sources.config import worst_case_search_seconds
+
+        monkeypatch.setenv("PYTHON_BRIDGE_TIMEOUT", "240000")
+        monkeypatch.setenv("BOOK_SOURCE_WALK_BUDGET", "300")
+
+        config = get_source_config()
+
+        assert worst_case_search_seconds(config) < 240.0
+
+    def test_impossibly_short_node_budget_is_rejected_before_the_bridge_starts(
+        self, monkeypatch
+    ):
+        """No positive walk can fit when Node leaves no overhead allowance."""
+        monkeypatch.setenv("PYTHON_BRIDGE_TIMEOUT", "30000")
+        monkeypatch.setenv("BOOK_SOURCE_WALK_BUDGET", "1")
+
+        with pytest.raises(ValueError, match="PYTHON_BRIDGE_TIMEOUT"):
+            get_source_config()
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param("2147483647", id="maximum-timer-delay"),
+            pytest.param("2147483648", id="above-maximum-timer-delay"),
+            pytest.param("9" * 5000, id="python-int-digit-limit"),
+            pytest.param("\ufeff300000", id="bom-prefix"),
+            pytest.param("300000\ufeff", id="bom-suffix"),
+        ],
+    )
+    def test_node_timeout_parser_matches_node_at_boundaries(self, monkeypatch, raw):
+        """Python must exactly match Node for boundary and trim inputs."""
+        from lib.sources.config import _node_bridge_timeout_seconds
+
+        monkeypatch.setenv("PYTHON_BRIDGE_TIMEOUT", raw)
+
+        node = subprocess.run(
+            [
+                "node",
+                "-e",
+                "const raw = process.env.PYTHON_BRIDGE_TIMEOUT?.trim(); "
+                "const value = raw && /^\\d+$/.test(raw) ? Number(raw) : NaN; "
+                "process.stdout.write(String(Number.isSafeInteger(value) && "
+                "value > 0 && value <= 2147483647 ? value / 1000 : 240));",
+            ],
+            check=True,
+            capture_output=True,
+            env=os.environ,
+            text=True,
+        )
+
+        assert _node_bridge_timeout_seconds() == float(node.stdout)
 
 
 class TestLibgenSearchIsBounded:
@@ -472,6 +536,74 @@ class TestPreflightTargetsTheRealEndpoint:
             }
         ]
 
+    @pytest.mark.asyncio
+    async def test_annas_preflight_is_clamped_to_the_shared_deadline(self, monkeypatch):
+        """A late Anna's probe must not start with a fresh full timeout.
+
+        Production mutation caught: call ``_preflight()`` without the shared
+        deadline, or pass ``config.preflight_timeout`` through unchanged.
+        Either leaves a late probe free to overrun the walk before the actual
+        request receives its correctly clamped budget.
+        """
+        from lib.sources.net import WalkDeadline
+
+        now = [0.0]
+        deadline = WalkDeadline(5.0, clock=lambda: now[0])
+        now[0] = 4.5
+        probe_timeouts = []
+
+        async def record_probe(*_args, timeout, **_kwargs):
+            probe_timeouts.append(timeout)
+
+        monkeypatch.setattr(annas, "probe_host", record_probe)
+        adapter = AnnasArchiveAdapter(
+            SourceConfig(preflight_enabled=True, preflight_timeout=5.0)
+        )
+
+        async def empty_search(*_args, **_kwargs):
+            return httpx.Response(200, text="<html></html>")
+
+        monkeypatch.setattr(adapter, "_fetch", empty_search)
+        try:
+            assert await adapter.search("anything", deadline=deadline) == []
+        finally:
+            await adapter.close()
+
+        assert probe_timeouts == [pytest.approx(0.5)]
+
+    @pytest.mark.asyncio
+    async def test_annas_does_not_start_preflight_after_the_shared_deadline(
+        self, monkeypatch
+    ):
+        """An expired walk names budget exhaustion instead of probing a host."""
+        from lib.sources.net import WalkDeadline
+
+        now = [0.0]
+        deadline = WalkDeadline(5.0, clock=lambda: now[0])
+        now[0] = 5.0
+        probe_calls = []
+
+        async def record_probe(*_args, **_kwargs):
+            probe_calls.append(True)
+
+        monkeypatch.setattr(annas, "probe_host", record_probe)
+        adapter = AnnasArchiveAdapter(SourceConfig(preflight_enabled=True))
+
+        async def empty_search(*_args, **_kwargs):
+            return httpx.Response(200, text="<html></html>")
+
+        monkeypatch.setattr(adapter, "_fetch", empty_search)
+        try:
+            with pytest.raises(
+                ProviderTimeoutError, match="walk ran out of time"
+            ) as excinfo:
+                await adapter.search("anything", deadline=deadline)
+        finally:
+            await adapter.close()
+
+        assert excinfo.value.reason == "walk_budget_exhausted"
+        assert probe_calls == []
+
 
 @pytest.mark.asyncio
 class TestPartialFailureIsNotAnEmptyResult:
@@ -716,6 +848,196 @@ class TestTheDocumentedTimeoutMarginIsEnforced:
 
 class TestTheWalkDeadline:
     """The primitive the whole budget now rests on."""
+
+    def test_suspension_freezes_remaining_time_until_the_consumer_returns(self):
+        """A yielded candidate's transfer is outside active resolution time.
+
+        Production mutation caught: omit the public suspension primitive, or
+        merely record a timestamp without freezing/rebasing the deadline.
+        """
+        from lib.sources.net import WalkDeadline
+
+        now = [0.0]
+        deadline = WalkDeadline(5.0, clock=lambda: now[0])
+
+        with deadline.suspended():
+            now[0] = 8.0
+            assert deadline.remaining() == 5.0
+
+        assert deadline.remaining() == 5.0
+        now[0] = 10.0
+        assert deadline.remaining() == 3.0
+
+    def test_suspension_rebases_after_an_exception_without_negative_elapsed_time(self):
+        """Cleanup cannot spend time or shorten the deadline on clock regression."""
+        from lib.sources.net import WalkDeadline
+
+        now = [0.0]
+        deadline = WalkDeadline(5.0, clock=lambda: now[0])
+
+        with pytest.raises(RuntimeError, match="consumer failed"):
+            with deadline.suspended():
+                now[0] = -2.0
+                raise RuntimeError("consumer failed")
+
+        now[0] = 0.0
+        assert deadline.remaining() == 5.0
+
+    @pytest.mark.asyncio
+    async def test_suspension_rebases_when_the_consumer_task_is_cancelled(self):
+        """Cancelling the consumer unwinds the synchronous context manager."""
+        from lib.sources.net import WalkDeadline
+
+        now = [0.0]
+        deadline = WalkDeadline(5.0, clock=lambda: now[0])
+
+        async def cancelled_consumer():
+            with deadline.suspended():
+                now[0] = 8.0
+                await asyncio.sleep(30)
+
+        task = asyncio.create_task(cancelled_consumer())
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert deadline.remaining() == 5.0
+
+    @pytest.mark.asyncio
+    async def test_libgen_search_uses_a_short_budget_when_preflight_is_disabled(
+        self,
+    ):
+        """A no-preflight search still has time for useful resolution work.
+
+        Production mutation caught: reserve two preflight phases unconditionally
+        before a LibGen search.  With preflight disabled, that rejects a
+        two-second walk before the actual bounded search is even started.
+        """
+        from lib.sources.libgen import LibgenAdapter
+
+        adapter = LibgenAdapter(
+            SourceConfig(
+                preflight_enabled=False,
+                total_timeout=2.0,
+                walk_budget=2.0,
+            )
+        )
+        expected = [MagicMock()]
+        with (
+            patch("lib.sources.libgen.LibgenSearch") as search_class,
+            patch.object(adapter, "_rate_limit", new=AsyncMock(return_value=None)),
+            patch.object(adapter, "_to_unified", return_value=expected),
+        ):
+            search_class.return_value.search_default.return_value = [object()]
+            assert await adapter.search("short budget") == expected
+
+    @pytest.mark.asyncio
+    async def test_libgen_admits_one_aggregate_preflight_and_a_resolution_slice(self):
+        """A six-second walk can afford a five-second aggregate preflight."""
+        from lib.sources.net import WalkDeadline
+
+        adapter = LibgenAdapter(
+            SourceConfig(
+                preflight_enabled=True,
+                preflight_timeout=5.0,
+                total_timeout=6.0,
+                walk_budget=6.0,
+            )
+        )
+        preflight_mirrors = []
+        expected = [MagicMock()]
+        now = [0.0]
+
+        async def record_preflight(mirror):
+            preflight_mirrors.append(mirror)
+
+        with (
+            patch.object(adapter, "_preflight", new=record_preflight),
+            patch.object(adapter, "_to_unified", return_value=expected),
+            patch("lib.sources.libgen.LibgenSearch") as search_class,
+        ):
+            search_class.return_value.search_default.return_value = [object()]
+            assert (
+                await adapter.search(
+                    "aggregate preflight",
+                    deadline=WalkDeadline(6.0, clock=lambda: now[0]),
+                )
+                == expected
+            )
+
+        assert preflight_mirrors == ["li"]
+
+    @pytest.mark.asyncio
+    async def test_libgen_candidate_resolution_uses_a_short_budget_without_preflight(
+        self,
+    ):
+        """The download candidate walk shares the no-preflight contract.
+
+        Production mutation caught: retain the unconditional two-preflight
+        reservation in ``iter_download_candidates`` after fixing only search.
+        """
+        from lib.sources.libgen import LibgenAdapter
+
+        adapter = LibgenAdapter(
+            SourceConfig(
+                preflight_enabled=False,
+                total_timeout=2.0,
+                walk_budget=2.0,
+            )
+        )
+        with (
+            patch.object(adapter, "_rate_limit", new=AsyncMock(return_value=None)),
+            patch.object(
+                adapter, "_resolve_key", new=AsyncMock(return_value=("KEY", ""))
+            ),
+            patch.object(
+                adapter, "_serves_bytes", new=AsyncMock(return_value=(True, ""))
+            ),
+        ):
+            candidates = adapter.iter_download_candidates("a" * 32)
+            first = await anext(candidates)
+            await candidates.aclose()
+
+        assert first.url.startswith("https://libgen.li/get.php?")
+
+    @pytest.mark.asyncio
+    async def test_late_mirror_does_not_sleep_past_its_resolution_budget(
+        self, monkeypatch
+    ):
+        """Pacing is refused before it spends the last useful resolution slice."""
+        from lib.sources.libgen import LibgenAdapter
+        from lib.sources.net import WalkDeadline
+
+        now = [0.0]
+        wall_clock = [100.0]
+        adapter = LibgenAdapter(
+            SourceConfig(
+                preflight_enabled=False,
+                total_timeout=2.0,
+                walk_budget=2.0,
+            )
+        )
+        adapter._last_request = 99.5
+        sleep_calls = []
+
+        async def advance_clock(delay):
+            sleep_calls.append(delay)
+            now[0] += delay
+            wall_clock[0] += delay
+
+        monkeypatch.setattr("lib.sources.libgen.time.time", lambda: wall_clock[0])
+        monkeypatch.setattr("lib.sources.libgen.asyncio.sleep", advance_clock)
+
+        with pytest.raises(AllSourcesFailedError) as excinfo:
+            await adapter.search(
+                "late mirror", deadline=WalkDeadline(2.0, clock=lambda: now[0])
+            )
+
+        assert sleep_calls == []
+        assert [failure.reason for failure in excinfo.value.failures] == [
+            "walk_budget_exhausted"
+        ]
 
     def test_an_attempt_is_clamped_to_what_the_walk_has_left(self):
         from lib.sources.net import WalkDeadline

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -510,3 +510,75 @@ class TestPartialFailureIsNotAnEmptyResult:
             setattr(router, name, adapter)
 
         assert await router.search("nothing matches", source="auto") == []
+
+
+class TestTheDocumentedTimeoutMarginIsEnforced:
+    """The composition in `config.py` must be checked, not asserted (#152).
+
+    That comment claimed `4 x 55s = 220s` against a 240-second
+    `PYTHON_BRIDGE_TIMEOUT`. It was wrong for months: `_mirror_candidates()`
+    prepends the configured mirror, so any `LIBGEN_MIRROR` outside the fallback
+    set produced four LibGen attempts and a 275-second worst case. Node then
+    killed the subprocess and the operator saw a generic bridge timeout instead
+    of the attributed per-mirror failures the error taxonomy exists to produce.
+
+    A comment cannot fail. These tests can.
+    """
+
+    # Kept in step with src/lib/python-runner.ts::DEFAULT_BRIDGE_TIMEOUT_MS.
+    NODE_BRIDGE_TIMEOUT_SECONDS = 240.0
+
+    def test_the_documented_margin_still_holds(self):
+        from lib.sources.config import SourceConfig, worst_case_search_seconds
+
+        worst = worst_case_search_seconds(SourceConfig())
+
+        assert worst < self.NODE_BRIDGE_TIMEOUT_SECONDS, (
+            f"an auto search can take {worst}s against a "
+            f"{self.NODE_BRIDGE_TIMEOUT_SECONDS}s bridge budget — Node will "
+            f"kill a legitimate walk. Raise PYTHON_BRIDGE_TIMEOUT and this "
+            f"constant together, or lower a provider budget."
+        )
+
+    def test_the_mirror_walk_is_capped_whatever_the_configured_mirror(self):
+        """The cap is what keeps the worst case independent of configuration."""
+        from lib.sources.config import (
+            MAX_LIBGEN_MIRROR_ATTEMPTS,
+            SourceConfig,
+        )
+        from lib.sources.libgen import LibgenAdapter
+
+        for mirror in ("li", "vg", "la", "rs", "is", "unknown-mirror"):
+            candidates = LibgenAdapter(
+                SourceConfig(libgen_mirror=mirror)
+            )._mirror_candidates()
+
+            assert len(candidates) <= MAX_LIBGEN_MIRROR_ATTEMPTS, (
+                f"{mirror!r} yields {len(candidates)} attempts; the timeout "
+                f"arithmetic assumes at most {MAX_LIBGEN_MIRROR_ATTEMPTS}"
+            )
+
+    def test_the_configured_mirror_is_never_the_one_dropped(self):
+        """The cap must cost a fallback, not the operator's own choice."""
+        from lib.sources.config import SourceConfig
+        from lib.sources.libgen import LibgenAdapter
+
+        for mirror in ("rs", "is", "unknown-mirror"):
+            candidates = LibgenAdapter(
+                SourceConfig(libgen_mirror=mirror)
+            )._mirror_candidates()
+
+            assert candidates[0] == mirror, (
+                f"{mirror!r} must be attempted first; capping the walk cannot "
+                f"mean ignoring what the operator configured"
+            )
+
+    def test_a_raised_provider_budget_fails_here_rather_than_in_production(self):
+        """The guard has to actually bind, or it is another dead comment."""
+        from lib.sources.config import SourceConfig, worst_case_search_seconds
+
+        generous = SourceConfig(total_timeout=90.0, preflight_timeout=15.0)
+
+        assert worst_case_search_seconds(generous) > self.NODE_BRIDGE_TIMEOUT_SECONDS, (
+            "the computation must be sensitive to the budgets it composes"
+        )

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -522,6 +522,14 @@ class TestTheDocumentedTimeoutMarginIsEnforced:
     killed the subprocess and the operator saw a generic bridge timeout instead
     of the attributed per-mirror failures the error taxonomy exists to produce.
 
+    The first fix capped the mirror list, which made the sum constant by
+    deleting `la` from the download walk — where the budget is generous and
+    byte-driven `li -> vg -> la` failover is a stated repo contract (Codex on
+    #153). The walk is now bounded by a shared `WalkDeadline` instead, so the
+    worst case is one configurable number and NOT a function of how many
+    mirrors or providers exist. Several of these tests assert that
+    independence directly, because it is the property that was missing.
+
     A comment cannot fail. These tests can.
     """
 
@@ -565,26 +573,30 @@ class TestTheDocumentedTimeoutMarginIsEnforced:
             f"constant together, or lower a provider budget."
         )
 
-    def test_the_mirror_walk_is_capped_whatever_the_configured_mirror(self):
-        """The cap is what keeps the worst case independent of configuration."""
-        from lib.sources.config import (
-            MAX_LIBGEN_MIRROR_ATTEMPTS,
-            SourceConfig,
-        )
-        from lib.sources.libgen import LibgenAdapter
+    def test_every_configured_fallback_survives_a_custom_mirror(self):
+        """Capping the list is the fix this one rejects (Codex on #153).
 
-        for mirror in ("li", "vg", "la", "rs", "is", "unknown-mirror"):
+        With `LIBGEN_MIRROR=rs` a three-attempt cap truncated `[rs, li, vg, la]`
+        to `[rs, li, vg]` — and `_mirror_candidates()` is shared by search AND
+        download, so `la` stopped being reachable on the long-budget download
+        walk even when it was the only mirror serving bytes.
+        """
+        from lib.sources.config import SourceConfig
+        from lib.sources.libgen import FALLBACK_MIRRORS, LibgenAdapter
+
+        for mirror in ("rs", "is", "unknown-mirror"):
             candidates = LibgenAdapter(
                 SourceConfig(libgen_mirror=mirror)
             )._mirror_candidates()
 
-            assert len(candidates) <= MAX_LIBGEN_MIRROR_ATTEMPTS, (
-                f"{mirror!r} yields {len(candidates)} attempts; the timeout "
-                f"arithmetic assumes at most {MAX_LIBGEN_MIRROR_ATTEMPTS}"
-            )
+            for fallback in FALLBACK_MIRRORS:
+                assert fallback in candidates, (
+                    f"{fallback!r} is unreachable with LIBGEN_MIRROR={mirror!r}; "
+                    f"the walk is bounded by the clock, not by dropping mirrors"
+                )
 
-    def test_the_configured_mirror_is_never_the_one_dropped(self):
-        """The cap must cost a fallback, not the operator's own choice."""
+    def test_the_configured_mirror_is_tried_first(self):
+        """A walk that runs out of clock must have spent it on the right mirror."""
         from lib.sources.config import SourceConfig
         from lib.sources.libgen import LibgenAdapter
 
@@ -594,15 +606,16 @@ class TestTheDocumentedTimeoutMarginIsEnforced:
             )._mirror_candidates()
 
             assert candidates[0] == mirror, (
-                f"{mirror!r} must be attempted first; capping the walk cannot "
-                f"mean ignoring what the operator configured"
+                f"{mirror!r} must be attempted first: the deadline can end a "
+                f"walk early, so the operator's own choice has to be the one "
+                f"that already had its turn"
             )
 
     def test_a_raised_provider_budget_fails_here_rather_than_in_production(self):
         """The guard has to actually bind, or it is another dead comment."""
         from lib.sources.config import SourceConfig, worst_case_search_seconds
 
-        generous = SourceConfig(total_timeout=90.0, preflight_timeout=15.0)
+        generous = SourceConfig(walk_budget=300.0)
 
         assert (
             worst_case_search_seconds(generous) > self._node_bridge_timeout_seconds()
@@ -622,17 +635,163 @@ class TestTheDocumentedTimeoutMarginIsEnforced:
             "is the whole point of reading it"
         )
 
-    def test_the_provider_count_is_derived_from_the_router(self):
-        """Adding a provider to `auto` must move the budget."""
-        from lib.sources.config import SourceConfig, _auto_search_provider_count
+    def test_the_worst_case_does_not_move_with_the_mirror_count(self):
+        """The property the old arithmetic lacked, asserted directly.
+
+        A custom `LIBGEN_MIRROR` genuinely adds a fourth mirror — that part was
+        never in dispute, and this test confirms it still does. What must NOT
+        move is the walk's worst case, because the mirrors share one clock
+        rather than each bringing their own budget.
+        """
+        from lib.sources.config import SourceConfig, worst_case_search_seconds
+        from lib.sources.libgen import LibgenAdapter
+
+        default = SourceConfig()
+        custom = SourceConfig(libgen_mirror="rs")
+
+        assert len(LibgenAdapter(custom)._mirror_candidates()) == (
+            len(LibgenAdapter(default)._mirror_candidates()) + 1
+        ), "the premise of #152 no longer holds; this test is testing nothing"
+
+        assert worst_case_search_seconds(custom) == worst_case_search_seconds(
+            default
+        ), (
+            "an extra mirror moved the worst case — the walk is being costed "
+            "per attempt again instead of against one shared deadline"
+        )
+
+    def test_the_worst_case_does_not_move_with_the_provider_count(self):
+        """Z-Library joining the `auto` walk under #40 must not break this."""
+        from lib.sources.config import SourceConfig, worst_case_search_seconds
         from lib.sources.router import SourceRouter
 
-        router = SourceRouter.__new__(SourceRouter)
-        router.config = SourceConfig(fallback_enabled=True)
+        one = SourceConfig(fallback_enabled=False)
+        many = SourceConfig(fallback_enabled=True)
 
-        assert _auto_search_provider_count() == len(
-            router._search_candidates("auto")
-        ), (
-            "a literal would keep reporting 220s after Z-Library joins the "
-            "auto walk, while the real worst case became 275s"
+        router = SourceRouter.__new__(SourceRouter)
+        router.config = many
+        assert len(router._search_candidates("auto")) > 1, (
+            "fallback is not actually adding a provider; nothing is being tested"
+        )
+
+        assert worst_case_search_seconds(one) == worst_case_search_seconds(many)
+
+    @staticmethod
+    def _node_long_timeout_seconds() -> float:
+        """The other Node budget, read rather than copied, for the same reason."""
+        import re
+        from pathlib import Path
+
+        source = (
+            Path(__file__).parent.parent.parent / "src" / "lib" / "python-runner.ts"
+        ).read_text()
+        match = re.search(
+            r"LONG_BRIDGE_TIMEOUT_MS\s*=\s*positiveIntEnv\("
+            r"\s*'PYTHON_BRIDGE_LONG_TIMEOUT'\s*,\s*(\d+)\s*\)",
+            source,
+        )
+        assert match, (
+            "could not read LONG_BRIDGE_TIMEOUT_MS from python-runner.ts — "
+            "the download guard cannot verify anything without it"
+        )
+        return int(match.group(1)) / 1000.0
+
+    def test_the_download_allocation_fits_the_long_budget(self):
+        """Resolution + transfer + OCR + finalization, computed not asserted.
+
+        This allocation lived only in a comment beside DEFAULT_DOWNLOAD_TIMEOUT,
+        which is exactly the shape of the sentence that made #152: correct when
+        written, never recomputed. The download walk shares the search walk's
+        budget, so raising `BOOK_SOURCE_WALK_BUDGET` has to fit BOTH ceilings.
+        """
+        from lib.sources.config import SourceConfig, worst_case_download_seconds
+
+        worst = worst_case_download_seconds(SourceConfig())
+
+        assert worst <= self._node_long_timeout_seconds(), (
+            f"an acquisition can take {worst}s against a "
+            f"{self._node_long_timeout_seconds()}s long-bridge budget"
+        )
+
+
+class TestTheWalkDeadline:
+    """The primitive the whole budget now rests on."""
+
+    def test_an_attempt_is_clamped_to_what_the_walk_has_left(self):
+        from lib.sources.net import WalkDeadline
+
+        now = [0.0]
+        deadline = WalkDeadline(165.0, clock=lambda: now[0])
+
+        assert deadline.reserve(45.0, minimum=11.0) == 45.0
+
+        now[0] = 140.0  # 25s left: less than a full attempt
+        assert deadline.reserve(45.0, minimum=11.0) == 25.0, (
+            "a late attempt started with a full 45s budget is how a walk "
+            "overruns the bridge timeout it was supposed to fit inside"
+        )
+
+        now[0] = 160.0  # 5s left: enough to time out, not enough to inform
+        assert deadline.reserve(45.0, minimum=11.0) is None
+        assert not deadline.expired(), (
+            "refusing a useless slice is not the same as having no time left; "
+            "conflating them would report the wrong reason to the caller"
+        )
+
+        now[0] = 170.0
+        assert deadline.expired()
+        assert deadline.remaining() == 0.0, "remaining() must never go negative"
+
+    @pytest.mark.asyncio
+    async def test_a_spent_walk_names_the_mirrors_it_never_attempted(self):
+        """The reason code has to distinguish this from a slow host.
+
+        Attributing an exhausted walk to the next mirror would report a healthy
+        server as slow, and send the operator to fix the wrong thing: this one
+        is fixed by raising BOOK_SOURCE_WALK_BUDGET.
+        """
+        from lib.sources.config import SourceConfig
+        from lib.sources.errors import AllSourcesFailedError
+        from lib.sources.libgen import LibgenAdapter
+        from lib.sources.net import WalkDeadline
+
+        adapter = LibgenAdapter(SourceConfig(libgen_mirror="rs"))
+
+        with pytest.raises(AllSourcesFailedError) as excinfo:
+            await adapter.search("anything", deadline=WalkDeadline(0.0))
+
+        failures = excinfo.value.failures
+        assert [f.reason for f in failures] == ["walk_budget_exhausted"]
+        for mirror in ("rs", "li", "vg", "la"):
+            assert mirror in failures[0].detail, (
+                f"{mirror!r} was skipped without being named; a silently "
+                f"absent mirror is indistinguishable from one that answered"
+            )
+
+    @pytest.mark.asyncio
+    async def test_the_router_gives_every_provider_the_same_clock(self):
+        """One walk, one deadline — not one per provider."""
+        from unittest.mock import AsyncMock
+
+        from lib.sources.config import SourceConfig
+        from lib.sources.router import SourceRouter
+
+        seen = []
+
+        async def record(query, deadline=None, **kwargs):
+            seen.append(deadline)
+            return []
+
+        router = SourceRouter(SourceConfig(fallback_enabled=True))
+        for name in ("_annas", "_libgen"):
+            adapter = AsyncMock()
+            adapter.search = record
+            setattr(router, name, adapter)
+
+        await router.search("nothing matches", source="auto")
+
+        assert len(seen) == 2, "both providers should have been attempted"
+        assert seen[0] is not None and seen[0] is seen[1], (
+            "each provider got its own deadline, so the walk costs the sum of "
+            "them again — which is the bug (#152)"
         )

--- a/__tests__/python/test_multi_source_timeouts.py
+++ b/__tests__/python/test_multi_source_timeouts.py
@@ -525,17 +525,42 @@ class TestTheDocumentedTimeoutMarginIsEnforced:
     A comment cannot fail. These tests can.
     """
 
-    # Kept in step with src/lib/python-runner.ts::DEFAULT_BRIDGE_TIMEOUT_MS.
-    NODE_BRIDGE_TIMEOUT_SECONDS = 240.0
+    @staticmethod
+    def _node_bridge_timeout_seconds() -> float:
+        """Read the real Node budget out of the TypeScript source.
+
+        A literal copied here would be independently maintained, so lowering
+        `DEFAULT_BRIDGE_TIMEOUT_MS` would leave this test green while the walk
+        it approves gets killed — the guard reproducing the exact cross-language
+        drift it exists to prevent (Codex on #153). Parsed rather than copied,
+        and the parse failing is itself a failure: an unreadable budget means
+        the guard is not guarding.
+        """
+        import re
+        from pathlib import Path
+
+        source = (
+            Path(__file__).parent.parent.parent / "src" / "lib" / "python-runner.ts"
+        ).read_text()
+        match = re.search(
+            r"DEFAULT_BRIDGE_TIMEOUT_MS\s*=\s*positiveIntEnv\("
+            r"\s*'PYTHON_BRIDGE_TIMEOUT'\s*,\s*(\d+)\s*\)",
+            source,
+        )
+        assert match, (
+            "could not read DEFAULT_BRIDGE_TIMEOUT_MS from python-runner.ts — "
+            "the timeout guard cannot verify anything without it"
+        )
+        return int(match.group(1)) / 1000.0
 
     def test_the_documented_margin_still_holds(self):
         from lib.sources.config import SourceConfig, worst_case_search_seconds
 
         worst = worst_case_search_seconds(SourceConfig())
 
-        assert worst < self.NODE_BRIDGE_TIMEOUT_SECONDS, (
+        assert worst < self._node_bridge_timeout_seconds(), (
             f"an auto search can take {worst}s against a "
-            f"{self.NODE_BRIDGE_TIMEOUT_SECONDS}s bridge budget — Node will "
+            f"{self._node_bridge_timeout_seconds()}s bridge budget — Node will "
             f"kill a legitimate walk. Raise PYTHON_BRIDGE_TIMEOUT and this "
             f"constant together, or lower a provider budget."
         )
@@ -579,6 +604,35 @@ class TestTheDocumentedTimeoutMarginIsEnforced:
 
         generous = SourceConfig(total_timeout=90.0, preflight_timeout=15.0)
 
-        assert worst_case_search_seconds(generous) > self.NODE_BRIDGE_TIMEOUT_SECONDS, (
-            "the computation must be sensitive to the budgets it composes"
+        assert (
+            worst_case_search_seconds(generous) > self._node_bridge_timeout_seconds()
+        ), "the computation must be sensitive to the budgets it composes"
+
+    def test_the_node_budget_is_read_from_the_typescript_source(self):
+        """The guard must not carry its own copy of the number it checks.
+
+        A literal `240.0` here is independently maintained, so lowering
+        `DEFAULT_BRIDGE_TIMEOUT_MS` would leave this green while the walk it
+        approves gets killed — the guard reproducing the exact cross-language
+        drift it exists to prevent (Codex on #153).
+        """
+        assert self._node_bridge_timeout_seconds() == 240.0, (
+            "reading python-runner.ts should currently yield 240s; if that "
+            "default changed, this test and the margin move together, which "
+            "is the whole point of reading it"
+        )
+
+    def test_the_provider_count_is_derived_from_the_router(self):
+        """Adding a provider to `auto` must move the budget."""
+        from lib.sources.config import SourceConfig, _auto_search_provider_count
+        from lib.sources.router import SourceRouter
+
+        router = SourceRouter.__new__(SourceRouter)
+        router.config = SourceConfig(fallback_enabled=True)
+
+        assert _auto_search_provider_count() == len(
+            router._search_candidates("auto")
+        ), (
+            "a literal would keep reporting 220s after Z-Library joins the "
+            "auto walk, while the real worst case became 275s"
         )

--- a/__tests__/python/test_source_base.py
+++ b/__tests__/python/test_source_base.py
@@ -40,7 +40,7 @@ class TestSourceAdapterABC:
             async def search(self, query, **kwargs):
                 return []
 
-            async def get_download_url(self, md5):
+            async def get_download_url(self, md5, **kwargs):
                 return DownloadResult(
                     url="http://example.com", source=SourceType.LIBGEN
                 )
@@ -63,7 +63,7 @@ class TestSourceAdapterABC:
                     )
                 ]
 
-            async def get_download_url(self, md5):
+            async def get_download_url(self, md5, **kwargs):
                 return DownloadResult(
                     url="http://example.com", source=SourceType.LIBGEN
                 )
@@ -88,7 +88,7 @@ class TestSourceAdapterABC:
                     )
                 ]
 
-            async def get_download_url(self, md5):
+            async def get_download_url(self, md5, **kwargs):
                 return DownloadResult(
                     url=f"http://dl.example.com/{md5}",
                     source=SourceType.ANNAS_ARCHIVE,
@@ -117,7 +117,7 @@ class TestSourceAdapterABC:
             async def search(self, query, **kwargs):
                 return []
 
-            async def get_download_url(self, md5):
+            async def get_download_url(self, md5, **kwargs):
                 return DownloadResult(url="", source=SourceType.LIBGEN)
 
             async def close(self):

--- a/__tests__/python/test_source_net.py
+++ b/__tests__/python/test_source_net.py
@@ -238,6 +238,39 @@ class TestProbeHost:
         assert excinfo.value.reason != "dns_failure", "must not blur into DNS failure"
 
     @pytest.mark.asyncio
+    async def test_probe_uses_one_deadline_for_slow_dns_and_tcp(self, monkeypatch):
+        """DNS cannot spend the whole preflight budget and restart TCP's."""
+        address = ("192.0.2.1", 443)
+
+        async def slow_dns(*_args, **_kwargs):
+            await asyncio.sleep(0.06)
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", address)]
+
+        async def slow_connect(_loop, sock, _target):
+            await asyncio.sleep(0.06)
+            return object(), _Writer(sock)
+
+        class _Writer:
+            def __init__(self, sock):
+                self.sock = sock
+
+            def close(self):
+                self.sock.close()
+
+            async def wait_closed(self):
+                return None
+
+        monkeypatch.setattr(net, "run_bounded", slow_dns)
+        monkeypatch.setattr(net, "_open_resolved_connection", slow_connect)
+
+        with pytest.raises(ProviderUnreachableError) as excinfo:
+            await net.probe_host(
+                "annas", "slow-probe.example", timeout=0.1, use_cache=False
+            )
+
+        assert excinfo.value.reason == "connect_timeout"
+
+    @pytest.mark.asyncio
     async def test_tcp_probe_reuses_the_daemon_resolved_address(self, monkeypatch):
         """The TCP phase must not ask open_connection to resolve the host again."""
         address = ("192.0.2.25", 443)

--- a/__tests__/python/test_source_router.py
+++ b/__tests__/python/test_source_router.py
@@ -293,6 +293,91 @@ class TestRouterDownload:
         ]
 
     @pytest.mark.asyncio
+    async def test_candidate_transfer_time_does_not_consume_next_provider_budget(
+        self, config_with_annas, monkeypatch
+    ):
+        """A failed transfer happens outside the resolution walk's active time.
+
+        Production mutation caught: omit the pause/rebase around ``yield`` in
+        ``SourceRouter.iter_download_candidates``.  Then a consumer's slow
+        failed transfer expires the shared deadline before the next provider
+        can resolve its candidate.
+        """
+        from lib.sources import router as router_module
+        from lib.sources.net import WalkDeadline as RealWalkDeadline
+
+        now = [0.0]
+        monkeypatch.setattr(
+            router_module,
+            "WalkDeadline",
+            lambda budget: RealWalkDeadline(budget, clock=lambda: now[0]),
+        )
+        router = SourceRouter(
+            SourceConfig(
+                annas_secret_key="test-key", fallback_enabled=True, walk_budget=2
+            )
+        )
+
+        async def annas_candidates(_md5, **_kwargs):
+            yield DownloadResult(
+                url="https://annas.example/book", source=SourceType.ANNAS_ARCHIVE
+            )
+
+        async def libgen_candidates(_md5, deadline, **_kwargs):
+            # This models a real resolver: it refuses to start after the
+            # shared resolution budget has expired.
+            if deadline.reserve(1.0, minimum=1.0) is not None:
+                yield DownloadResult(
+                    url="https://libgen.li/book", source=SourceType.LIBGEN
+                )
+
+        router._annas = AsyncMock()
+        router._annas.iter_download_candidates = annas_candidates
+        router._libgen = AsyncMock()
+        router._libgen.iter_download_candidates = libgen_candidates
+
+        stream = router.iter_download_candidates("abc", source="auto")
+        assert (await anext(stream)).url == "https://annas.example/book"
+
+        # A downstream transfer can be arbitrarily slow; it should not age the
+        # deadline governing *future URL resolution*.
+        now[0] = 10.0
+
+        assert (await anext(stream)).url == "https://libgen.li/book"
+        await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_closing_after_a_candidate_rebases_the_shared_deadline(
+        self, monkeypatch
+    ):
+        """Generator close must leave the deadline usable for later resolution."""
+        from lib.sources import router as router_module
+        from lib.sources.net import WalkDeadline as RealWalkDeadline
+
+        now = [0.0]
+        monkeypatch.setattr(
+            router_module,
+            "WalkDeadline",
+            lambda budget: RealWalkDeadline(budget, clock=lambda: now[0]),
+        )
+        router = SourceRouter(SourceConfig(walk_budget=2.0))
+        seen_deadlines = []
+
+        async def libgen_candidates(_md5, deadline, **_kwargs):
+            seen_deadlines.append(deadline)
+            yield DownloadResult(url="https://libgen.li/book", source=SourceType.LIBGEN)
+
+        router._libgen = AsyncMock()
+        router._libgen.iter_download_candidates = libgen_candidates
+
+        stream = router.iter_download_candidates("abc", source="libgen")
+        assert (await anext(stream)).url == "https://libgen.li/book"
+        now[0] = 10.0
+        await stream.aclose()
+
+        assert seen_deadlines[0].reserve(1.0, minimum=1.0) == 1.0
+
+    @pytest.mark.asyncio
     async def test_closing_router_stream_closes_suspended_provider_stream(
         self, config_with_annas
     ):

--- a/__tests__/python/test_source_router.py
+++ b/__tests__/python/test_source_router.py
@@ -246,7 +246,7 @@ class TestRouterDownload:
             async def search(self, query, **kwargs):
                 return []
 
-            async def get_download_url(self, md5):
+            async def get_download_url(self, md5, **kwargs):
                 return DownloadResult(
                     url=f"https://single.example/{md5}", source=SourceType.LIBGEN
                 )
@@ -267,12 +267,12 @@ class TestRouterDownload:
         """Stopping after the first provider candidate would hide later mirrors."""
         router = SourceRouter(config_with_annas)
 
-        async def annas_candidates(_md5):
+        async def annas_candidates(_md5, **kwargs):
             yield DownloadResult(
                 url="https://annas.example/book", source=SourceType.ANNAS_ARCHIVE
             )
 
-        async def libgen_candidates(_md5):
+        async def libgen_candidates(_md5, **kwargs):
             yield DownloadResult(url="https://libgen.li/book", source=SourceType.LIBGEN)
             yield DownloadResult(url="https://libgen.vg/book", source=SourceType.LIBGEN)
 
@@ -301,7 +301,7 @@ class TestRouterDownload:
         closed = False
 
         class ResourceAdapter:
-            async def iter_download_candidates(self, _md5):
+            async def iter_download_candidates(self, _md5, **kwargs):
                 nonlocal closed
                 try:
                     yield DownloadResult(
@@ -333,12 +333,12 @@ class TestRouterDownload:
         """An explicit source selection must never invoke the other adapter."""
         router = SourceRouter(config_with_annas)
 
-        async def annas_candidates(_md5):
+        async def annas_candidates(_md5, **kwargs):
             yield DownloadResult(
                 url="https://annas.example/book", source=SourceType.ANNAS_ARCHIVE
             )
 
-        async def libgen_candidates(_md5):
+        async def libgen_candidates(_md5, **kwargs):
             yield DownloadResult(
                 url="https://libgen.example/book", source=SourceType.LIBGEN
             )

--- a/docs/RETRY_CONFIGURATION.md
+++ b/docs/RETRY_CONFIGURATION.md
@@ -56,28 +56,48 @@ Preflight is skipped when `HTTP_PROXY` or `HTTPS_PROXY` covers the target, with
 letting that probe veto the real client would create a false outage.
 
 The preflight budget applies to two phases (DNS, then TCP). At the defaults, one
-provider attempt can cost at most `2 × 5s + 45s = 55s`. LibGen walks **at most
-three** mirrors — capped by `MAX_LIBGEN_MIRROR_ATTEMPTS`, so the number does not
-change when an operator sets `LIBGEN_MIRROR` — and `auto` can add Anna's
-Archive, so the worst-case search budget is `4 × 55s = 220s`, below the
-240-second ordinary bridge budget. Raise `PYTHON_BRIDGE_TIMEOUT` whenever
-provider budgets make that composition larger; otherwise the outer process-tree
-kill can preempt legitimate fallback work.
+provider attempt can cost at most `2 × 5s + 45s = 55s`. Those numbers size an
+**attempt**. They do not size a walk, and the difference is what #152 was.
 
-**Do not verify that composition by reading.** `lib/sources/config.py`
-provides `worst_case_search_seconds()` and
-`__tests__/python/test_multi_source_timeouts.py` compares it to the Node budget,
-so a raised provider budget fails the suite instead of producing an unexplained
-timeout. The prose above was wrong for months before #152, because it assumed
-three mirrors while a custom `LIBGEN_MIRROR` produced four.
+A walk costs providers × mirrors, and both factors are operator input:
+`LIBGEN_MIRROR` set to something outside `("li", "vg", "la")` adds a fourth
+mirror, and `BOOK_SOURCE_FALLBACK_ENABLED` decides whether `auto` adds Anna's.
+Any product written down here goes stale the moment either moves — this
+document said `4 × 55s = 220s` for months while the real figure under a custom
+mirror was 275s, against a 240-second bridge budget. Node killed the subprocess
+and the operator saw a generic timeout instead of the attributed per-mirror
+failures the error taxonomy exists to produce.
+
+**The walk is bounded by a wall clock instead.** `SourceRouter` creates one
+`WalkDeadline` per search or download and passes it to every adapter; each
+attempt draws `min(its own budget, what the walk has left)` from it. So:
+
+| Setting | Default | Bounds |
+|---|---|---|
+| `BOOK_SOURCE_WALK_BUDGET` | `165` (seconds) | one whole walk, across every provider and mirror |
+| `BOOK_SOURCE_TOTAL_TIMEOUT` | `45` (seconds) | one attempt, clamped by whatever the walk has left |
+
+The worst case is now `BOOK_SOURCE_WALK_BUDGET`, independent of how many
+mirrors or providers exist. Mirrors are **not** capped: every configured
+fallback stays a candidate, so `li → vg → la` failover survives a custom
+`LIBGEN_MIRROR`, and a mirror that fails its preflight in 5s leaves room for
+the next rather than consuming one of a fixed three. A mirror the deadline
+never reaches is reported with reason `walk_budget_exhausted`, naming the
+mirrors skipped — deliberately distinct from a timeout, which is a verdict
+about a host. This one is fixed by raising `BOOK_SOURCE_WALK_BUDGET`.
+
+**Do not verify the composition by reading.** `lib/sources/config.py` provides
+`worst_case_search_seconds()` and `worst_case_download_seconds()`, and
+`__tests__/python/test_multi_source_timeouts.py` compares both against the Node
+budgets parsed out of `src/lib/python-runner.ts`. Raising the walk budget past
+what either allows fails the suite instead of producing an unexplained timeout.
 
 Source-file transfer has a separate 1,500-second default because a valid large
-book can exceed the 45-second search and URL-resolution budget. The 2,400-second
-long bridge default composes worst-case LibGen resolution
-(`MAX_LIBGEN_MIRROR_ATTEMPTS × (2 × 5s + 45s) = 165s`), transfer (`1,500s`), the OCR subprocess default
-(`600s`), and finalization headroom (`135s`). If any component is overridden,
-keep `PYTHON_BRIDGE_LONG_TIMEOUT` at least as large as their sum after converting
-milliseconds to seconds.
+book can exceed the per-attempt resolution budget. The 2,400-second long bridge
+default composes the walk budget (`165s`), transfer (`1,500s`), the OCR
+subprocess default (`600s`), and finalization headroom (`135s`). Both bridge
+budgets are satisfied by the same walk budget, so raising it has to fit under
+both — which is what `worst_case_download_seconds()` checks.
 
 LibGen download resolution inspects at most the first 2 KiB of a candidate
 response. Some CDNs ignore `Range` and answer `200`; the probe streams and closes

--- a/docs/RETRY_CONFIGURATION.md
+++ b/docs/RETRY_CONFIGURATION.md
@@ -56,16 +56,25 @@ Preflight is skipped when `HTTP_PROXY` or `HTTPS_PROXY` covers the target, with
 letting that probe veto the real client would create a false outage.
 
 The preflight budget applies to two phases (DNS, then TCP). At the defaults, one
-provider attempt can cost at most `2 × 5s + 45s = 55s`. LibGen can walk three
-mirrors and `auto` can add Anna's Archive, so the worst-case search budget is
-`4 × 55s = 220s`, below the 240-second ordinary bridge budget. Raise
-`PYTHON_BRIDGE_TIMEOUT` whenever provider budgets make that composition larger;
-otherwise the outer process-tree kill can preempt legitimate fallback work.
+provider attempt can cost at most `2 × 5s + 45s = 55s`. LibGen walks **at most
+three** mirrors — capped by `MAX_LIBGEN_MIRROR_ATTEMPTS`, so the number does not
+change when an operator sets `LIBGEN_MIRROR` — and `auto` can add Anna's
+Archive, so the worst-case search budget is `4 × 55s = 220s`, below the
+240-second ordinary bridge budget. Raise `PYTHON_BRIDGE_TIMEOUT` whenever
+provider budgets make that composition larger; otherwise the outer process-tree
+kill can preempt legitimate fallback work.
+
+**Do not verify that composition by reading.** `lib/sources/config.py`
+provides `worst_case_search_seconds()` and
+`__tests__/python/test_multi_source_timeouts.py` compares it to the Node budget,
+so a raised provider budget fails the suite instead of producing an unexplained
+timeout. The prose above was wrong for months before #152, because it assumed
+three mirrors while a custom `LIBGEN_MIRROR` produced four.
 
 Source-file transfer has a separate 1,500-second default because a valid large
 book can exceed the 45-second search and URL-resolution budget. The 2,400-second
 long bridge default composes worst-case LibGen resolution
-(`3 × (2 × 5s + 45s) = 165s`), transfer (`1,500s`), the OCR subprocess default
+(`MAX_LIBGEN_MIRROR_ATTEMPTS × (2 × 5s + 45s) = 165s`), transfer (`1,500s`), the OCR subprocess default
 (`600s`), and finalization headroom (`135s`). If any component is overridden,
 keep `PYTHON_BRIDGE_LONG_TIMEOUT` at least as large as their sum after converting
 milliseconds to seconds.

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -380,48 +380,42 @@ arithmetic: one provider attempt costs at worst `2 x preflight + total` = 55s,
 LibGen walks three mirrors, and today's worst case is 4 attempts = 220s against
 a 240-second `PYTHON_BRIDGE_TIMEOUT` — a 20-second margin.
 
-**LibGen's mirror walk is capped, and that cap is load-bearing here.**
-`_mirror_candidates()` used to return `[configured] + [li, vg, la minus
-configured]`, so a supported custom `LIBGEN_MIRROR` such as `rs` yielded
-**four** — and a three-source order reached six attempts = 330s against a 240s
-ceiling. #153 capped the walk at `MAX_LIBGEN_MIRROR_ATTEMPTS`, which is what
-makes LibGen's contribution a constant rather than a function of operator
-configuration.
+**The walk is bounded by a shared deadline, and that is what makes an ordered
+walk possible.** `_mirror_candidates()` returns `[configured] + [li, vg, la
+minus configured]`, so a supported custom `LIBGEN_MIRROR` such as `rs` yields
+**four** mirrors, and a three-source order would reach six attempts = 330s
+against a 240s ceiling. #153 first capped that list at three, which made the
+sum constant by removing `la` from the walk — including from the *download*
+walk, where the budget is generous and byte-driven `li → vg → la` failover is a
+stated repo contract. That trade was rejected.
 
-The bound must still be **computed, not written down**: every source in the
-order, times that source's own worst-case attempt count.
-`worst_case_search_seconds()` does this today for `auto`, deriving the provider
-count from `SourceRouter._search_candidates` and LibGen's from the cap, with a
-test comparing the result to the Node budget read out of `python-runner.ts`.
-The ordered walk extends the same computation over `BOOK_SOURCE_ORDER` rather
-than introducing a second one.
+What shipped instead is `WalkDeadline`: `SourceRouter` creates one per search or
+download, every provider and every mirror draws its per-attempt budget from what
+that deadline has left, and a mirror it never reaches is reported as
+`walk_budget_exhausted` rather than silently absent. The worst case is
+`BOOK_SOURCE_WALK_BUDGET` — 165s, the figure both Node budgets already allowed
+for resolution — and it does not move when a mirror or a provider is added.
 
-What must not happen is a **new** provider or mirror source arriving with a
-hand-counted total beside it. LibGen's cap removes one variable; it does not
-make the sum a constant, because the number of sources in an order is still
-operator input.
+That independence is the precondition `BOOK_SOURCE_ORDER` needed. A per-provider
+budget makes the total a function of how many sources and mirrors exist, so it
+needs re-deriving every time either grows; `config.py`'s comment was wrong twice
+for exactly that reason. No cap on one provider's mirrors could ever bound a
+walk whose length the operator chooses, which is why the cap was the wrong shape
+of fix even where its arithmetic was right. An ordered walk of N sources now
+costs the same 165s as a walk of two, and the sources late in the order are the
+ones that get squeezed — which is the correct behaviour for an ordering the
+operator wrote down in priority order.
 
-**This was live on `master`, not only a future problem.** An operator who set
-`LIBGEN_MIRROR=rs` already reached 5 attempts = 275s against the 240s bridge
-timeout on a plain `auto` search. Filed as #152 and fixed in #153 by the cap
-plus a computed, tested bound.
+`worst_case_search_seconds()` and `worst_case_download_seconds()` compute the
+totals against the Node budgets parsed out of `python-runner.ts`, so both
+ceilings fail the suite rather than production. #152 is closed by this.
 
-That fix makes the current numbers true; it does not remove the underlying
-fragility. A **per-provider** budget means the total is a function of how many
-sources and mirrors exist, so it needs re-deriving every time either grows —
-and `config.py`'s comment was wrong twice for exactly that reason before the
-computation replaced it. Sharing one budget across the ordered walk is the
-durable answer and remains a precondition of `BOOK_SOURCE_ORDER`: no cap on one
-provider's mirrors can bound a walk whose length the operator chooses. #152
-stays open for it.
-
-This is a precondition, not a follow-up. Before three-source orders become
-valid, the migration must either share one total budget across the ordered walk
-rather than granting each provider its own, or raise `PYTHON_BRIDGE_TIMEOUT`
-with the margin recomputed and written down where the existing arithmetic
-lives. A full-order timeout test covering the longest permitted order lands in
-the same stage; without it the regression is invisible until a slow walk in
-production.
+This was a precondition, not a follow-up, and it is now met: the shared budget
+exists, so a three-source order is bounded by construction rather than by a
+recomputed margin. What still lands in the same stage as `BOOK_SOURCE_ORDER` is
+a full-order timeout test covering the longest permitted order — the deadline
+makes the bound hold in principle, and the test is what shows the ordered walk
+actually threads it to every provider.
 
 **`BOOK_SOURCE_ORDER` is comma-separated, case-insensitive, whitespace-
 tolerant.** It is an environment variable, so it reaches Python as a string,

--- a/docs/adr/ADR-011-Z-Library-Source-Adapter.md
+++ b/docs/adr/ADR-011-Z-Library-Source-Adapter.md
@@ -380,28 +380,40 @@ arithmetic: one provider attempt costs at worst `2 x preflight + total` = 55s,
 LibGen walks three mirrors, and today's worst case is 4 attempts = 220s against
 a 240-second `PYTHON_BRIDGE_TIMEOUT` — a 20-second margin.
 
-**LibGen does not always walk three mirrors.** `_mirror_candidates()` returns
-`[configured] + [m for m in ("li", "vg", "la") if m != configured]`, so a
-supported custom `LIBGEN_MIRROR` such as `rs` yields **four**. An order of
-`[zlibrary, annas_archive, libgen]` is therefore up to **six** attempts = 330s,
-not five — Node kills a legitimate walk 90 seconds before the router returns
-its structured result, and the operator sees a subprocess timeout instead of
-the attributed failures the whole error taxonomy exists to produce.
+**LibGen's mirror walk is capped, and that cap is load-bearing here.**
+`_mirror_candidates()` used to return `[configured] + [li, vg, la minus
+configured]`, so a supported custom `LIBGEN_MIRROR` such as `rs` yielded
+**four** — and a three-source order reached six attempts = 330s against a 240s
+ceiling. #153 capped the walk at `MAX_LIBGEN_MIRROR_ATTEMPTS`, which is what
+makes LibGen's contribution a constant rather than a function of operator
+configuration.
 
-The bound must be computed from the registry and the *configuration*, not from
-a constant: every source in the order, times that source's own worst-case
-attempt count, where LibGen's depends on whether `LIBGEN_MIRROR` names one of
-the fallbacks. Any arithmetic here that hardcodes three mirrors is wrong for a
-configuration this project supports.
+The bound must still be **computed, not written down**: every source in the
+order, times that source's own worst-case attempt count.
+`worst_case_search_seconds()` does this today for `auto`, deriving the provider
+count from `SourceRouter._search_candidates` and LibGen's from the cap, with a
+test comparing the result to the Node budget read out of `python-runner.ts`.
+The ordered walk extends the same computation over `BOOK_SOURCE_ORDER` rather
+than introducing a second one.
 
-**This is not only a future problem.** The same mistake is live on `master`
-today: `config.py`'s own documented sum assumes three mirrors, so an operator
-who sets `LIBGEN_MIRROR=rs` already reaches 5 attempts = 275s against the 240s
-bridge timeout on a plain `auto` search. Tracked as #152. A per-provider budget
-re-breaks the sum every time a source or mirror is added — the comment in
-`config.py` has now been wrong twice for that reason — which is the argument
-for sharing one budget across the ordered walk rather than recomputing a
-constant a third time.
+What must not happen is a **new** provider or mirror source arriving with a
+hand-counted total beside it. LibGen's cap removes one variable; it does not
+make the sum a constant, because the number of sources in an order is still
+operator input.
+
+**This was live on `master`, not only a future problem.** An operator who set
+`LIBGEN_MIRROR=rs` already reached 5 attempts = 275s against the 240s bridge
+timeout on a plain `auto` search. Filed as #152 and fixed in #153 by the cap
+plus a computed, tested bound.
+
+That fix makes the current numbers true; it does not remove the underlying
+fragility. A **per-provider** budget means the total is a function of how many
+sources and mirrors exist, so it needs re-deriving every time either grows —
+and `config.py`'s comment was wrong twice for exactly that reason before the
+computation replaced it. Sharing one budget across the ordered walk is the
+durable answer and remains a precondition of `BOOK_SOURCE_ORDER`: no cap on one
+provider's mirrors can bound a walk whose length the operator chooses. #152
+stays open for it.
 
 This is a precondition, not a follow-up. Before three-source orders become
 valid, the migration must either share one total budget across the ordered walk

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -22,6 +22,7 @@ from .config import ANNAS_TRUSTED_HOSTS, SourceConfig
 from .errors import (
     ProviderConfigurationError,
     ProviderResponseError,
+    ProviderTimeoutError,
     ProviderUnreachableError,
     SourceError,
 )
@@ -177,7 +178,7 @@ class AnnasArchiveAdapter(SourceAdapter):
             )
         return self._client
 
-    async def _preflight(self) -> None:
+    async def _preflight(self, deadline: Optional[WalkDeadline] = None) -> None:
         """Fail fast if the configured Anna's host is not reachable.
 
         Anna's domains lapse (annas-archive.org and .se are NXDOMAIN as of
@@ -187,11 +188,21 @@ class AnnasArchiveAdapter(SourceAdapter):
         """
         if not self.config.preflight_enabled or not self.host:
             return
+        timeout = self.config.preflight_timeout
+        if deadline is not None:
+            timeout = deadline.reserve(timeout, minimum=0.000001)
+            if timeout is None:
+                raise ProviderTimeoutError(
+                    PROVIDER,
+                    self.host,
+                    "walk budget exhausted before preflight",
+                    reason="walk_budget_exhausted",
+                )
         await probe_host(
             PROVIDER,
             self.host,
             port=self.port,
-            timeout=self.config.preflight_timeout,
+            timeout=timeout,
             scheme=self.scheme,
         )
 
@@ -251,7 +262,7 @@ class AnnasArchiveAdapter(SourceAdapter):
             ProviderUnreachableError: If the host does not resolve or connect
             ProviderResponseError: If it answers with an HTTP or protocol error
         """
-        await self._preflight()
+        await self._preflight(deadline)
 
         client = await self._get_client()
         url = f"{self.base_url}/search?q={quote(query)}"
@@ -408,7 +419,7 @@ class AnnasArchiveAdapter(SourceAdapter):
                 f"has moved to a new domain you have verified yourself.",
             )
 
-        await self._preflight()
+        await self._preflight(deadline)
 
         client = await self._get_client()
         url = f"{self.base_url}/dyn/api/fast_download.json"

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -27,6 +27,7 @@ from .errors import (
 )
 from .models import DownloadResult, QuotaInfo, SourceType, UnifiedBookResult
 from .net import (
+    WalkDeadline,
     bounded_await,
     build_timeout,
     classify_httpx_error,
@@ -111,6 +112,20 @@ class QuotaExhaustedError(Exception):
     """Raised when Anna's Archive download quota is exhausted."""
 
     pass
+
+
+def _attempt_budget(config, deadline: Optional[WalkDeadline]) -> float:
+    """One attempt's budget, clamped to whatever the shared walk has left.
+
+    Without the clamp a provider late in an `auto` walk starts a fresh
+    45-second attempt on a walk that has 3 seconds left, and the bridge is
+    killed mid-request rather than returning the failures it had collected
+    (#152). With no deadline — an adapter used directly — the configured
+    budget stands.
+    """
+    if deadline is None:
+        return config.total_timeout
+    return min(config.total_timeout, max(0.0, deadline.remaining()))
 
 
 class AnnasArchiveAdapter(SourceAdapter):
@@ -210,7 +225,12 @@ class AnnasArchiveAdapter(SourceAdapter):
         response.raise_for_status()
         return response
 
-    async def search(self, query: str, **kwargs) -> List[UnifiedBookResult]:
+    async def search(
+        self,
+        query: str,
+        deadline: Optional[WalkDeadline] = None,
+        **kwargs,
+    ) -> List[UnifiedBookResult]:
         """Search Anna's Archive for books.
 
         Scrapes HTML from /search?q={query} and extracts MD5 hashes
@@ -218,6 +238,10 @@ class AnnasArchiveAdapter(SourceAdapter):
 
         Args:
             query: Search query string
+            deadline: Wall-clock ceiling shared with the rest of the router's
+                walk. Anna's is one attempt, but in an `auto` search it runs
+                alongside LibGen's mirror walk and they spend the same clock —
+                which is the whole point of a shared deadline (#152).
             **kwargs: Additional search options (unused)
 
         Returns:
@@ -237,7 +261,7 @@ class AnnasArchiveAdapter(SourceAdapter):
             # outer budget is what actually enforces config.total_timeout.
             response = await bounded_await(
                 self._fetch(client, url),
-                self.config.total_timeout,
+                _attempt_budget(self.config, deadline),
                 provider=PROVIDER,
                 host=self.host,
                 operation="search",
@@ -339,7 +363,11 @@ class AnnasArchiveAdapter(SourceAdapter):
             extra=extra,
         )
 
-    async def get_download_url(self, md5: str) -> DownloadResult:
+    async def get_download_url(
+        self,
+        md5: str,
+        deadline: Optional[WalkDeadline] = None,
+    ) -> DownloadResult:
         """Get fast download URL for a book.
 
         Calls /dyn/api/fast_download.json with MD5 and API key.
@@ -393,7 +421,7 @@ class AnnasArchiveAdapter(SourceAdapter):
         try:
             response = await bounded_await(
                 self._fetch(client, url, params=params),
-                self.config.total_timeout,
+                _attempt_budget(self.config, deadline),
                 provider=PROVIDER,
                 host=self.host,
                 operation="download resolution",

--- a/lib/sources/base.py
+++ b/lib/sources/base.py
@@ -5,9 +5,10 @@ to provide consistent search and download behavior.
 """
 
 from abc import ABC, abstractmethod
-from typing import AsyncIterator, List
+from typing import AsyncIterator, List, Optional
 
 from .models import DownloadResult, UnifiedBookResult
+from .net import WalkDeadline
 
 
 class SourceAdapter(ABC):
@@ -21,11 +22,22 @@ class SourceAdapter(ABC):
     """
 
     @abstractmethod
-    async def search(self, query: str, **kwargs) -> List[UnifiedBookResult]:
+    async def search(
+        self,
+        query: str,
+        deadline: Optional[WalkDeadline] = None,
+        **kwargs,
+    ) -> List[UnifiedBookResult]:
         """Search for books matching query.
 
         Args:
             query: Search string (title, author, ISBN, etc.)
+            deadline: Wall-clock ceiling for the WHOLE walk this attempt
+                belongs to, shared across providers and mirrors. An adapter
+                must draw its per-attempt budget from what this has left
+                rather than starting a full-length attempt on a spent walk;
+                None means the adapter is being used directly and its own
+                configured budget applies.
             **kwargs: Source-specific search options
 
         Returns:
@@ -34,24 +46,33 @@ class SourceAdapter(ABC):
         pass
 
     @abstractmethod
-    async def get_download_url(self, md5: str) -> DownloadResult:
+    async def get_download_url(
+        self,
+        md5: str,
+        deadline: Optional[WalkDeadline] = None,
+    ) -> DownloadResult:
         """Get download URL for a book by MD5 hash.
 
         Args:
             md5: MD5 hash identifying the book
+            deadline: As for `search`.
 
         Returns:
             DownloadResult with URL and optional quota info
         """
         pass
 
-    async def iter_download_candidates(self, md5: str) -> AsyncIterator[DownloadResult]:
+    async def iter_download_candidates(
+        self,
+        md5: str,
+        deadline: Optional[WalkDeadline] = None,
+    ) -> AsyncIterator[DownloadResult]:
         """Yield source-neutral download candidates for one book.
 
         Adapters with a single resolution path inherit this compatibility
         implementation. Providers with independent mirrors override it.
         """
-        yield await self.get_download_url(md5)
+        yield await self.get_download_url(md5, deadline=deadline)
 
     @abstractmethod
     async def close(self) -> None:

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -155,6 +155,25 @@ class SourceConfig:
         return bool(self.annas_secret_key)
 
 
+def _auto_search_provider_count() -> int:
+    """How many providers an `auto` search can attempt.
+
+    Read from `SourceRouter`'s own candidate list so the budget arithmetic
+    cannot fall behind a newly registered source. Falls back to the historical
+    two (Anna's and LibGen) if the router cannot be imported, which keeps this
+    module usable in a partial environment rather than making a budget helper
+    the thing that breaks it.
+    """
+    try:
+        from .router import SourceRouter  # noqa: PLC0415
+
+        router = SourceRouter.__new__(SourceRouter)
+        router.config = SourceConfig(fallback_enabled=True)
+        return len(router._search_candidates("auto"))
+    except Exception:  # noqa: BLE001 - a budget helper must not break imports
+        return 2
+
+
 def worst_case_search_seconds(config: "SourceConfig") -> float:
     """Worst-case wall clock for an `auto` search, from the live budgets.
 
@@ -166,8 +185,15 @@ def worst_case_search_seconds(config: "SourceConfig") -> float:
     a failing build instead of a subprocess kill in production.
     """
     per_attempt = (2 * config.preflight_timeout) + config.total_timeout
-    # LibGen's capped mirror walk, plus Anna's on top for `auto`.
-    return per_attempt * (MAX_LIBGEN_MIRROR_ATTEMPTS + 1)
+    # Derived from the router rather than counted by hand: when a provider joins
+    # the `auto` walk — Z-Library, under #40 — the sum has to move with it, and
+    # a literal `+ 1` here would keep reporting 220s while the real worst case
+    # became 275s (Codex on #153). The docstring promises this tracks the
+    # provider count; it now does.
+    providers = _auto_search_provider_count()
+    # LibGen contributes its capped mirror walk; every other provider one
+    # attempt each.
+    return per_attempt * (MAX_LIBGEN_MIRROR_ATTEMPTS + (providers - 1))
 
 
 def _positive_float(name: str, default: float) -> float:

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -24,29 +24,58 @@ from dataclasses import dataclass
 # mirrors, and because the LibGen library's own request cannot be interrupted
 # once started (see lib/sources/net.run_bounded).
 #
-# These compose. The preflight budget is per PHASE and there are two (DNS, then
-# TCP), so one provider attempt costs at worst 2*preflight + total = 55s. LibGen
-# walks at most MAX_LIBGEN_MIRROR_ATTEMPTS mirrors and an `auto` search adds
-# Anna's on top, giving a worst case of 4 x 55s = 220s. PYTHON_BRIDGE_TIMEOUT on
-# the Node side (240s) has to stay above that — a subprocess kill that fires
-# first would preempt a legitimate slow walk rather than catch a hang.
+# These compose, and for months this comment tried to state how. It said one
+# provider attempt costs 2*preflight + total = 55s, that LibGen walks three
+# mirrors, that an `auto` search adds Anna's, and therefore 4 x 55s = 220s
+# against a 240s PYTHON_BRIDGE_TIMEOUT. Every clause was true and the total was
+# wrong: a custom LIBGEN_MIRROR prepends a fourth mirror, making it 275s, so the
+# Node side killed the subprocess and the operator got a generic timeout instead
+# of the per-mirror failures the walk had collected (#152).
 #
-# Do not maintain that sum by hand. `worst_case_search_seconds()` computes it
-# and a test compares it to the Node budget, so raising a budget here surfaces
-# in the suite rather than as an unexplained timeout in production. This comment
-# was wrong for months before #152: a custom LIBGEN_MIRROR added a fourth
-# mirror and nothing recomputed the total.
+# The repair is not a better sum. A walk costs providers x mirrors, both of
+# which move with configuration, so any hand-maintained product drifts the
+# moment either factor does. The walk is bounded by a WALL CLOCK instead:
+# `WalkDeadline` (net.py) is created once per walk and every attempt draws from
+# it, so the worst case is WALK_BUDGET regardless of how many mirrors or
+# providers exist. The numbers below therefore size individual ATTEMPTS; only
+# WALK_BUDGET sizes the walk, and only it has to stay under the Node budget.
 DEFAULT_CONNECT_TIMEOUT = 10.0
 DEFAULT_READ_TIMEOUT = 30.0
 DEFAULT_TOTAL_TIMEOUT = 45.0
 # A source URL can legitimately serve a multi-hundred-megabyte book. Keep its
-# full-transfer wall clock finite but separate from the 45-second search and
-# URL-resolution budget. The independent 40-minute Node budget allows 165
-# seconds for worst-case LibGen resolution, 25 minutes for transfer, 10 minutes
-# for OCR, and 135 seconds for finalization without coupling Python config to a
-# TypeScript constant.
+# full-transfer wall clock finite but separate from the per-attempt search and
+# URL-resolution budget. The 40-minute Node budget splits into DEFAULT_WALK_
+# BUDGET for resolution, this for transfer, OCR_ALLOWANCE and
+# FINALIZE_ALLOWANCE; `worst_case_download_seconds()` adds them up and a test
+# compares the total to PYTHON_BRIDGE_LONG_TIMEOUT.
 DEFAULT_DOWNLOAD_TIMEOUT = 1500.0
 DEFAULT_PREFLIGHT_TIMEOUT = 5.0
+
+# The ceiling on a whole search or download-resolution walk, however many
+# providers and mirrors it spans. ONE number covers both, and 165s is what both
+# Node budgets already allow it:
+#
+#   search   PYTHON_BRIDGE_TIMEOUT      240s = 165 + 75s of bridge overhead
+#   download PYTHON_BRIDGE_LONG_TIMEOUT 2400s = 165 resolution + 1500 transfer
+#                                              + 600 OCR + 135 finalization
+#
+# Both sums are asserted by tests that read the TypeScript constants, so this
+# cannot drift out of step with either. It is also, deliberately, the same
+# clock the capped three-mirror walk used to cost — the change is that the cap
+# is gone, so a mirror that fails its preflight in 5s now leaves room for the
+# fourth instead of consuming one of only three slots.
+DEFAULT_WALK_BUDGET = 165.0
+
+# What the bridge costs outside the walk: spawning python, importing the source
+# package, and serializing results back over stdout. Generous on purpose — the
+# margin absorbs a slow cold start, it is not a number to tune.
+WALK_OVERHEAD_ALLOWANCE = 30.0
+
+# The rest of the long (download) budget, named so the sum can be computed
+# instead of asserted in prose: OCR is bounded by rag_processing, and
+# finalization covers hashing, staging-to-final rename and envelope writing.
+OCR_ALLOWANCE = 600.0
+FINALIZE_ALLOWANCE = 135.0
 
 # Hosts operated by the Anna's Archive project, per the mirror list the live
 # site itself advertises (verified 2026-07-24: .gl/.pk/.gd serve real search
@@ -83,12 +112,6 @@ DEFAULT_ANNAS_BASE_URL = "https://annas-archive.gl"
 # https://libgen.{mirror}/ — keep scripts/check_upstream.py deriving its probe
 # host from here so the probe cannot drift from the runtime again.
 DEFAULT_LIBGEN_MIRROR = "li"
-
-# The mirror walk is capped so the timeout arithmetic above stays a constant
-# rather than a function of operator configuration. `_mirror_candidates()` puts
-# the configured mirror first, so a custom value costs the *last* fallback
-# rather than displacing failover: three attempts either way (#152).
-MAX_LIBGEN_MIRROR_ATTEMPTS = 3
 
 # LibGen's blocklist is a moving target and it fails SILENTLY: a blocked UA
 # gets HTTP 200 with nginx's ~640-byte default page, which is indistinguishable
@@ -134,6 +157,9 @@ class SourceConfig:
         download_timeout: Seconds allowed for a complete source-file transfer
         preflight_enabled: Probe host reachability before the real request
         preflight_timeout: Seconds allowed for each probe phase
+        walk_budget: Seconds allowed for a WHOLE walk, across every
+            provider and mirror it touches. The only budget the Node side
+            has to be kept in step with.
     """
 
     annas_secret_key: str = ""
@@ -148,6 +174,7 @@ class SourceConfig:
     download_timeout: float = DEFAULT_DOWNLOAD_TIMEOUT
     preflight_enabled: bool = True
     preflight_timeout: float = DEFAULT_PREFLIGHT_TIMEOUT
+    walk_budget: float = DEFAULT_WALK_BUDGET
 
     @property
     def has_annas_key(self) -> bool:
@@ -155,45 +182,38 @@ class SourceConfig:
         return bool(self.annas_secret_key)
 
 
-def _auto_search_provider_count() -> int:
-    """How many providers an `auto` search can attempt.
-
-    Read from `SourceRouter`'s own candidate list so the budget arithmetic
-    cannot fall behind a newly registered source. Falls back to the historical
-    two (Anna's and LibGen) if the router cannot be imported, which keeps this
-    module usable in a partial environment rather than making a budget helper
-    the thing that breaks it.
-    """
-    try:
-        from .router import SourceRouter  # noqa: PLC0415
-
-        router = SourceRouter.__new__(SourceRouter)
-        router.config = SourceConfig(fallback_enabled=True)
-        return len(router._search_candidates("auto"))
-    except Exception:  # noqa: BLE001 - a budget helper must not break imports
-        return 2
-
-
 def worst_case_search_seconds(config: "SourceConfig") -> float:
-    """Worst-case wall clock for an `auto` search, from the live budgets.
+    """Worst-case wall clock the Node side must allow for one bridge call.
 
-    Computed rather than asserted, because the hand-maintained version in the
-    comment above was wrong for months: it assumed three LibGen mirrors, and a
-    custom `LIBGEN_MIRROR` made it four (#152). Anything that changes a budget,
-    the mirror cap, or the number of providers in an `auto` walk changes this
-    number, and the test comparing it to `PYTHON_BRIDGE_TIMEOUT` turns that into
-    a failing build instead of a subprocess kill in production.
+    Now a sum of exactly two terms, neither of which depends on how many
+    mirrors or providers exist: the walk's own ceiling, and what the bridge
+    costs around it. That independence is the point. The previous version
+    multiplied a per-attempt cost by a mirror count and a provider count, and
+    was wrong for months because a custom `LIBGEN_MIRROR` changed one of the
+    factors and nothing recomputed the product (#152). Adding Z-Library to the
+    `auto` walk under #40 would have broken it again.
+
+    A test compares this to `PYTHON_BRIDGE_TIMEOUT` in `python-runner.ts`, so
+    raising `BOOK_SOURCE_WALK_BUDGET` past what the Node side allows fails the
+    build instead of producing a killed subprocess in production.
     """
-    per_attempt = (2 * config.preflight_timeout) + config.total_timeout
-    # Derived from the router rather than counted by hand: when a provider joins
-    # the `auto` walk — Z-Library, under #40 — the sum has to move with it, and
-    # a literal `+ 1` here would keep reporting 220s while the real worst case
-    # became 275s (Codex on #153). The docstring promises this tracks the
-    # provider count; it now does.
-    providers = _auto_search_provider_count()
-    # LibGen contributes its capped mirror walk; every other provider one
-    # attempt each.
-    return per_attempt * (MAX_LIBGEN_MIRROR_ATTEMPTS + (providers - 1))
+    return config.walk_budget + WALK_OVERHEAD_ALLOWANCE
+
+
+def worst_case_download_seconds(config: "SourceConfig") -> float:
+    """Worst-case wall clock for one acquisition, against the LONG budget.
+
+    The same discipline as `worst_case_search_seconds`, for the other Node
+    timeout. The allocation used to live only in a comment beside
+    `DEFAULT_DOWNLOAD_TIMEOUT`, which is how #152 happened to the search side:
+    a correct sentence nobody recomputed.
+    """
+    return (
+        config.walk_budget
+        + config.download_timeout
+        + OCR_ALLOWANCE
+        + FINALIZE_ALLOWANCE
+    )
 
 
 def _positive_float(name: str, default: float) -> float:
@@ -244,4 +264,5 @@ def get_source_config() -> SourceConfig:
         preflight_timeout=_positive_float(
             "BOOK_SOURCE_PREFLIGHT_TIMEOUT", DEFAULT_PREFLIGHT_TIMEOUT
         ),
+        walk_budget=_positive_float("BOOK_SOURCE_WALK_BUDGET", DEFAULT_WALK_BUDGET),
     )

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -70,6 +70,14 @@ DEFAULT_WALK_BUDGET = 165.0
 # package, and serializing results back over stdout. Generous on purpose — the
 # margin absorbs a slow cold start, it is not a number to tune.
 WALK_OVERHEAD_ALLOWANCE = 30.0
+DEFAULT_NODE_BRIDGE_TIMEOUT_SECONDS = 240.0
+MAX_NODE_TIMER_DELAY_MS = 2_147_483_647
+WALK_BUDGET_SAFETY_MARGIN = 0.001
+_ECMASCRIPT_TRIM_CHARS = (
+    "\u0009\u000a\u000b\u000c\u000d\u0020\u00a0\u1680\u2000\u2001\u2002"
+    "\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f"
+    "\u205f\u3000\ufeff"
+)
 
 # The rest of the long (download) budget, named so the sum can be computed
 # instead of asserted in prose: OCR is bounded by rag_processing, and
@@ -233,6 +241,41 @@ def _positive_float(name: str, default: float) -> float:
     return value if math.isfinite(value) and value > 0 else default
 
 
+def _ecmascript_trim(value: str) -> str:
+    """Match JavaScript String.prototype.trim for environment values."""
+    return value.strip(_ECMASCRIPT_TRIM_CHARS)
+
+
+def _node_bridge_timeout_seconds() -> float:
+    """Match Node's positive-integer bridge-timeout environment parsing."""
+    raw = _ecmascript_trim(os.environ.get("PYTHON_BRIDGE_TIMEOUT", ""))
+    if not raw or not raw.isascii() or not raw.isdecimal():
+        return DEFAULT_NODE_BRIDGE_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_NODE_BRIDGE_TIMEOUT_SECONDS
+    if value <= 0 or value > MAX_NODE_TIMER_DELAY_MS:
+        return DEFAULT_NODE_BRIDGE_TIMEOUT_SECONDS
+    return value / 1000.0
+
+
+def _walk_budget() -> float:
+    """Read a walk budget that the owning Node bridge can actually allow."""
+    requested = _positive_float("BOOK_SOURCE_WALK_BUDGET", DEFAULT_WALK_BUDGET)
+    available = (
+        _node_bridge_timeout_seconds()
+        - WALK_OVERHEAD_ALLOWANCE
+        - WALK_BUDGET_SAFETY_MARGIN
+    )
+    if available <= 0:
+        raise ValueError(
+            "PYTHON_BRIDGE_TIMEOUT leaves no time for a source walk after "
+            "the bridge overhead allowance"
+        )
+    return min(requested, available)
+
+
 def get_source_config() -> SourceConfig:
     """Load configuration from environment variables.
 
@@ -264,5 +307,5 @@ def get_source_config() -> SourceConfig:
         preflight_timeout=_positive_float(
             "BOOK_SOURCE_PREFLIGHT_TIMEOUT", DEFAULT_PREFLIGHT_TIMEOUT
         ),
-        walk_budget=_positive_float("BOOK_SOURCE_WALK_BUDGET", DEFAULT_WALK_BUDGET),
+        walk_budget=_walk_budget(),
     )

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -26,11 +26,16 @@ from dataclasses import dataclass
 #
 # These compose. The preflight budget is per PHASE and there are two (DNS, then
 # TCP), so one provider attempt costs at worst 2*preflight + total = 55s. LibGen
-# walks up to three mirrors and an `auto` search adds Anna's on top, giving a
-# worst case of 4 x 55s = 220s. PYTHON_BRIDGE_TIMEOUT on the Node side (240s)
-# has to stay above that — a subprocess kill that fires first would preempt a
-# legitimate slow walk rather than catch a hang. Raising any value here without
-# raising that one narrows a margin that is already only 20s.
+# walks at most MAX_LIBGEN_MIRROR_ATTEMPTS mirrors and an `auto` search adds
+# Anna's on top, giving a worst case of 4 x 55s = 220s. PYTHON_BRIDGE_TIMEOUT on
+# the Node side (240s) has to stay above that — a subprocess kill that fires
+# first would preempt a legitimate slow walk rather than catch a hang.
+#
+# Do not maintain that sum by hand. `worst_case_search_seconds()` computes it
+# and a test compares it to the Node budget, so raising a budget here surfaces
+# in the suite rather than as an unexplained timeout in production. This comment
+# was wrong for months before #152: a custom LIBGEN_MIRROR added a fourth
+# mirror and nothing recomputed the total.
 DEFAULT_CONNECT_TIMEOUT = 10.0
 DEFAULT_READ_TIMEOUT = 30.0
 DEFAULT_TOTAL_TIMEOUT = 45.0
@@ -78,6 +83,12 @@ DEFAULT_ANNAS_BASE_URL = "https://annas-archive.gl"
 # https://libgen.{mirror}/ — keep scripts/check_upstream.py deriving its probe
 # host from here so the probe cannot drift from the runtime again.
 DEFAULT_LIBGEN_MIRROR = "li"
+
+# The mirror walk is capped so the timeout arithmetic above stays a constant
+# rather than a function of operator configuration. `_mirror_candidates()` puts
+# the configured mirror first, so a custom value costs the *last* fallback
+# rather than displacing failover: three attempts either way (#152).
+MAX_LIBGEN_MIRROR_ATTEMPTS = 3
 
 # LibGen's blocklist is a moving target and it fails SILENTLY: a blocked UA
 # gets HTTP 200 with nginx's ~640-byte default page, which is indistinguishable
@@ -142,6 +153,21 @@ class SourceConfig:
     def has_annas_key(self) -> bool:
         """Check if Anna's Archive API key is configured."""
         return bool(self.annas_secret_key)
+
+
+def worst_case_search_seconds(config: "SourceConfig") -> float:
+    """Worst-case wall clock for an `auto` search, from the live budgets.
+
+    Computed rather than asserted, because the hand-maintained version in the
+    comment above was wrong for months: it assumed three LibGen mirrors, and a
+    custom `LIBGEN_MIRROR` made it four (#152). Anything that changes a budget,
+    the mirror cap, or the number of providers in an `auto` walk changes this
+    number, and the test comparing it to `PYTHON_BRIDGE_TIMEOUT` turns that into
+    a failing build instead of a subprocess kill in production.
+    """
+    per_attempt = (2 * config.preflight_timeout) + config.total_timeout
+    # LibGen's capped mirror walk, plus Anna's on top for `auto`.
+    return per_attempt * (MAX_LIBGEN_MIRROR_ATTEMPTS + 1)
 
 
 def _positive_float(name: str, default: float) -> float:

--- a/lib/sources/errors.py
+++ b/lib/sources/errors.py
@@ -30,6 +30,12 @@ REASON_TEXT = {
     "protocol_error": "returned a malformed response",
     "integrity_mismatch": "returned bytes that did not match the requested digest",
     "configuration_error": "cannot run with the supplied configuration",
+    # Not a verdict on the host: it names the mirrors and providers the walk
+    # never got to. Distinct from a timeout precisely so an operator can tell
+    # "this mirror is slow" from "the walk ran out of clock before its turn"
+    # — the second is fixed by raising BOOK_SOURCE_WALK_BUDGET, the first is
+    # not (#152).
+    "walk_budget_exhausted": "was not attempted before the walk ran out of time",
     "unknown": "failed for an unclassified reason",
 }
 

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -18,11 +18,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from .base import SourceAdapter
-from .config import (
-    DEFAULT_LIBGEN_USER_AGENT,
-    MAX_LIBGEN_MIRROR_ATTEMPTS,
-    SourceConfig,
-)
+from .config import DEFAULT_LIBGEN_USER_AGENT, SourceConfig
 from .errors import (
     AllSourcesFailedError,
     ProviderResponseError,
@@ -31,6 +27,7 @@ from .errors import (
 )
 from .models import DownloadResult, SourceType, UnifiedBookResult
 from .net import (
+    WalkDeadline,
     bounded_await,
     build_timeout,
     classify_httpx_error,
@@ -338,7 +335,12 @@ class LibgenAdapter(SourceAdapter):
             await asyncio.sleep(self.MIN_REQUEST_INTERVAL - elapsed)
         self._last_request = time.time()
 
-    async def search(self, query: str, **kwargs) -> List[UnifiedBookResult]:
+    async def search(
+        self,
+        query: str,
+        deadline: Optional[WalkDeadline] = None,
+        **kwargs,
+    ) -> List[UnifiedBookResult]:
         """Search for books matching query, failing over between mirrors.
 
         Two hazards are handled here that the previous implementation was not
@@ -358,8 +360,17 @@ class LibgenAdapter(SourceAdapter):
         hazard (#124): it is a parse failure, not an empty result, and it is
         recorded as a typed per-mirror failure so the walk continues.
 
+        A fourth is the walk's own length. Mirrors are no longer capped, so
+        the attempts all draw from one `WalkDeadline` — shared with the router,
+        so Anna's half of an `auto` search spends the same clock. When it runs
+        out the remaining mirrors are reported as unattempted rather than
+        rushed through with a sliver of a budget each (#152).
+
         Args:
             query: Search string (title, author, ISBN, etc.)
+            deadline: Wall-clock ceiling shared with the rest of the walk. A
+                private one is created when called directly, so an adapter
+                used outside the router is still bounded.
             **kwargs: Ignored (for interface compatibility)
 
         Returns:
@@ -368,10 +379,21 @@ class LibgenAdapter(SourceAdapter):
         Raises:
             AllSourcesFailedError: If no mirror could complete the search
         """
+        deadline = deadline or WalkDeadline(self.config.walk_budget)
         failures: List[SourceError] = []
+        mirrors = self._mirror_candidates()
 
-        for mirror in self._mirror_candidates():
+        for index, mirror in enumerate(mirrors):
             host = mirror_host(mirror)
+            # Enough left for two preflight phases plus something to search
+            # with, or the attempt is not worth starting.
+            if deadline.reserve(
+                self.config.total_timeout,
+                minimum=(2 * self.config.preflight_timeout) + 1.0,
+            ) is None:
+                failures.append(self._unattempted(mirrors[index:], deadline))
+                break
+
             try:
                 await self._preflight(mirror)
             except ProviderUnreachableError as exc:
@@ -380,6 +402,14 @@ class LibgenAdapter(SourceAdapter):
                 continue
 
             await self._rate_limit()
+
+            # Re-read after the preflight and the rate-limit sleep: both spend
+            # wall clock, and the budget handed to the search has to be what is
+            # left now, not what was left before them.
+            budget = deadline.reserve(self.config.total_timeout, minimum=1.0)
+            if budget is None:
+                failures.append(self._unattempted(mirrors[index:], deadline))
+                break
 
             def _search_sync(mirror=mirror):
                 # The fetched page is read back on the SAME thread that
@@ -400,7 +430,7 @@ class LibgenAdapter(SourceAdapter):
             try:
                 results, page = await run_bounded(
                     _search_sync,
-                    self.config.total_timeout,
+                    budget,
                     provider=PROVIDER,
                     host=host,
                     operation="search",
@@ -477,21 +507,41 @@ class LibgenAdapter(SourceAdapter):
         ]
 
     def _mirror_candidates(self) -> List[str]:
-        """Mirrors to try, configured one first, capped at a constant count.
+        """Mirrors to try, configured one first, without duplicates.
 
-        The cap is what keeps the timeout arithmetic in `config.py` a constant
-        instead of a function of configuration. Without it a custom
-        `LIBGEN_MIRROR` prepended a fourth mirror, pushing an `auto` search to
-        275s against a 240s bridge budget — so the subprocess was killed and
-        the operator got a generic timeout instead of the attributed per-mirror
-        failures (#152).
+        Deliberately uncapped. Truncating this list was the first attempt at
+        #152 and it bought constant timeout arithmetic by deleting `la` from
+        the walk whenever an operator set a custom `LIBGEN_MIRROR` — including
+        from the DOWNLOAD walk, where the budget is generous and byte-driven
+        `li -> vg -> la` failover is a stated repo contract (Codex on #153).
 
-        The configured mirror is first, so the cap costs the *last* fallback
-        rather than the operator's own choice: three attempts either way, and
-        the mirror they asked for is always among them.
+        What is bounded is the clock, not the list: every attempt draws from a
+        shared `WalkDeadline`, so the walk costs at most `config.walk_budget`
+        no matter how many mirrors are in it. A mirror the deadline never
+        reaches is reported as `walk_budget_exhausted` rather than silently
+        absent.
         """
-        ordered = [self.mirror] + [m for m in FALLBACK_MIRRORS if m != self.mirror]
-        return ordered[:MAX_LIBGEN_MIRROR_ATTEMPTS]
+        return [self.mirror] + [m for m in FALLBACK_MIRRORS if m != self.mirror]
+
+    def _unattempted(self, mirrors: List[str], deadline: WalkDeadline) -> SourceError:
+        """One failure naming the mirrors the walk never reached.
+
+        Not a timeout: `read_timeout` and `search_timeout` are verdicts about a
+        HOST, and attributing an exhausted walk to the next mirror in the list
+        would report a healthy server as slow. The operator fixes this one by
+        raising `BOOK_SOURCE_WALK_BUDGET`, which is a different action, so it
+        gets a different reason code.
+        """
+        return SourceError(
+            PROVIDER,
+            "",
+            reason="walk_budget_exhausted",
+            detail=(
+                f"{len(mirrors)} mirror(s) not attempted "
+                f"({', '.join(mirrors)}); the walk's "
+                f"{deadline.budget:.0f}s budget was already spent"
+            ),
+        )
 
     async def _preflight(self, mirror: str) -> None:
         """Fail fast if a mirror is not reachable.
@@ -626,7 +676,11 @@ class LibgenAdapter(SourceAdapter):
             cdn = urlparse(str(response.url)).hostname or "?"
             return True, cdn
 
-    async def iter_download_candidates(self, md5: str) -> AsyncIterator[DownloadResult]:
+    async def iter_download_candidates(
+        self,
+        md5: str,
+        deadline: Optional[WalkDeadline] = None,
+    ) -> AsyncIterator[DownloadResult]:
         """Yield one working clearnet candidate per unique mirror.
 
         Walks `_mirror_candidates()` and yields each mirror that resolves and
@@ -655,12 +709,26 @@ class LibgenAdapter(SourceAdapter):
         # 2026-08-17, #124), which surfaces as "no GET link" on every mirror.
         # The timeout stays on the configured per-phase budget rather than a
         # bare 30s — bounding these calls is what #106 exists for.
+        deadline = deadline or WalkDeadline(self.config.walk_budget)
+        mirrors = self._mirror_candidates()
+
         async with httpx.AsyncClient(
             timeout=build_timeout(self.config),
             follow_redirects=True,
             headers={"User-Agent": get_user_agent(self.config)},
         ) as client:
-            for mirror in self._mirror_candidates():
+            for index, mirror in enumerate(mirrors):
+                # The walk is bounded by the clock, not by a mirror cap: every
+                # configured fallback stays a candidate, and `la` is reachable
+                # even when an operator has set a custom LIBGEN_MIRROR ahead of
+                # it — which capping the list took away (Codex on #153).
+                if deadline.reserve(
+                    self.config.total_timeout,
+                    minimum=(2 * self.config.preflight_timeout) + 1.0,
+                ) is None:
+                    failures.append(self._unattempted(mirrors[index:], deadline))
+                    break
+
                 try:
                     await self._preflight(mirror)
                 except ProviderUnreachableError as exc:
@@ -669,6 +737,11 @@ class LibgenAdapter(SourceAdapter):
                     continue
 
                 await self._rate_limit()
+
+                budget = deadline.reserve(self.config.total_timeout, minimum=1.0)
+                if budget is None:
+                    failures.append(self._unattempted(mirrors[index:], deadline))
+                    break
 
                 async def resolve_attempt() -> tuple[Optional[str], str]:
                     """Resolve and validate one mirror under one total budget."""
@@ -683,7 +756,7 @@ class LibgenAdapter(SourceAdapter):
                 try:
                     url, detail = await bounded_await(
                         resolve_attempt(),
-                        self.config.total_timeout,
+                        budget,
                         provider=PROVIDER,
                         host=mirror_host(mirror),
                         operation="download resolution",
@@ -722,9 +795,13 @@ class LibgenAdapter(SourceAdapter):
         if failures:
             raise AllSourcesFailedError("download resolution", failures)
 
-    async def get_download_url(self, md5: str) -> DownloadResult:
+    async def get_download_url(
+        self,
+        md5: str,
+        deadline: Optional[WalkDeadline] = None,
+    ) -> DownloadResult:
         """Return the first candidate for compatibility with existing callers."""
-        candidates = self.iter_download_candidates(md5)
+        candidates = self.iter_download_candidates(md5, deadline=deadline)
         try:
             return await anext(candidates)
         finally:

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -18,7 +18,11 @@ import requests
 from bs4 import BeautifulSoup
 
 from .base import SourceAdapter
-from .config import DEFAULT_LIBGEN_USER_AGENT, SourceConfig
+from .config import (
+    DEFAULT_LIBGEN_USER_AGENT,
+    MAX_LIBGEN_MIRROR_ATTEMPTS,
+    SourceConfig,
+)
 from .errors import (
     AllSourcesFailedError,
     ProviderResponseError,
@@ -473,8 +477,21 @@ class LibgenAdapter(SourceAdapter):
         ]
 
     def _mirror_candidates(self) -> List[str]:
-        """Mirrors to try, configured one first, without duplicates."""
-        return [self.mirror] + [m for m in FALLBACK_MIRRORS if m != self.mirror]
+        """Mirrors to try, configured one first, capped at a constant count.
+
+        The cap is what keeps the timeout arithmetic in `config.py` a constant
+        instead of a function of configuration. Without it a custom
+        `LIBGEN_MIRROR` prepended a fourth mirror, pushing an `auto` search to
+        275s against a 240s bridge budget — so the subprocess was killed and
+        the operator got a generic timeout instead of the attributed per-mirror
+        failures (#152).
+
+        The configured mirror is first, so the cap costs the *last* fallback
+        rather than the operator's own choice: three attempts either way, and
+        the mirror they asked for is always among them.
+        """
+        ordered = [self.mirror] + [m for m in FALLBACK_MIRRORS if m != self.mirror]
+        return ordered[:MAX_LIBGEN_MIRROR_ATTEMPTS]
 
     async def _preflight(self, mirror: str) -> None:
         """Fail fast if a mirror is not reachable.

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -213,6 +213,12 @@ def mirror_host(mirror: str) -> str:
     return f"libgen.{mirror}"
 
 
+def _attempt_minimum(config: SourceConfig) -> float:
+    """Least useful walk slice before starting a LibGen mirror attempt."""
+    preflight_budget = config.preflight_timeout if config.preflight_enabled else 0.0
+    return preflight_budget + 1.0
+
+
 def _nginx_stub(text: str) -> bool:
     """True when a body is nginx's default page rather than LibGen's.
 
@@ -325,15 +331,32 @@ class LibgenAdapter(SourceAdapter):
         self.mirror = config.libgen_mirror
         self._last_request = 0.0
 
-    async def _rate_limit(self) -> None:
+    async def _rate_limit(
+        self,
+        deadline: Optional[WalkDeadline] = None,
+        *,
+        minimum_after: float = 0.0,
+    ) -> bool:
         """Enforce rate limiting between requests.
 
-        Sleeps if the last request was less than MIN_REQUEST_INTERVAL ago.
+        Returns false rather than sleeping when pacing would consume the
+        deadline slice required for the actual resolution attempt.
         """
         elapsed = time.time() - self._last_request
-        if elapsed < self.MIN_REQUEST_INTERVAL:
-            await asyncio.sleep(self.MIN_REQUEST_INTERVAL - elapsed)
+        delay = max(0.0, self.MIN_REQUEST_INTERVAL - elapsed)
+        if delay:
+            if (
+                deadline is not None
+                and deadline.reserve(
+                    delay + minimum_after,
+                    minimum=delay + minimum_after,
+                )
+                is None
+            ):
+                return False
+            await asyncio.sleep(delay)
         self._last_request = time.time()
+        return True
 
     async def search(
         self,
@@ -385,12 +408,15 @@ class LibgenAdapter(SourceAdapter):
 
         for index, mirror in enumerate(mirrors):
             host = mirror_host(mirror)
-            # Enough left for two preflight phases plus something to search
+            # Enough left for one aggregate preflight plus something to search
             # with, or the attempt is not worth starting.
-            if deadline.reserve(
-                self.config.total_timeout,
-                minimum=(2 * self.config.preflight_timeout) + 1.0,
-            ) is None:
+            if (
+                deadline.reserve(
+                    self.config.total_timeout,
+                    minimum=_attempt_minimum(self.config),
+                )
+                is None
+            ):
                 failures.append(self._unattempted(mirrors[index:], deadline))
                 break
 
@@ -401,7 +427,9 @@ class LibgenAdapter(SourceAdapter):
                 failures.append(exc)
                 continue
 
-            await self._rate_limit()
+            if await self._rate_limit(deadline, minimum_after=1.0) is False:
+                failures.append(self._unattempted(mirrors[index:], deadline))
+                break
 
             # Re-read after the preflight and the rate-limit sleep: both spend
             # wall clock, and the budget handed to the search has to be what is
@@ -722,10 +750,13 @@ class LibgenAdapter(SourceAdapter):
                 # configured fallback stays a candidate, and `la` is reachable
                 # even when an operator has set a custom LIBGEN_MIRROR ahead of
                 # it — which capping the list took away (Codex on #153).
-                if deadline.reserve(
-                    self.config.total_timeout,
-                    minimum=(2 * self.config.preflight_timeout) + 1.0,
-                ) is None:
+                if (
+                    deadline.reserve(
+                        self.config.total_timeout,
+                        minimum=_attempt_minimum(self.config),
+                    )
+                    is None
+                ):
                     failures.append(self._unattempted(mirrors[index:], deadline))
                     break
 
@@ -736,7 +767,9 @@ class LibgenAdapter(SourceAdapter):
                     logger.warning(f"LibGen mirror {mirror} unreachable: {exc}")
                     continue
 
-                await self._rate_limit()
+                if await self._rate_limit(deadline, minimum_after=1.0) is False:
+                    failures.append(self._unattempted(mirrors[index:], deadline))
+                    break
 
                 budget = deadline.reserve(self.config.total_timeout, minimum=1.0)
                 if budget is None:

--- a/lib/sources/net.py
+++ b/lib/sources/net.py
@@ -33,6 +33,13 @@ three different mechanisms:
    so a host that trickles bytes never trips it. `bounded_await` puts one
    wall-clock deadline over a whole async operation, which is what actually
    enforces `config.total_timeout`. `build_timeout` alone never did.
+
+5. **Walks that outlive the caller that is waiting for them** — bounding each
+   attempt says nothing about a walk of N attempts, and N is not a constant:
+   it is the number of providers times the number of mirrors each one has,
+   both of which move with configuration. `WalkDeadline` puts a single
+   wall-clock ceiling over the whole walk, so the worst case stops being a
+   sum nobody recomputes and becomes a number the caller sets (#152).
 """
 
 import asyncio
@@ -41,6 +48,7 @@ import logging
 import socket
 import ssl
 import threading
+import time
 import urllib.request
 from contextlib import asynccontextmanager
 from typing import Any, Callable, Dict, Optional, Tuple
@@ -564,3 +572,68 @@ async def bounded_await(
             f"{operation} exceeded {timeout:g}s",
             reason="search_timeout",
         ) from None
+
+
+class WalkDeadline:
+    """One wall-clock ceiling shared by every attempt in a multi-source walk.
+
+    `bounded_await` and `run_bounded` bound a single attempt. A walk is many
+    attempts, and its cost is the *product* of two things nobody keeps in their
+    head: how many providers the router tries, and how many mirrors each of
+    those walks internally. #152 is what happens when that product is tracked
+    by hand — a custom `LIBGEN_MIRROR` added a fourth mirror, the worst case
+    went from 220s to 275s against a 240s bridge budget, and the operator got
+    a killed subprocess and a generic timeout instead of the per-mirror
+    failures the walk had actually collected.
+
+    Capping the mirror list was the obvious repair and the wrong one: it bought
+    constant arithmetic by deleting the last fallback from the download walk,
+    where the budget is generous and `li -> vg -> la` failover is a stated
+    repo contract. A deadline buys the same constant without dropping anyone.
+    Every mirror stays a candidate; what is bounded is the clock, not the list.
+
+    Deliberately not a module-level singleton. Every MCP operation spawns a
+    fresh `python_bridge.py`, so process-global state is a recurring source of
+    bugs here; a deadline is created per walk and passed down explicitly.
+
+    Args:
+        budget: Seconds the whole walk may take.
+        clock: Monotonic time source, injectable for tests. Monotonic rather
+            than wall-clock so an NTP step mid-walk cannot expire or extend it.
+    """
+
+    def __init__(self, budget: float, clock: Callable[[], float] = time.monotonic):
+        self._clock = clock
+        self.budget = max(0.0, float(budget))
+        self._expires_at = clock() + self.budget
+
+    def remaining(self) -> float:
+        """Seconds left, never negative."""
+        return max(0.0, self._expires_at - self._clock())
+
+    def expired(self) -> bool:
+        """True once nothing further may be started."""
+        return self.remaining() <= 0.0
+
+    def reserve(self, want: float, *, minimum: float) -> Optional[float]:
+        """Budget for the next attempt, or None if starting one is dishonest.
+
+        Returns `min(want, remaining)` when at least `minimum` seconds are
+        left. Below that the attempt is refused rather than started with a
+        sliver of a budget, because a 0.2s timeout would be recorded against
+        the *mirror* — reporting a healthy host as slow when what actually ran
+        out was the walk. The caller records `walk_budget_exhausted` instead,
+        which names the real cause and is the reason the operator can act on.
+
+        Args:
+            want: The attempt's own budget, from config.
+            minimum: Least useful slice — typically one preflight phase, since
+                an attempt that cannot finish DNS cannot inform anyone.
+
+        Returns:
+            Seconds to allow this attempt, or None to stop the walk.
+        """
+        left = self.remaining()
+        if left < minimum:
+            return None
+        return min(want, left)

--- a/lib/sources/net.py
+++ b/lib/sources/net.py
@@ -50,8 +50,8 @@ import ssl
 import threading
 import time
 import urllib.request
-from contextlib import asynccontextmanager
-from typing import Any, Callable, Dict, Optional, Tuple
+from contextlib import asynccontextmanager, contextmanager
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple
 from urllib.parse import urlsplit
 
 import httpx
@@ -284,7 +284,7 @@ async def probe_host(
         provider: Provider name for error attribution
         host: Hostname to probe
         port: TCP port (default 443)
-        timeout: Budget in seconds for EACH of the DNS and connect phases
+        timeout: Aggregate budget in seconds for DNS and TCP connect together
         use_cache: Reuse a verdict already reached for this (host, port)
         scheme: URL scheme the real request will use, for proxy detection
 
@@ -317,6 +317,7 @@ async def _probe_host_uncached(
     provider: str, host: str, port: int, timeout: float
 ) -> Optional[ProviderUnreachableError]:
     """Run the probe, returning the failure rather than raising it."""
+    started = time.monotonic()
     # DNS is a blocking libc/NSS call and cannot be cancelled. The event loop's
     # default executor uses non-daemon workers and joins them during
     # asyncio.run() shutdown, so wait_for(loop.getaddrinfo(...)) can return at
@@ -343,6 +344,15 @@ async def _probe_host_uncached(
             provider, host, f"{type(exc).__name__}: {exc}", reason="dns_failure"
         )
 
+    remaining = max(0.0, timeout - (time.monotonic() - started))
+    if remaining <= 0:
+        return ProviderUnreachableError(
+            provider,
+            host,
+            "no time left for TCP after DNS",
+            reason="connect_timeout",
+        )
+
     # TCP connect. Deliberately no TLS handshake: this only answers "is anything
     # listening", and a handshake would double the cost of the common case.
     async def connect_resolved():
@@ -366,12 +376,12 @@ async def _probe_host_uncached(
 
     writer = None
     try:
-        _, writer = await asyncio.wait_for(connect_resolved(), timeout)
+        _, writer = await asyncio.wait_for(connect_resolved(), remaining)
     except asyncio.TimeoutError:
         return ProviderUnreachableError(
             provider,
             host,
-            f"no TCP handshake within {timeout:g}s",
+            f"no TCP handshake within {remaining:g}s",
             reason="connect_timeout",
         )
     except ConnectionRefusedError:
@@ -606,10 +616,35 @@ class WalkDeadline:
         self._clock = clock
         self.budget = max(0.0, float(budget))
         self._expires_at = clock() + self.budget
+        self._suspended_at: Optional[float] = None
+        self._suspension_depth = 0
+
+    @contextmanager
+    def suspended(self) -> Iterator[None]:
+        """Exclude consumer-held candidate time from active walk resolution.
+
+        The router yields a resolved URL so its consumer can try the transfer.
+        A slow or failed transfer must not exhaust the deadline that controls
+        the next provider's URL resolution.  ``finally`` deliberately rebases
+        on normal resume, generator close, and exceptions alike.
+        """
+        if self._suspension_depth == 0:
+            self._suspended_at = self._clock()
+        self._suspension_depth += 1
+        try:
+            yield
+        finally:
+            self._suspension_depth -= 1
+            if self._suspension_depth == 0:
+                paused_at = self._suspended_at
+                self._suspended_at = None
+                if paused_at is not None:
+                    self._expires_at += max(0.0, self._clock() - paused_at)
 
     def remaining(self) -> float:
         """Seconds left, never negative."""
-        return max(0.0, self._expires_at - self._clock())
+        clock = self._suspended_at if self._suspended_at is not None else self._clock()
+        return max(0.0, self._expires_at - clock)
 
     def expired(self) -> bool:
         """True once nothing further may be started."""

--- a/lib/sources/router.py
+++ b/lib/sources/router.py
@@ -280,7 +280,8 @@ class SourceRouter:
                 async for result in provider_stream:
                     if result.quota_info and result.quota_info.downloads_left == 0:
                         raise QuotaExhaustedError(f"{name} quota exhausted")
-                    yield result
+                    with deadline.suspended():
+                        yield result
             except QuotaExhaustedError as exc:
                 failures.append(
                     SourceError(name, detail=str(exc), reason="quota_exhausted")

--- a/lib/sources/router.py
+++ b/lib/sources/router.py
@@ -18,6 +18,7 @@ from .config import SourceConfig, get_source_config
 from .errors import AllSourcesFailedError, SourceError
 from .libgen import LibgenAdapter
 from .models import DownloadResult, UnifiedBookResult
+from .net import WalkDeadline
 
 logger = logging.getLogger("zlibrary.sources")
 
@@ -156,10 +157,19 @@ class SourceRouter:
         candidates = self._search_candidates(source)
         failures: List[SourceError] = []
         answered = False
+        # ONE clock for the whole walk, created here and spent by every
+        # provider and every mirror beneath them. The alternative — each
+        # attempt bounded on its own — makes the walk's cost a product of two
+        # counts that move with configuration, and #152 is what that product
+        # being wrong looks like from the operator's side: a killed bridge
+        # process and a generic timeout in place of attributed failures.
+        deadline = WalkDeadline(self.config.walk_budget)
 
         for name in candidates:
             try:
-                results = await self._adapter_for(name).search(query, **kwargs)
+                results = await self._adapter_for(name).search(
+                    query, deadline=deadline, **kwargs
+                )
             except AllSourcesFailedError as exc:
                 # A provider that walks its own mirrors (LibGen) reports a set.
                 failures.extend(exc.failures)
@@ -251,6 +261,7 @@ class SourceRouter:
         """Flatten candidate streams, crossing providers only for ``auto``."""
         candidates = self._download_candidates(source)
         failures: List[SourceError] = []
+        deadline = WalkDeadline(self.config.walk_budget)
 
         for name in candidates:
             provider_stream = None
@@ -258,11 +269,11 @@ class SourceRouter:
                 adapter = self._adapter_for(name)
                 candidate_method = getattr(adapter, "iter_download_candidates", None)
                 if candidate_method and inspect.isasyncgenfunction(candidate_method):
-                    provider_stream = candidate_method(md5)
+                    provider_stream = candidate_method(md5, deadline=deadline)
                 else:
 
                     async def single_candidate():
-                        yield await adapter.get_download_url(md5)
+                        yield await adapter.get_download_url(md5, deadline=deadline)
 
                     provider_stream = single_candidate()
 

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -37,7 +37,8 @@ from bs4 import BeautifulSoup
 # copies that went stale).
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "zlibrary" / "src"))
-from lib.sources.config import get_source_config  # noqa: E402
+from lib.sources.config import get_source_config
+from lib.sources.libgen import LibgenAdapter  # noqa: E402
 from lib.sources.libgen import FALLBACK_MIRRORS as LIBGEN_FALLBACK_MIRRORS  # noqa: E402
 from lib.sources.libgen import _nginx_stub as _libgen_nginx_stub  # noqa: E402
 from lib.sources.libgen import get_user_agent as libgen_user_agent  # noqa: E402
@@ -66,8 +67,13 @@ LIBGEN_BASE_URL = f"https://libgen.{_source_config.libgen_mirror}"
 # mirrors hand off to *different* CDN nodes that fail independently — on
 # 2026-08-10 `li` -> cdn4.booksdl.lc failed TLS while `vg`/`la` -> cdn3 served
 # real bytes.
+# Derived from the adapter, not restated. Production caps its walk at
+# MAX_LIBGEN_MIRROR_ATTEMPTS, and a probe that walked one mirror further would
+# report the download path healthy on a mirror production never reaches — the
+# reachability-vs-capability gap this script exists to close, inverted (Codex
+# on #153).
 LIBGEN_MIRROR_CANDIDATES: tuple[str, ...] = tuple(
-    dict.fromkeys([_source_config.libgen_mirror, "li", "vg", "la"])
+    LibgenAdapter(_source_config)._mirror_candidates()
 )
 
 # A small, stable PDF used to exercise the download path end to end. Verified

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -302,7 +302,7 @@ def libgen_probe_timeout(config, min_request_interval: float = 0.0) -> float:
     """Wall clock the production adapter may legitimately spend on one search.
 
     `LibgenAdapter.search` walks every mirror candidate, and each attempt can
-    cost a two-phase preflight (DNS, then TCP — the budget is per phase), the
+    cost one aggregate preflight (DNS plus TCP), the
     rate-limit wait, and the full per-provider total budget. Deriving the
     deadline from the same config the adapter reads means an operator who
     raises `BOOK_SOURCE_TOTAL_TIMEOUT` does not thereby make the canary
@@ -318,7 +318,7 @@ def libgen_probe_timeout(config, min_request_interval: float = 0.0) -> float:
     mirrors = len({config.libgen_mirror, *LIBGEN_FALLBACK_MIRRORS})
     per_mirror = float(config.total_timeout) + float(min_request_interval)
     if config.preflight_enabled:
-        per_mirror += 2 * float(config.preflight_timeout)
+        per_mirror += float(config.preflight_timeout)
     return mirrors * per_mirror + LIBGEN_PROBE_MARGIN
 
 

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -67,11 +67,12 @@ LIBGEN_BASE_URL = f"https://libgen.{_source_config.libgen_mirror}"
 # mirrors hand off to *different* CDN nodes that fail independently — on
 # 2026-08-10 `li` -> cdn4.booksdl.lc failed TLS while `vg`/`la` -> cdn3 served
 # real bytes.
-# Derived from the adapter, not restated. Production caps its walk at
-# MAX_LIBGEN_MIRROR_ATTEMPTS, and a probe that walked one mirror further would
-# report the download path healthy on a mirror production never reaches — the
-# reachability-vs-capability gap this script exists to close, inverted (Codex
-# on #153).
+# Derived from the adapter, not restated, so the probe walks exactly the list
+# production walks. Production may stop early when its `WalkDeadline` runs out;
+# the probe deliberately does not, because a mirror skipped for lack of clock
+# is a fact about one busy walk, not about the mirror's health — and reporting
+# it as untested would hide the reachability-vs-capability gap this script
+# exists to close (Codex on #153).
 LIBGEN_MIRROR_CANDIDATES: tuple[str, ...] = tuple(
     LibgenAdapter(_source_config)._mirror_candidates()
 )


### PR DESCRIPTION
`lib/sources/config.py` documents the timeout composition and warns the margin is thin:

> one provider attempt costs at worst `2*preflight + total = 55s`. LibGen walks up to three mirrors and an `auto` search adds Anna's on top, giving a worst case of `4 x 55s = 220s`. `PYTHON_BRIDGE_TIMEOUT` (240s) has to stay above that [...] a margin that is already only 20s.

**"Up to three mirrors" is only true for the default.**

```python
return [self.mirror] + [m for m in FALLBACK_MIRRORS if m != self.mirror]
```

`FALLBACK_MIRRORS = ("li", "vg", "la")`, and the default is `li`. Any other supported value prepends a fourth:

| `LIBGEN_MIRROR` | mirrors | attempts with `auto` | worst case | vs 240s |
|---|---|---|---|---|
| `li` (default) | 3 | 4 | 220s | 20s margin |
| `rs` | 4 | 5 | **275s** | **35s over** |

The consequence is not a slow search — Node kills the subprocess, so the operator gets a generic bridge timeout **instead of** the attributed per-mirror failures the error taxonomy exists to produce. The diagnostic machinery is destroyed by exactly the case that most needs it, and only for operators who set a custom mirror, only when mirrors are slow rather than failing fast. It presents as an occasional unexplained timeout.

## Two changes

**The walk is capped** at `MAX_LIBGEN_MIRROR_ATTEMPTS = 3`, making the worst case independent of configuration.

The cap costs the *last fallback*, never the operator's choice — the configured mirror is first in the list, so `rs` yields `['rs', 'li', 'vg']`. Three attempts either way, and the mirror they asked for is always attempted. That is the trade, stated plainly: one fewer fallback for a custom mirror, against a subprocess kill that discards every failure detail.

**The arithmetic is checked rather than asserted.** `worst_case_search_seconds()` computes it from the live budgets and a test compares it to the Node budget:

```python
assert worst < NODE_BRIDGE_TIMEOUT_SECONDS, (
    f"an auto search can take {worst}s against a {NODE_BRIDGE_TIMEOUT_SECONDS}s "
    f"bridge budget — Node will kill a legitimate walk."
)
```

There is also a test proving the guard **binds** — a raised provider budget makes it fail — because a guard that cannot fail is the same defect one level up, and this whole issue is a comment that could not fail.

## Why not the alternatives

I considered raising `PYTHON_BRIDGE_TIMEOUT` to cover six attempts: that lengthens hang detection for everyone to accommodate a configuration most operators do not use. And sharing one budget across the ordered walk — the durable fix ADR-011 recommends — changes failure semantics, since one slow mirror would then starve the rest. That is worth doing deliberately, not as a drive-by inside a timeout correction. #152 stays open for it; this makes the current numbers true in the meantime.

**Verified**: `worst_case_search_seconds(SourceConfig())` returns `220.0`; `rs` and `is` both yield three-mirror walks with the configured mirror first; full fast Python suite green.