### PR TITLE
fix(sources): parse LibGen journal-article rows against the real column map

### DIFF
--- a/__tests__/python/test_check_upstream.py
+++ b/__tests__/python/test_check_upstream.py
@@ -725,6 +725,288 @@ class TestLibgenSearchProbeUsesProductionAdapter:
         assert "Welcome to nginx!" in result.detail
 
 
+class TestLibgenArticleSearchProbe:
+    """The article canary is separate from the existing book-row canary."""
+
+    def _run(self, check_upstream, search_impl):
+        from unittest.mock import patch
+
+        async def go():
+            with patch("lib.sources.libgen.LibgenAdapter.search", new=search_impl):
+                async with httpx.AsyncClient(
+                    transport=httpx.MockTransport(lambda request: httpx.Response(500))
+                ) as client:
+                    return await check_upstream.probe_libgen_article(client)
+
+        return asyncio.run(go())
+
+    def test_probe_queries_a_known_article_result(self, check_upstream):
+        """The live canary must cover article markup, not only monograph rows.
+
+        Restoring the former Pride and Prejudice query here leaves the article
+        parser's selector, edition ID, and MD5 path outside drift detection.
+        """
+        from types import SimpleNamespace
+
+        seen = {}
+
+        async def fake_search(_self, query, **_kwargs):
+            seen["query"] = query
+            return [
+                SimpleNamespace(
+                    md5="e3f85ebc6faa062bceb95b349f369672",
+                    title="The Inner Citadel P Hadot",
+                    extra={"id": "76430726", "content_type": "article"},
+                )
+            ]
+
+        result = self._run(check_upstream, fake_search)
+
+        assert result.ok is True
+        assert result.name == "libgen:article-search"
+        assert seen["query"] == "The Inner Citadel Meditations Marcus Aurelius"
+
+    def test_pre_repair_series_id_and_joined_title_do_not_clear_the_canary(
+        self, check_upstream
+    ):
+        """The old series.php identity must fail despite a valid article MD5."""
+        from types import SimpleNamespace
+
+        async def fake_search(_self, _query, **_kwargs):
+            return [
+                SimpleNamespace(
+                    md5="e3f85ebc6faa062bceb95b349f369672",
+                    title=(
+                        "The Classical Review 2001oct vol 51 iss 2 The Inner "
+                        "Citadel P Hadot DOI 101093cr512298"
+                    ),
+                    extra={"id": "23549", "content_type": "article"},
+                )
+            ]
+
+        result = self._run(check_upstream, fake_search)
+
+        assert result.ok is False
+        assert "NONE usable article" in result.detail
+
+    def test_correct_edition_id_without_the_article_title_marker_fails(
+        self, check_upstream
+    ):
+        """The article ID alone does not prove the edition title was selected."""
+        from types import SimpleNamespace
+
+        async def fake_search(_self, _query, **_kwargs):
+            return [
+                SimpleNamespace(
+                    md5="e3f85ebc6faa062bceb95b349f369672",
+                    title="The Classical Review October 2001",
+                    extra={"id": "76430726", "content_type": "article"},
+                )
+            ]
+
+        result = self._run(check_upstream, fake_search)
+
+        assert result.ok is False
+        assert "NONE usable article" in result.detail
+
+    def test_valid_md5_book_row_does_not_clear_the_article_canary(self, check_upstream):
+        """A book result proves neither the article selector nor its MD5 path."""
+        from types import SimpleNamespace
+
+        async def fake_search(_self, _query, **_kwargs):
+            return [
+                SimpleNamespace(
+                    md5="3b516fa296c861195bc94fad9bddda9e",
+                    title="The Inner Citadel",
+                    extra={"content_type": "book"},
+                )
+            ]
+
+        result = self._run(check_upstream, fake_search)
+
+        assert result.ok is False
+        assert "NONE usable article" in result.detail
+
+
+def test_run_probes_includes_the_article_canary(check_upstream):
+    """The article probe has to be wired into doctor and scheduled CI."""
+    from unittest.mock import patch
+
+    async def zlibrary(_client):
+        return [check_upstream.ProbeResult("zlibrary:eapi", True, "ok")]
+
+    async def annas(_client):
+        return check_upstream.ProbeResult("annas-archive:search", True, "ok")
+
+    async def libgen_canaries(_client):
+        return (
+            check_upstream.ProbeResult("libgen:search", True, "ok"),
+            check_upstream.ProbeResult("libgen:article-search", True, "ok"),
+        )
+
+    async def download(_client):
+        return check_upstream.ProbeResult("libgen:download", True, "ok")
+
+    async def go():
+        with (
+            patch.object(check_upstream, "probe_zlibrary_eapi", zlibrary),
+            patch.object(check_upstream, "probe_annas", annas),
+            patch.object(check_upstream, "probe_libgen_canaries", libgen_canaries),
+            patch.object(check_upstream, "probe_libgen_download", download),
+        ):
+            return await check_upstream.run_probes()
+
+    results = asyncio.run(go())
+
+    assert [result.name for result in results] == [
+        "zlibrary:eapi",
+        "annas-archive:search",
+        "libgen:search",
+        "libgen:article-search",
+        "libgen:download",
+    ]
+
+
+def test_run_probes_starts_the_article_search_only_after_book_search_finishes(
+    check_upstream,
+):
+    """The article canary starts only after the book canary returns."""
+    from unittest.mock import patch
+
+    book_started = asyncio.Event()
+    allow_book_finish = asyncio.Event()
+    article_started = asyncio.Event()
+    order = []
+
+    async def zlibrary(_client):
+        return [check_upstream.ProbeResult("zlibrary:eapi", True, "ok")]
+
+    async def annas(_client):
+        return check_upstream.ProbeResult("annas-archive:search", True, "ok")
+
+    async def download(_client):
+        return check_upstream.ProbeResult("libgen:download", True, "ok")
+
+    async def libgen_canaries(_client):
+        order.append("book:start")
+        book_started.set()
+        await allow_book_finish.wait()
+        order.append("book:end")
+        order.append("article:start")
+        article_started.set()
+        return (
+            check_upstream.ProbeResult("libgen:search", True, "ok"),
+            check_upstream.ProbeResult("libgen:article-search", True, "ok"),
+        )
+
+    async def go():
+        with (
+            patch.object(check_upstream, "probe_zlibrary_eapi", zlibrary),
+            patch.object(check_upstream, "probe_annas", annas),
+            patch.object(check_upstream, "probe_libgen_download", download),
+            patch.object(check_upstream, "probe_libgen_canaries", libgen_canaries),
+        ):
+            probes = asyncio.create_task(check_upstream.run_probes())
+            await book_started.wait()
+            await asyncio.sleep(0)
+            assert article_started.is_set() is False
+            allow_book_finish.set()
+            results = await probes
+        return results
+
+    results = asyncio.run(go())
+
+    assert [result.name for result in results] == [
+        "zlibrary:eapi",
+        "annas-archive:search",
+        "libgen:search",
+        "libgen:article-search",
+        "libgen:download",
+    ]
+    assert order == ["book:start", "book:end", "article:start"]
+
+
+def test_run_probes_reuses_the_adapter_so_article_search_is_rate_limited(
+    check_upstream,
+):
+    """The second canary must inherit the first request's pacing state."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lib.sources import libgen as libgen_mod
+    from lib.sources.config import SourceConfig
+
+    config = SourceConfig(
+        libgen_mirror="li",
+        default_source="libgen",
+        fallback_enabled=False,
+        preflight_enabled=False,
+    )
+    search_adapters = []
+    sleep_delays = []
+    closed = []
+
+    async def fake_search(adapter, query, **_kwargs):
+        search_adapters.append(adapter)
+        await adapter._rate_limit()
+        if query == "Pride and Prejudice":
+            return [
+                SimpleNamespace(
+                    md5="3b516fa296c861195bc94fad9bddda9e",
+                    title="Pride and Prejudice",
+                    extra={"id": "1342", "content_type": "book"},
+                )
+            ]
+        return [
+            SimpleNamespace(
+                md5="e3f85ebc6faa062bceb95b349f369672",
+                title="The Inner Citadel P Hadot",
+                extra={"id": "76430726", "content_type": "article"},
+            )
+        ]
+
+    async def fake_sleep(delay):
+        sleep_delays.append(delay)
+
+    async def fake_close(adapter):
+        closed.append(adapter)
+
+    async def zlibrary(_client):
+        return [check_upstream.ProbeResult("zlibrary:eapi", True, "ok")]
+
+    async def annas(_client):
+        return check_upstream.ProbeResult("annas-archive:search", True, "ok")
+
+    async def download(_client):
+        return check_upstream.ProbeResult("libgen:download", True, "ok")
+
+    async def go():
+        with (
+            patch.object(check_upstream, "get_source_config", return_value=config),
+            patch.object(check_upstream, "probe_zlibrary_eapi", zlibrary),
+            patch.object(check_upstream, "probe_annas", annas),
+            patch.object(check_upstream, "probe_libgen_download", download),
+            patch.object(libgen_mod.LibgenAdapter, "search", fake_search),
+            patch.object(libgen_mod.LibgenAdapter, "close", fake_close),
+            patch.object(libgen_mod.time, "time", side_effect=[100, 100, 101, 102]),
+            patch.object(libgen_mod.asyncio, "sleep", fake_sleep),
+        ):
+            return await check_upstream.run_probes()
+
+    results = asyncio.run(go())
+
+    assert [result.name for result in results] == [
+        "zlibrary:eapi",
+        "annas-archive:search",
+        "libgen:search",
+        "libgen:article-search",
+        "libgen:download",
+    ]
+    assert search_adapters[0] is search_adapters[1]
+    assert sleep_delays == [1.0]
+    assert closed == [search_adapters[0]]
+
+
 def test_libgen_block_does_not_set_the_zlibrary_blocked_flag(check_upstream):
     """A walled LibGen must not suppress the Z-Library drift report.
 

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -1457,6 +1457,7 @@ class TestLibgenMixedBookAndArticleRows:
         assert len(results) == 4, "two books and two articles, none dropped"
 
     def test_article_row_fields_are_not_column_shifted(self, results):
+        """The corrected row keeps its edition title, rather than journal metadata."""
         article = next(r for r in results if r.md5 == self.ARTICLE_MD5)
 
         assert article.author == "Rutherford, R. B."
@@ -1465,7 +1466,23 @@ class TestLibgenMixedBookAndArticleRows:
         assert article.year == "2001 October"
         assert article.extra["language"] == "English"
         assert article.extra["pages"] == "0"
-        assert "Classical Review" in article.title, "used to be empty"
+        assert article.title.startswith("The Inner Citadel P Hadot")
+
+    def test_article_uses_its_edition_title_and_id(self, results):
+        """The series and issue links describe metadata, not this edition.
+
+        A mutation that joins every anchor in the title cell (or takes its
+        first link) would return the journal name, issue metadata, DOI, and
+        the shared `series.php` ID instead of the article's edition identity.
+        """
+        article = next(r for r in results if r.md5 == self.ARTICLE_MD5)
+
+        assert article.extra["id"] == "76430726"
+        assert article.title == (
+            "The Inner Citadel P Hadot The Inner Citadel the Meditations of "
+            "Marcus Aurelius  Pp x  351 Cambridge MA and London Harvard "
+            "University Press 1998 Cased 2795 ISBN 0674461711"
+        )
 
     def test_rows_declare_their_object_type(self, results):
         by_md5 = {r.md5: r for r in results}
@@ -1483,3 +1500,83 @@ class TestLibgenMixedBookAndArticleRows:
         assert book.year == "2001"
         assert book.extra["language"] == "English"
         assert "Inner Citadel" in book.title
+
+
+class TestLibgenEditionLinkSelection:
+    """Only a visible, direct edition link identifies a result row."""
+
+    MD5 = "a3f85ebc6faa062bceb95b349f369672"
+
+    @staticmethod
+    def _parse(title_markup):
+        from bs4 import BeautifulSoup
+        from libgen_api_enhanced.search_request import SearchRequest
+        from lib.sources.libgen import _get_books
+
+        table = BeautifulSoup(
+            f"""
+            <table><tr>
+              <td><img src="" /></td>
+              <td>{title_markup}</td>
+              <td>Author</td><td>Publisher</td><td>2026</td><td>English</td>
+              <td>1</td><td>1 MB</td><td>pdf</td>
+              <td><a href="/ads.php?md5={TestLibgenEditionLinkSelection.MD5}">1</a></td>
+            </tr></table>
+            """,
+            "html.parser",
+        ).table
+        request = SearchRequest("title", mirror="https://libgen.li")
+        return list(_get_books(request, table))
+
+    def test_skips_blank_duplicate_and_uses_nested_visible_title_content(self):
+        books = self._parse(
+            '<a href="edition.php?id=11111"><span></span></a>'
+            '<a href="edition.php?id=24680"><span>Visible <strong>Article</strong></span></a>'
+        )
+
+        assert len(books) == 1
+        assert books[0].id == "24680"
+        assert books[0].title == "Visible Article"
+
+    @pytest.mark.parametrize(
+        ("href", "expected_id"),
+        [
+            ("edition.php?id=101", "101"),
+            ("/edition.php?id=102", "102"),
+            ("https://libgen.li/edition.php?id=103", "103"),
+        ],
+    )
+    def test_accepts_direct_edition_link_url_forms(self, href, expected_id):
+        books = self._parse(f'<a href="{href}"><span>Article</span></a>')
+
+        assert len(books) == 1
+        assert books[0].id == expected_id
+
+    @pytest.mark.parametrize(
+        "href",
+        ["/notedition.php?id=123", "/fooedition.php?id=123"],
+    )
+    def test_rejects_paths_that_only_end_with_edition_php(self, href):
+        assert self._parse(f'<a href="{href}">Article</a>') == []
+
+    @pytest.mark.parametrize(
+        "href",
+        [
+            "edition.php",
+            "edition.php?id=",
+            "edition.php?id=not-a-number",
+            "edition.php?not_id=123",
+        ],
+    )
+    def test_skips_direct_edition_links_without_a_usable_id(self, href):
+        assert self._parse(f'<a href="{href}">Article</a>') == []
+
+    def test_ignores_nested_metadata_edition_link(self):
+        books = self._parse(
+            '<span><a href="edition.php?id=98765">Series metadata</a></span>'
+            '<a href="edition.php?id=12345"><span>Actual</span> article</a>'
+        )
+
+        assert len(books) == 1
+        assert books[0].id == "12345"
+        assert books[0].title == "Actual article"

--- a/__tests__/python/test_libgen_adapter.py
+++ b/__tests__/python/test_libgen_adapter.py
@@ -6,6 +6,7 @@ LibgenSearch calls in asyncio.to_thread().
 """
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
@@ -1360,3 +1361,125 @@ class TestSearchUserAgentBlockIsTyped:
             "existing handlers catch ProviderResponseError; narrowing the "
             "hierarchy here would silently change failover behaviour"
         )
+
+
+class TestLibgenMixedBookAndArticleRows:
+    """Journal-article rows must parse against the real column layout (#132).
+
+    These run against `test_files/libgen/mixed_book_article_results.html`,
+    trimmed from a live libgen.li capture rather than hand-written, because
+    the bug is caused by real markup a hand-written mock does not reproduce:
+    an article row's cover cell holds `<img src="">`, which defeats the
+    upstream parser's "covers"-in-src cover detection and shifts every field
+    one column left.
+    """
+
+    FIXTURE = (
+        Path(__file__).resolve().parents[2]
+        / "test_files"
+        / "libgen"
+        / "mixed_book_article_results.html"
+    )
+
+    # From the captured page: the Classical Review review-article row and the
+    # Hadot monograph, which sit in the same results table.
+    ARTICLE_MD5 = "e3f85ebc6faa062bceb95b349f369672"
+    BOOK_MD5 = "3b516fa296c861195bc94fad9bddda9e"
+
+    @pytest.fixture
+    def results(self):
+        """Drive the real adapter search over the fixture page.
+
+        Patching `requests.get` (rather than the library's parser) keeps the
+        UA shim, the bounded thread and `_to_unified` in the path, so this
+        pins the behaviour a caller actually sees.
+        """
+        from lib.sources.config import SourceConfig
+        from lib.sources.libgen import LibgenAdapter
+
+        adapter = LibgenAdapter(
+            SourceConfig(
+                libgen_mirror="li",
+                default_source="libgen",
+                fallback_enabled=False,
+                preflight_enabled=False,
+            )
+        )
+
+        response = MagicMock()
+        response.text = self.FIXTURE.read_text()
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=response):
+            return asyncio.run(adapter.search("inner citadel"))
+
+    def test_fixture_reproduces_the_srcless_article_cover_cell(self):
+        """Guard the guard.
+
+        A fixture whose article rows carry a normal cover image parses fine
+        under the broken parser too, so assert the precondition rather than
+        trusting it: both kinds of row are present, both are ten columns
+        wide, and only the book rows have a "covers" src.
+        """
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(self.FIXTURE.read_text(), "html.parser")
+        table = soup.find("table", {"id": "tablelibgen"})
+        rows = [r for r in table.find_all("tr") if len(r.find_all("td")) >= 9]
+
+        kinds = []
+        for row in rows:
+            tds = row.find_all("td")
+            assert len(tds) == 10, "book and article rows share one layout"
+            badge = [
+                a.get("title")
+                for a in row.select("span.badge a[title]")
+                if a.get("title") in ("Book", "Journal article")
+            ]
+            assert badge, "every row must carry its object-type badge"
+            image = tds[0].find("img")
+            assert image is not None, "every row must carry a cover cell"
+            has_cover_src = "covers" in (image.get("src") or "")
+            assert has_cover_src == (badge[0] == "Book"), (
+                "the bug needs article rows with an empty cover src and book "
+                "rows with a real one"
+            )
+            kinds.append(badge[0])
+
+        assert kinds.count("Book") == 2
+        assert kinds.count("Journal article") == 2
+
+    def test_article_rows_survive_the_md5_filter(self, results):
+        """The headline symptom: article rows arrived md5-less and were lost."""
+        md5s = {r.md5 for r in results}
+        assert self.ARTICLE_MD5 in md5s
+        assert len(results) == 4, "two books and two articles, none dropped"
+
+    def test_article_row_fields_are_not_column_shifted(self, results):
+        article = next(r for r in results if r.md5 == self.ARTICLE_MD5)
+
+        assert article.author == "Rutherford, R. B."
+        assert article.extension == "pdf", "used to hold the file size"
+        assert article.size == "73 kB", "used to hold the page count"
+        assert article.year == "2001 October"
+        assert article.extra["language"] == "English"
+        assert article.extra["pages"] == "0"
+        assert "Classical Review" in article.title, "used to be empty"
+
+    def test_rows_declare_their_object_type(self, results):
+        by_md5 = {r.md5: r for r in results}
+
+        assert by_md5[self.ARTICLE_MD5].extra["content_type"] == "article"
+        assert by_md5[self.BOOK_MD5].extra["content_type"] == "book"
+
+    def test_book_rows_are_unchanged(self, results):
+        """The fix must not disturb the rows that already parsed."""
+        book = next(r for r in results if r.md5 == self.BOOK_MD5)
+
+        assert book.author == "Pierre Hadot, Michael Chase"
+        assert book.extension == "pdf"
+        assert book.size == "5 MB"
+        assert book.year == "2001"
+        assert book.extra["language"] == "English"
+        assert "Inner Citadel" in book.title

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -38,6 +38,7 @@ from .net import (
 # CRITICAL: Import is libgen_api_enhanced, NOT libgen_api
 from libgen_api_enhanced import LibgenSearch
 from libgen_api_enhanced import search_request as _lge_search_request
+from libgen_api_enhanced.book import Book as _LgeBook
 
 logger = logging.getLogger("zlibrary.sources")
 
@@ -194,6 +195,139 @@ class _RequestsWithUA:
 
 _search_requests = _RequestsWithUA()
 _lge_search_request.requests = _search_requests
+
+
+# libgen.li labels every result row with an object-type badge in the title
+# cell (`<span class="badge"><a title="Journal article">a</a></span>`). The
+# labels seen on a live capture are "Book" and "Journal article"; anything
+# else falls through to a slugified form of the badge's own text rather than
+# being guessed at.
+_OBJECT_TYPE_BY_BADGE = {
+    "book": "book",
+    "fiction book": "book",
+    "journal article": "article",
+    "magazine": "magazine",
+    "comics": "comics",
+    "standart": "standard",
+}
+
+
+def _row_object_type(title_cell) -> str:
+    """Object type for a results row, read from its badge. '' if unlabelled."""
+    for anchor in title_cell.select("span.badge a[title]"):
+        label = (anchor.get("title") or "").strip().lower()
+        if label:
+            return _OBJECT_TYPE_BY_BADGE.get(label, label.replace(" ", "_"))
+    return ""
+
+
+def _has_cover_cell(tds) -> bool:
+    """Whether a row's first cell is the cover column.
+
+    Structural, not cosmetic: the cover cell holds an image and no text of its
+    own. Upstream instead requires the literal string "covers" in the image
+    src, which is exactly what article rows fail (see `_get_books`).
+    """
+    first = tds[0]
+    return first.find("img") is not None and not first.get_text(strip=True)
+
+
+def _get_books(self, table):
+    """Replacement for `SearchRequest.get_books` that keeps columns aligned.
+
+    libgen-api-enhanced 1.3 locates the cover column by matching "covers" in
+    the first cell's `<img src>`. On libgen.li every result row carries a
+    cover cell, but journal-article rows carry `<img src="">` there, so the
+    match fails, the row is read with offset 0, and every field lands one
+    column to the left: empty title, the citation text in `author`, a file
+    size like "73 kB" in `extension`, "0" in `size`, a date in `language` —
+    and no md5 at all, because the mirror links are then read from the
+    extension cell, which holds no links (#132).
+
+    The compensation belongs here rather than in `_to_unified`: by the time a
+    `Book` object exists its md5 has already been dropped, so no post-hoc
+    un-shift can recover it and article rows would stay undownloadable.
+    Installed by the same monkeypatch mechanism as the UA shim above.
+
+    Book and article rows share one ten-column layout — verified against a
+    live libgen.li capture on 2026-08-23, trimmed into
+    `test_files/libgen/mixed_book_article_results.html`. They differ only in
+    the cover `<img src>` and in the object-type badge, which this parser
+    reads onto `Book.content_type` so callers can tell an article from a book
+    instead of inferring it from mangled fields.
+
+    Remove when libgen-api-enhanced detects the cover column structurally and
+    exposes the object type; `pyproject.toml` pins `libgen-api-enhanced>=1.3`.
+    """
+    for row in table.find_all("tr"):
+        tds = row.find_all("td")
+        if len(tds) < 9:
+            continue
+
+        offset = 1 if _has_cover_cell(tds) else 0
+        if len(tds) < offset + 9:
+            continue
+
+        cover_url = None
+        if offset:
+            cover_img = tds[0].find("img", src=True)
+            src = cover_img["src"] if cover_img else ""
+            if "covers" in src:
+                cover_url = urljoin(self.mirror, src).replace("_small", "")
+
+        title_cell = tds[offset]
+        title_links = title_cell.find_all("a", href=True)
+        if not title_links:
+            continue
+
+        raw_title = "".join([link.text for link in title_links])
+        title = re.sub(r"\s+", " ", raw_title.strip())
+        title = re.sub(r"[^A-Za-z0-9 ]+", "", title.strip())
+        id_param = parse_qs(urlparse(title_links[0]["href"]).query).get("id", [""])[0]
+
+        author = tds[offset + 1].get_text(strip=True)
+        publisher = tds[offset + 2].get_text(strip=True)
+        year = tds[offset + 3].get_text(strip=True)
+        language = tds[offset + 4].get_text(strip=True)
+        pages = tds[offset + 5].get_text(strip=True)
+
+        size_link = tds[offset + 6].find("a")
+        size = (
+            size_link.get_text(strip=True)
+            if size_link
+            else tds[offset + 6].get_text(strip=True)
+        )
+
+        extension = tds[offset + 7].get_text(strip=True)
+
+        mirror_links = tds[offset + 8].find_all("a", href=True)
+        mirrors = self.get_mirrors(mirror_links[:4])
+
+        md5 = ""
+        if mirrors[0]:
+            md5 = parse_qs(urlparse(mirrors[0]).query).get("md5", [""])[0]
+
+        book = _LgeBook(
+            id_param,
+            title,
+            author,
+            publisher,
+            year,
+            language,
+            pages,
+            size,
+            extension,
+            md5,
+            mirrors[:4],
+            cover_url,
+            "",
+            "",
+        )
+        book.content_type = _row_object_type(title_cell)
+        yield book
+
+
+_lge_search_request.SearchRequest.get_books = _get_books
 
 # Mirrors tried in order when resolving a download. Different mirrors hand off
 # to different CDN nodes (cdn3/cdn4/... .booksdl.lc) and those nodes fail
@@ -428,14 +562,15 @@ class LibgenAdapter(SourceAdapter):
     def _to_unified(self, results) -> List[UnifiedBookResult]:
         """Convert libgen-api-enhanced books into UnifiedBookResult.
 
-        Rows whose md5 is not a full 32-hex digest are dropped:
-        journal-article rows come back column-shifted from the parser
-        (empty md5, or another column's value — an ISBN, a citation — in
-        the md5 field, #132), and anything short of a real md5 cannot be
-        resolved by ads.php. Same rule as the production canary's
-        usable-row check. The full per-object-type parse is #132's job;
-        this filter is the minimal slice that keeps #134's wider search
-        results usable.
+        Rows whose md5 is not a full 32-hex digest are still dropped —
+        anything short of a real md5 cannot be resolved by ads.php, the same
+        rule as the production canary's usable-row check. What changed in
+        #132 is which rows that catches: journal-article rows used to arrive
+        column-shifted and md5-less from the upstream parser and were dropped
+        wholesale, and now parse correctly (see `_get_books`), so they reach
+        callers as real results carrying `extra["content_type"] == "article"`.
+        The filter remains as the backstop for a row shape neither this
+        adapter nor upstream anticipated.
         """
         dropped = sum(
             1
@@ -466,6 +601,10 @@ class LibgenAdapter(SourceAdapter):
                     "id": getattr(book, "id", ""),
                     "language": getattr(book, "language", ""),
                     "pages": getattr(book, "pages", ""),
+                    # "book" | "article" | "" when the row carried no badge.
+                    # A caller that wants only monographs filters on this
+                    # rather than on the shape of a mangled title (#132).
+                    "content_type": getattr(book, "content_type", "") or "",
                 },
             )
             for book in results

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -276,14 +276,21 @@ def _get_books(self, table):
                 cover_url = urljoin(self.mirror, src).replace("_small", "")
 
         title_cell = tds[offset]
-        title_links = title_cell.find_all("a", href=True)
-        if not title_links:
+        edition_links = [
+            link
+            for link in title_cell.find_all("a", href=True, recursive=False)
+            if urlparse(link["href"]).path.rsplit("/", maxsplit=1)[-1] == "edition.php"
+            and parse_qs(urlparse(link["href"]).query).get("id", [""])[0].isdigit()
+            and link.get_text(" ", strip=True)
+        ]
+        if not edition_links:
             continue
 
-        raw_title = "".join([link.text for link in title_links])
+        edition_link = edition_links[0]
+        raw_title = edition_link.get_text(" ", strip=True)
         title = re.sub(r"\s+", " ", raw_title.strip())
         title = re.sub(r"[^A-Za-z0-9 ]+", "", title.strip())
-        id_param = parse_qs(urlparse(title_links[0]["href"]).query).get("id", [""])[0]
+        id_param = parse_qs(urlparse(edition_link["href"]).query)["id"][0]
 
         author = tds[offset + 1].get_text(strip=True)
         publisher = tds[offset + 2].get_text(strip=True)

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -290,6 +290,13 @@ LIBGEN_PROBE_MARGIN = 30.0
 # truthiness check would call that healthy (Codex on #133; the #132 shape).
 MD5_PATTERN = re.compile(r"[0-9a-fA-F]{32}")
 
+# This query yielded the article rows captured for #132. Unlike the former
+# Pride and Prejudice canary, it makes the doctor exercise the article title
+# selector, edition ID, and MD5 path in the production adapter.
+LIBGEN_ARTICLE_CANARY = "The Inner Citadel Meditations Marcus Aurelius"
+LIBGEN_ARTICLE_CANARY_EDITION_ID = "76430726"
+LIBGEN_ARTICLE_CANARY_TITLE_MARKER = "The Inner Citadel P Hadot"
+
 
 def libgen_probe_timeout(config, min_request_interval: float = 0.0) -> float:
     """Wall clock the production adapter may legitimately spend on one search.
@@ -322,8 +329,33 @@ def _usable_row(result) -> bool:
     )
 
 
-async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
-    """LibGen is the router's fallback source; mirrors rotate frequently.
+def _usable_article_row(result) -> bool:
+    """Whether a parsed article row is one the downloader could act on."""
+    return _usable_row(result) and (
+        (getattr(result, "extra", {}) or {}).get("content_type") == "article"
+    )
+
+
+def _usable_article_canary_row(result) -> bool:
+    """Whether a parsed row proves this article canary retained its identity."""
+    extra = getattr(result, "extra", {}) or {}
+    return (
+        _usable_article_row(result)
+        and extra.get("id") == LIBGEN_ARTICLE_CANARY_EDITION_ID
+        and LIBGEN_ARTICLE_CANARY_TITLE_MARKER.casefold()
+        in (result.title or "").casefold()
+    )
+
+
+async def _probe_libgen_search(
+    client: httpx.AsyncClient,
+    adapter,
+    *,
+    canary: str,
+    name: str,
+    content_type: Optional[str] = None,
+) -> ProbeResult:
+    """Run a production-adapter LibGen canary against one expected row type.
 
     The probe goes through the PRODUCTION adapter, not a hand-rolled fetch.
     On 2026-08-17 (#124) the mirror served its UA-blocklist stub (default
@@ -337,13 +369,9 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
     adapter builds production's own HTTP stack.
     """
     from lib.sources.errors import AllSourcesFailedError  # noqa: PLC0415
-    from lib.sources.libgen import (  # noqa: PLC0415
-        LibgenAdapter,
-        LibgenUserAgentBlocked,
-    )
+    from lib.sources.libgen import LibgenUserAgentBlocked  # noqa: PLC0415
 
-    canary = "Pride and Prejudice"
-    config = get_source_config()
+    config = adapter.config
     try:
         # #106's budgets bound the adapter internally, but the canary carries
         # its own deadline too: a canary that can hang has the exact defect
@@ -351,8 +379,8 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
         # the adapter's own configured mirror-walk budget rather than fixed at
         # 90s, which was below the ~165s default worst case (Codex on #133).
         results = await asyncio.wait_for(
-            LibgenAdapter(config).search(canary),
-            timeout=libgen_probe_timeout(config, LibgenAdapter.MIN_REQUEST_INTERVAL),
+            adapter.search(canary),
+            timeout=libgen_probe_timeout(config, adapter.MIN_REQUEST_INTERVAL),
         )
     except Exception as exc:  # noqa: BLE001
         # A UA block is not upstream drift and must not be summarised as one.
@@ -374,7 +402,7 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
             and all(isinstance(f, LibgenUserAgentBlocked) for f in failures)
         )
         return ProbeResult(
-            name="libgen:search",
+            name=name,
             ok=False,
             blocked=blocked,
             detail=f"adapter search failed: {type(exc).__name__}: {exc}",
@@ -385,13 +413,25 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
     # a resolvable md5 can never be downloaded (Codex on #128; the article-row
     # column-shift in #132 is exactly this shape). Shape, not truthiness — a
     # shifted column can carry an ISBN or a citation here and still be truthy.
-    usable = [r for r in results if _usable_row(r)]
+    usable = [
+        r
+        for r in results
+        if (
+            _usable_article_canary_row(r)
+            if content_type == "article"
+            else _usable_row(r)
+        )
+    ]
+    row_description = f" {content_type}" if content_type else ""
     if usable:
         return ProbeResult(
-            name="libgen:search",
+            name=name,
             ok=True,
             detail=(
-                f"{len(usable)} usable result(s) (32-hex md5 + title) of "
+                f"{len(usable)} usable{row_description} result(s) "
+                f"({content_type + ' content type + ' if content_type else ''}"
+                f"{'expected edition ID + title marker + ' if content_type else ''}"
+                f"32-hex md5 + title) of "
                 f"{len(results)} parsed by the production adapter "
                 f"for canary {canary!r}"
             ),
@@ -399,17 +439,19 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
         )
     if results:
         return ProbeResult(
-            name="libgen:search",
+            name=name,
             ok=False,
             detail=(
-                f"{len(results)} parsed result(s) but NONE usable "
-                f"(a 32-hex md5 and a nonblank title) for canary "
+                f"{len(results)} parsed result(s) but NONE usable{row_description} "
+                f"({content_type + ' content type, ' if content_type else ''}"
+                f"{'the expected edition ID, title marker, ' if content_type else ''}"
+                "a 32-hex md5 and a nonblank title) for canary "
                 f"{canary!r} — row-markup drift"
             ),
             required=False,
         )
     return ProbeResult(
-        name="libgen:search",
+        name=name,
         ok=False,
         detail=(
             f"0 parsed results for canary {canary!r} — page had a results "
@@ -417,6 +459,65 @@ async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
         ),
         required=False,
     )
+
+
+async def probe_libgen(client: httpx.AsyncClient) -> ProbeResult:
+    """Check that the production adapter can parse a normal LibGen book row."""
+    from lib.sources.libgen import LibgenAdapter  # noqa: PLC0415
+
+    adapter = LibgenAdapter(get_source_config())
+    try:
+        return await _probe_libgen_search(
+            client,
+            adapter,
+            canary="Pride and Prejudice",
+            name="libgen:search",
+        )
+    finally:
+        await adapter.close()
+
+
+async def probe_libgen_article(client: httpx.AsyncClient) -> ProbeResult:
+    """Check that the production adapter parses an article row with an MD5."""
+    from lib.sources.libgen import LibgenAdapter  # noqa: PLC0415
+
+    adapter = LibgenAdapter(get_source_config())
+    try:
+        return await _probe_libgen_search(
+            client,
+            adapter,
+            canary=LIBGEN_ARTICLE_CANARY,
+            name="libgen:article-search",
+            content_type="article",
+        )
+    finally:
+        await adapter.close()
+
+
+async def probe_libgen_canaries(
+    client: httpx.AsyncClient,
+) -> tuple[ProbeResult, ProbeResult]:
+    """Run book and article canaries through one paced production adapter."""
+    from lib.sources.libgen import LibgenAdapter  # noqa: PLC0415
+
+    adapter = LibgenAdapter(get_source_config())
+    try:
+        book = await _probe_libgen_search(
+            client,
+            adapter,
+            canary="Pride and Prejudice",
+            name="libgen:search",
+        )
+        article = await _probe_libgen_search(
+            client,
+            adapter,
+            canary=LIBGEN_ARTICLE_CANARY,
+            name="libgen:article-search",
+            content_type="article",
+        )
+        return book, article
+    finally:
+        await adapter.close()
 
 
 def _extract_libgen_key(
@@ -616,13 +717,16 @@ async def run_probes() -> list[ProbeResult]:
         follow_redirects=True,
         headers={"User-Agent": "zlibrary-mcp-upstream-check"},
     ) as client:
-        zlib_results, annas, libgen, libgen_download = await asyncio.gather(
-            probe_zlibrary_eapi(client),
-            probe_annas(client),
-            probe_libgen(client),
-            probe_libgen_download(client),
+        zlib_task = asyncio.create_task(probe_zlibrary_eapi(client))
+        annas_task = asyncio.create_task(probe_annas(client))
+        download_task = asyncio.create_task(probe_libgen_download(client))
+        # Both canaries use one adapter so its per-instance rate limit applies
+        # between their searches. Keep the existing book canary first.
+        libgen, libgen_article = await probe_libgen_canaries(client)
+        zlib_results, annas, libgen_download = await asyncio.gather(
+            zlib_task, annas_task, download_task
         )
-    return [*zlib_results, annas, libgen, libgen_download]
+    return [*zlib_results, annas, libgen, libgen_article, libgen_download]
 
 
 def actionable_failures(results: list[ProbeResult]) -> list[ProbeResult]:

--- a/test_files/libgen/mixed_book_article_results.html
+++ b/test_files/libgen/mixed_book_article_results.html
@@ -1,0 +1,77 @@
+<!-- Trimmed from a live libgen.li capture (2026-08-23), query
+     "The Inner Citadel Meditations Marcus Aurelius": two book rows and
+     two journal-article rows from one results table. See #132. -->
+<html><body>
+<table class="table table-striped" id="tablelibgen"><thead><tr>
+<th scope="col"></th>
+<th class="first_col" scope="col"><nobr>
+ID  
+Time add.  
+Title  
+Series </nobr></th>
+<th scope="col"><nobr>Author(s) </nobr></th>
+<th scope="col"><nobr>Publisher </nobr></th>
+<th scope="col"><nobr>Year </nobr></th>
+<th scope="col">Language</th>
+<th scope="col">Pages</th>
+<th scope="col"><nobr>Size  </nobr></th>
+<th scope="col"><nobr>Ext. </nobr></th>
+<th scope="col">Mirrors</th>
+</tr></thead><tbody><tr>
+<td><a href="edition.php?id=137175221"><img src="/covers/1397000/3b516fa296c861195bc94fad9bddda9e_small.jpg" style="max-height:70px;max-width:150px;height:auto;width:auto;"/></a></td>
+<td><b>Meditations of Marcus Aurelius</b><br/><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=137175221" title="Add/Edit : 2015-10-02/2021-10-07; ID: 92437668&lt;br&gt;Hadot - The Inner Citadel - The Meditations of Marcus Aurelius">The Inner Citadel: The Meditations of Marcus Aurelius <i></i></a><br/><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=137175221" title="Add/Edit : 2015-10-02/2021-10-07; ID: 92437668&lt;br&gt;Hadot - The Inner Citadel - The Meditations of Marcus Aurelius"><i><font color="green"> 0674007077; 9780674007079</font></i></a>
+<nobr><span class="badge badge-primary"><a data-html="true" data-placement="bottom" data-toggle="tooltip" title="Book">b</a></span>
+<span "="" class="badge badge-secondary">l 1397954</span></nobr>
+</td>
+<td>Pierre Hadot, Michael Chase</td>
+<td>Harvard University Press</td>
+<td><nobr>2001</nobr></td>
+<td>English</td>
+<td>0 / 368</td>
+<td><nobr><a href="/file.php?id=92437668">5 MB</a></nobr></td>
+<td>pdf</td>
+<td><nobr><a data-html="true" data-placement="bottom" data-toggle="tooltip" href="/ads.php?md5=3b516fa296c861195bc94fad9bddda9e" title="libgen"><span class="badge badge-primary">1</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://libgen.xyz/book/3b516fa296c861195bc94fad9bddda9e" title="libgen.xyz"><span class="badge badge-primary">2</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://en.annas-archive.gl/md5/3b516fa296c861195bc94fad9bddda9e?r=Ax2w6jC" title="anna's archive"><span class="badge badge-primary">3</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://libgen.pw/book/3b516fa296c861195bc94fad9bddda9e" title="libgen.pw"><span class="badge badge-primary">4</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://randombook.org/book/3b516fa296c861195bc94fad9bddda9e" title="randombook.org"><span class="badge badge-primary">5</span></a> </nobr></td>
+</tr><tr>
+<td><a href="edition.php?id=76430726"><img src="" style="max-height:70px;max-width:150px;height:auto;width:auto;"/></a></td>
+<td><b><a href="series.php?id=23549">The Classical Review   </a><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=76430726" title="Add/Edit : 2019-02-24/2021-07-21; ID: 76050070&lt;br&gt;"><i> 2001-oct vol. 51 iss. 2</i></a> pp.298—300</b><br/><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=76430726" title="Add/Edit : 2019-02-24/2021-07-21; ID: 76050070&lt;br&gt;">The Inner Citadel P. Hadot:  The Inner Citadel: the Meditations of Marcus Aurelius . Pp. x + 351. Cambridge, MA and London: Harvard University Press, 1998. Cased, $27.95. ISBN: 0-674-46171-1. <i></i></a><br/><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=76430726" title="Add/Edit : 2019-02-24/2021-07-21; ID: 76050070&lt;br&gt;"><i><font color="green">DOI: 10.1093/cr/51.2.298</font></i></a>
+<nobr><span class="badge badge-primary"><a data-html="true" data-placement="bottom" data-toggle="tooltip" title="Journal article">a</a></span>
+<span "="" class="badge badge-secondary">a 70182330</span></nobr>
+</td>
+<td>Rutherford, R. B.</td>
+<td></td>
+<td><nobr>2001 October</nobr></td>
+<td>English</td>
+<td>0</td>
+<td><nobr><a href="/file.php?id=76050070">73 kB</a></nobr></td>
+<td>pdf</td>
+<td><a data-html="true" data-placement="bottom" data-toggle="tooltip" href="/ads.php?md5=e3f85ebc6faa062bceb95b349f369672&amp;downloadname=10.1093/cr/51.2.298" title="libgen"><span class="badge badge-primary">Libgen</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="http://sci-hub.ru/10.1093/cr/51.2.298" title="sci-hub"><span class="badge badge-primary">Sci-Hub</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://libgen.xyz/book/e3f85ebc6faa062bceb95b349f369672" title="libgen.xyz"><span class="badge badge-primary">libgen.xyz</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://libgen.pw/book/e3f85ebc6faa062bceb95b349f369672" title="libgen.pw"><span class="badge badge-primary">libgen.pw</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://en.annas-archive.gl/md5/e3f85ebc6faa062bceb95b349f369672?r=Ax2w6jC" title="anna's archive"><span class="badge badge-primary">Anna's arch</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://randombook.org/book/e3f85ebc6faa062bceb95b349f369672" title="Randombook"><span class="badge badge-primary">Randombook</span></a> </td>
+</tr><tr>
+<td><a href="edition.php?id=49104818"><img src="" style="max-height:70px;max-width:150px;height:auto;width:auto;"/></a></td>
+<td><b><a href="series.php?id=17466">Mind   </a><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=49104818" title="Add/Edit : 2015-06-21/2021-07-21; ID: 49051038&lt;br&gt;"><i> 2001-jul 01 vol. 110 iss. 439</i></a> pp.764—767</b><br/><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=49104818" title="Add/Edit : 2015-06-21/2021-07-21; ID: 49051038&lt;br&gt;">The Inner Citadel: the Meditations of Marcus Aurelius. Pierre Hadot <i></i></a><br/><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=49104818" title="Add/Edit : 2015-06-21/2021-07-21; ID: 49051038&lt;br&gt;"><i><font color="green">DOI: 10.1093/mind/110.439.764</font></i></a>
+<nobr><span class="badge badge-primary"><a data-html="true" data-placement="bottom" data-toggle="tooltip" title="Journal article">a</a></span>
+<span "="" class="badge badge-secondary">a 42724128</span></nobr>
+</td>
+<td>Baltzly, D.</td>
+<td></td>
+<td><nobr>2001 July 01</nobr></td>
+<td>English</td>
+<td>0</td>
+<td><nobr><a href="/file.php?id=49051038">68 kB</a></nobr></td>
+<td>pdf</td>
+<td><a data-html="true" data-placement="bottom" data-toggle="tooltip" href="/ads.php?md5=0aaced84265e767256fa026c21e6ab24&amp;downloadname=10.1093/mind/110.439.764" title="libgen"><span class="badge badge-primary">Libgen</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="http://sci-hub.ru/10.1093/mind/110.439.764" title="sci-hub"><span class="badge badge-primary">Sci-Hub</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://libgen.xyz/book/0aaced84265e767256fa026c21e6ab24" title="libgen.xyz"><span class="badge badge-primary">libgen.xyz</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://libgen.pw/book/0aaced84265e767256fa026c21e6ab24" title="libgen.pw"><span class="badge badge-primary">libgen.pw</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://en.annas-archive.gl/md5/0aaced84265e767256fa026c21e6ab24?r=Ax2w6jC" title="anna's archive"><span class="badge badge-primary">Anna's arch</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://randombook.org/book/0aaced84265e767256fa026c21e6ab24" title="Randombook"><span class="badge badge-primary">Randombook</span></a> </td>
+</tr><tr>
+<td><a href="edition.php?id=142174989"><img src="/covers/3531000/1bf9dd21f01e3b17c82a44417eee7f58_small.jpg" style="max-height:70px;max-width:150px;height:auto;width:auto;"/></a></td>
+<td><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=142174989" title="Add/Edit : 2022-07-28/2022-08-07; ID: 97935113&lt;br&gt;The Inner Citadel_ The Meditations of Marc - Pierre Hadot">The Inner Citadel: The Meditations of Marcus Aurelius <i>Revised</i></a><br/><a data-html="true" data-placement="right" data-toggle="tooltip" href="edition.php?id=142174989" title="Add/Edit : 2022-07-28/2022-08-07; ID: 97935113&lt;br&gt;The Inner Citadel_ The Meditations of Marc - Pierre Hadot"><i><font color="green"> 0674007077; 9780674007079</font></i></a>
+<nobr><span class="badge badge-primary"><a data-html="true" data-placement="bottom" data-toggle="tooltip" title="Book">b</a></span>
+<span "="" class="badge badge-secondary">l 3531632</span></nobr>
+</td>
+<td>Pierre Hadot</td>
+<td>Harvard University Press</td>
+<td><nobr>2001</nobr></td>
+<td>English</td>
+<td>0 / 368</td>
+<td><nobr><a href="/file.php?id=97935113">681 kB</a></nobr></td>
+<td>epub</td>
+<td><nobr><a data-html="true" data-placement="bottom" data-toggle="tooltip" href="/ads.php?md5=1bf9dd21f01e3b17c82a44417eee7f58" title="libgen"><span class="badge badge-primary">1</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://libgen.xyz/book/1bf9dd21f01e3b17c82a44417eee7f58" title="libgen.xyz"><span class="badge badge-primary">2</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://en.annas-archive.gl/md5/1bf9dd21f01e3b17c82a44417eee7f58?r=Ax2w6jC" title="anna's archive"><span class="badge badge-primary">3</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://libgen.pw/book/1bf9dd21f01e3b17c82a44417eee7f58" title="libgen.pw"><span class="badge badge-primary">4</span></a> <a data-html="true" data-placement="bottom" data-toggle="tooltip" href="https://randombook.org/book/1bf9dd21f01e3b17c82a44417eee7f58" title="randombook.org"><span class="badge badge-primary">5</span></a> </nobr></td>
+</tr></tbody></table>
+</body></html>


### PR DESCRIPTION
Closes #132

## Fix shape: parse them properly, marked with `content_type`

The issue offered two shapes. The column map turned out to be fully discoverable — **book and article rows on libgen.li share one ten-column layout** — so this parses article rows correctly rather than detecting and dropping them. Dropping would have discarded real, downloadable results: every article row carries a genuine `ads.php?md5=…` mirror link.

## Root cause (upstream, compensated here)

The shift happens in `libgen-api-enhanced` 1.3, not in `_to_unified`. `SearchRequest.get_books` locates the cover column by matching the literal string `covers` in the first cell's `<img src>`. Article rows carry `<img src="">` in their cover cell, so the match fails, the row is read with `offset = 0`, and every field lands one column left — the exact symptom the issue reports, including the empty md5, which comes from reading the mirror links out of the extension cell.

`_to_unified` cannot repair this: by the time a `Book` object exists the md5 has already been dropped on the floor. So the adapter replaces `SearchRequest.get_books` with a corrected copy — the same monkeypatch mechanism already used for the User-Agent shim — which:

- detects the cover column structurally (an image cell with no text of its own) instead of by src pattern;
- reads libgen.li's per-row object-type badge (`title="Book"` / `title="Journal article"`) onto `Book.content_type`, surfaced as `extra["content_type"]`.

The `#138` md5 filter stays, now as a backstop for row shapes neither side anticipated rather than as the thing that swallows every article.

## Verification

New fixture `test_files/libgen/mixed_book_article_results.html`, trimmed from a live libgen.li capture (query "The Inner Citadel Meditations Marcus Aurelius"): two book rows, two journal-article rows, one table. The regression tests drive the real `LibgenAdapter.search()` over it with `requests.get` patched — no network from the test — and include a "guard the guard" test asserting the fixture actually reproduces the empty-`src` cover cell that triggers the bug.

- Before the fix (`lib/sources/libgen.py` stashed): **3 failed, 2 passed** — the article md5 never reaches the caller, so the field and `content_type` assertions fail too.
- After: **5 passed**.
- Full Python unit suite: **1351 passed, 3 skipped, 7 xfailed** (3 skips are the pre-existing Tesseract-absent OCR tests). `ruff check` and `ruff format --check` clean.

Not verified: behaviour against libgen mirrors other than `li`, and against object types beyond book/article (magazine, comics, standards badges are mapped by name but unobserved).