### PR TITLE
fix(sources): resume partial transfers instead of restarting from zero (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A download that died part-way through restarted from byte zero, so a CDN
+  node that drops large transfers could never finish one.** Measured during a
+  ~30-text sweep on 2026-08-17: `cdn3.booksdl.lc` behind the `li` mirror cut
+  ~10 transfers of files over roughly 10 MB at varying offsets, costing the
+  sweep two books despite valid resolved keys. A transfer that stops early now
+  re-requests the remainder with a `Range` header
+  (`BOOK_SOURCE_DOWNLOAD_RESUME_ATTEMPTS`, default 2, inside the existing
+  `BOOK_SOURCE_DOWNLOAD_TIMEOUT` rather than extending it), and the bytes it
+  staged survive into the next mirror's attempt, so rotating CDN nodes costs
+  the remainder instead of the whole file. Mid-transfer death is now its own
+  reason code, `partial_transfer`, distinct from a host that never answered. A
+  resumed file is re-digested whole against the catalog MD5 before it is
+  published, a resume is refused unless the server answers `206` with a
+  `Content-Range` that continues exactly where the staged bytes end, and a
+  server that ignores `Range` and answers `200` restarts cleanly rather than
+  appending to a prefix the body already contains (#135).
 - **`search_multi_source` could hang forever, and leave the Python process
   behind when it did.** Three defects compounded: the vendored
   `libgen_api_enhanced` calls `requests.get` with no `timeout=` (and catches a

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -1231,13 +1231,9 @@ class TestDownloadBook:
         """Changing unique staging suffixes cannot overwrite another attempt."""
         body = b"%PDF-1.7 owned body"
         digest = hashlib.md5(body).hexdigest()
-        attempt = tmp_path / ".source-fixed.part"
-        sibling = tmp_path / ".source-fixed.pdf"
+        attempt = tmp_path / f".source-{digest}-fixed.part"
+        sibling = tmp_path / f".source-{digest}-fixed.pdf"
         sibling.write_bytes(b"another attempt")
-
-        def fixed_mkstemp(**_kwargs):
-            descriptor = os.open(attempt, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
-            return descriptor, str(attempt)
 
         class Response:
             url = httpx.URL("https://cdn.example/book.pdf")
@@ -1269,7 +1265,7 @@ class TestDownloadBook:
             def stream(self, *_args):
                 return Stream()
 
-        mocker.patch("python_bridge.tempfile.mkstemp", side_effect=fixed_mkstemp)
+        mocker.patch("python_bridge._staging_token", return_value="fixed")
         mocker.patch("httpx.AsyncClient", Client)
 
         with pytest.raises(FileExistsError):
@@ -1997,7 +1993,15 @@ asyncio.run(python_bridge.main())
     async def test_redirected_partial_read_timeout_attributes_the_cdn_host(
         self, tmp_path, mocker, monkeypatch, capsys
     ):
-        """After a redirect, the failing request host owns the failure."""
+        """After a redirect, the failing request host owns the failure.
+
+        The reason is `partial_transfer` rather than `read_timeout` because
+        bytes reached disk before the body stopped: what the operator needs to
+        know is that this CDN host truncates transfers, which is a different
+        remedy from a host that never answers (#135). A stall that delivers
+        nothing is still classified by the transport error — see
+        test_source_transfer_failures_reach_main_as_typed_envelopes.
+        """
         cdn_request = httpx.Request("GET", "https://cdn.example/file")
 
         class FakeResponse:
@@ -2063,7 +2067,8 @@ asyncio.run(python_bridge.main())
         envelope = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
         failure_envelope = envelope["details"]["failures"][0]
         assert failure_envelope["host"] == "cdn.example"
-        assert failure_envelope["reason"] == "read_timeout"
+        assert failure_envelope["reason"] == "partial_transfer"
+        assert "ReadTimeout" in failure_envelope["detail"]
         assert envelope["details"]["operation"] == "download"
         assert not (tmp_path / "0123456789abcdef0123456789abcdef.download").exists()
 
@@ -2719,3 +2724,497 @@ class TestDownloadHonoursTheLibgenUserAgentOverride:
             "a LibGen-scoped override reaching Anna's is both a behaviour "
             "change on an unrelated transfer and an identifier leak"
         )
+
+
+# --- Partial-transfer recovery (#135) ---------------------------------------
+
+# A body with a recognisable signature and enough length that a cut through it
+# is unambiguous. The real failure is a CDN dropping a >10MB transfer; nothing
+# here needs that size, only a transfer with a middle.
+RESUME_BODY = b"%PDF-1.7 " + bytes(range(256)) * 40
+RESUME_DIGEST = hashlib.md5(RESUME_BODY).hexdigest()
+RESUME_CUT = 4096
+
+
+class ScriptedResponse:
+    """One scripted HTTP response, doubling as its own stream context.
+
+    `fail_after` reproduces the observed failure: N bytes arrive and the
+    connection then dies. No live request is made anywhere in these tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        body=b"",
+        status_code=200,
+        headers=None,
+        url="https://cdn3.booksdl.test/file",
+        fail_after=None,
+        error=None,
+    ):
+        self.body = body
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.url = httpx.URL(url)
+        self.fail_after = fail_after
+        self.error = error or httpx.RemoteProtocolError(
+            "peer closed connection without sending complete message body"
+        )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=httpx.Request("GET", self.url),
+                response=httpx.Response(self.status_code),
+            )
+
+    async def aiter_bytes(self, _chunk_size=65536):
+        if self.fail_after is None:
+            yield self.body
+            return
+        yield self.body[: self.fail_after]
+        raise self.error
+
+
+class ScriptedTransport:
+    """httpx.AsyncClient stand-in that records what each request asked for."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    @property
+    def ranges(self):
+        return [headers.get("Range") for _url, headers in self.requests]
+
+    def install(self, mocker):
+        transport = self
+
+        class Client:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def stream(self, _method, url, **kwargs):
+                transport.requests.append((url, dict(kwargs.get("headers") or {})))
+                assert transport.responses, "the transfer made an unscripted request"
+                return transport.responses.pop(0)
+
+        mocker.patch("httpx.AsyncClient", Client)
+        return self
+
+
+def content_range(start, total):
+    return f"bytes {start}-{total - 1}/{total}"
+
+
+@pytest.fixture
+def resumable(monkeypatch):
+    """Lower the resume floor so a small scripted body exercises the path."""
+    monkeypatch.setattr(python_bridge, "RESUMABLE_PARTIAL_MIN_BYTES", 64, raising=False)
+    monkeypatch.setattr(python_bridge, "RESUME_BACKOFF_SECONDS", 0, raising=False)
+
+
+class TestPartialTransferRecovery:
+    """A transfer that dies mid-body resumes instead of restarting (#135)."""
+
+    @pytest.mark.asyncio
+    async def test_dropped_transfer_resumes_from_the_staged_offset(
+        self, tmp_path, mocker, resumable
+    ):
+        """The retry asks for the remainder and the file is assembled whole."""
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                    fail_after=RESUME_CUT,
+                ),
+                ScriptedResponse(
+                    body=RESUME_BODY[RESUME_CUT:],
+                    status_code=206,
+                    headers={
+                        "content-type": "application/pdf",
+                        "content-range": content_range(RESUME_CUT, len(RESUME_BODY)),
+                    },
+                ),
+            ]
+        ).install(mocker)
+
+        result = await python_bridge._download_url_to_file(
+            "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+        )
+
+        assert transport.ranges == [None, f"bytes={RESUME_CUT}-"]
+        assert Path(result).read_bytes() == RESUME_BODY
+        assert Path(result).stat().st_size == len(RESUME_BODY)
+        assert not list(tmp_path.glob(".source-*.part"))
+
+    @pytest.mark.asyncio
+    async def test_truncated_body_against_declared_length_resumes(
+        self, tmp_path, mocker, resumable
+    ):
+        """A body that ends early WITHOUT erroring is still a partial transfer."""
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY[:RESUME_CUT],
+                    headers={
+                        "content-type": "application/pdf",
+                        "content-length": str(len(RESUME_BODY)),
+                    },
+                ),
+                ScriptedResponse(
+                    body=RESUME_BODY[RESUME_CUT:],
+                    status_code=206,
+                    headers={
+                        "content-type": "application/pdf",
+                        "content-range": content_range(RESUME_CUT, len(RESUME_BODY)),
+                    },
+                ),
+            ]
+        ).install(mocker)
+
+        result = await python_bridge._download_url_to_file(
+            "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+        )
+
+        assert transport.ranges == [None, f"bytes={RESUME_CUT}-"]
+        assert Path(result).read_bytes() == RESUME_BODY
+
+    @pytest.mark.asyncio
+    async def test_server_that_ignores_range_restarts_rather_than_appends(
+        self, tmp_path, mocker, resumable
+    ):
+        """A 200 answer to a Range request is the whole file, not a remainder."""
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                    fail_after=RESUME_CUT,
+                ),
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    status_code=200,
+                    headers={"content-type": "application/pdf"},
+                ),
+            ]
+        ).install(mocker)
+
+        result = await python_bridge._download_url_to_file(
+            "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+        )
+
+        assert transport.ranges == [None, f"bytes={RESUME_CUT}-"]
+        assert Path(result).read_bytes() == RESUME_BODY
+        assert Path(result).stat().st_size == len(RESUME_BODY)
+
+    @pytest.mark.asyncio
+    async def test_resume_that_returns_a_different_file_is_rejected(
+        self, tmp_path, mocker, resumable
+    ):
+        """Concatenating someone else's bytes must fail, never report success."""
+        other = b"%PDF-1.7 an entirely different book" * 400
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                    fail_after=RESUME_CUT,
+                ),
+                ScriptedResponse(
+                    body=other[RESUME_CUT:],
+                    status_code=206,
+                    headers={
+                        "content-type": "application/pdf",
+                        "content-range": content_range(RESUME_CUT, len(other)),
+                    },
+                ),
+            ]
+        ).install(mocker)
+
+        with pytest.raises(ProviderResponseError) as excinfo:
+            await python_bridge._download_url_to_file(
+                "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+            )
+
+        assert transport.ranges == [None, f"bytes={RESUME_CUT}-"]
+        assert excinfo.value.reason == "integrity_mismatch"
+        # The spliced file is destroyed rather than parked: a later attempt
+        # resuming from it would inherit the corruption.
+        assert not list(tmp_path.glob(".source-*"))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("headers", "why"),
+        [
+            ({}, "no Content-Range at all"),
+            ({"content-range": "bytes 0-99/100"}, "a range starting somewhere else"),
+            (
+                {
+                    "content-range": content_range(RESUME_CUT, len(RESUME_BODY)),
+                    "content-encoding": "gzip",
+                },
+                "an encoded body whose offsets are not the staged ones",
+            ),
+        ],
+    )
+    async def test_resume_rejects_a_206_that_does_not_continue_the_partial(
+        self, headers, why, tmp_path, mocker, resumable
+    ):
+        """A 206 the staged bytes cannot be appended to is a failure, not a guess."""
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                    fail_after=RESUME_CUT,
+                ),
+                ScriptedResponse(
+                    body=RESUME_BODY[RESUME_CUT:],
+                    status_code=206,
+                    headers={"content-type": "application/pdf", **headers},
+                ),
+            ]
+        ).install(mocker)
+
+        with pytest.raises(ProviderResponseError) as excinfo:
+            await python_bridge._download_url_to_file(
+                "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+            )
+
+        assert transport.ranges == [None, f"bytes={RESUME_CUT}-"], why
+        assert excinfo.value.reason == "protocol_error", why
+        assert not list(tmp_path.glob(".source-*")), why
+
+    @pytest.mark.asyncio
+    async def test_unsatisfiable_range_discards_the_partial_and_starts_over(
+        self, tmp_path, mocker, resumable
+    ):
+        """A partial the server will not resume must not become a permanent trap."""
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                    fail_after=RESUME_CUT,
+                ),
+                ScriptedResponse(status_code=416, headers={}),
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                ),
+            ]
+        ).install(mocker)
+
+        result = await python_bridge._download_url_to_file(
+            "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+        )
+
+        assert transport.ranges == [None, f"bytes={RESUME_CUT}-", None]
+        assert Path(result).read_bytes() == RESUME_BODY
+
+    @pytest.mark.asyncio
+    async def test_interstitial_on_resume_leaves_the_staged_prefix_intact(
+        self, tmp_path, mocker, resumable
+    ):
+        """An expired key mid-resume must not be appended to the real bytes."""
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                    fail_after=RESUME_CUT,
+                ),
+                ScriptedResponse(
+                    body=b"<html><body>key expired</body></html>",
+                    status_code=206,
+                    headers={
+                        "content-type": "application/octet-stream",
+                        "content-range": content_range(RESUME_CUT, len(RESUME_BODY)),
+                    },
+                ),
+            ]
+        ).install(mocker)
+
+        with pytest.raises(ProviderResponseError) as excinfo:
+            await python_bridge._download_url_to_file(
+                "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+            )
+
+        assert transport.ranges == [None, f"bytes={RESUME_CUT}-"]
+        assert excinfo.value.reason == "protocol_error"
+        parked = tmp_path / f".source-{RESUME_DIGEST}.part"
+        assert parked.read_bytes() == RESUME_BODY[:RESUME_CUT]
+
+    @pytest.mark.asyncio
+    async def test_partial_survives_one_mirror_and_is_resumed_by_the_next(
+        self, tmp_path, mocker, resumable
+    ):
+        """Rotation to another mirror keeps the bytes the first one delivered.
+
+        This is the composition the issue asks for: mirrors resolve to
+        different CDN nodes, and the candidate walk already advances on a
+        failed transfer, so the parked partial is what makes that advance cost
+        the remainder rather than the whole file.
+        """
+        config = python_bridge.get_source_config()
+        config.download_resume_attempts = 0
+
+        first = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    url="https://cdn3.booksdl.test/file",
+                    headers={"content-type": "application/pdf"},
+                    fail_after=RESUME_CUT,
+                )
+            ]
+        ).install(mocker)
+
+        with pytest.raises(ProviderResponseError) as excinfo:
+            await python_bridge._download_url_to_file(
+                "https://libgen.li/get",
+                str(tmp_path),
+                RESUME_DIGEST,
+                "libgen",
+                config=config,
+            )
+
+        assert excinfo.value.reason == "partial_transfer"
+        assert excinfo.value.host == "cdn3.booksdl.test"
+        assert first.ranges == [None]
+        parked = tmp_path / f".source-{RESUME_DIGEST}.part"
+        assert parked.stat().st_size == RESUME_CUT
+
+        second = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY[RESUME_CUT:],
+                    url="https://cdn4.booksdl.test/file",
+                    status_code=206,
+                    headers={
+                        "content-type": "application/pdf",
+                        "content-range": content_range(RESUME_CUT, len(RESUME_BODY)),
+                    },
+                )
+            ]
+        ).install(mocker)
+
+        result = await python_bridge._download_url_to_file(
+            "https://libgen.vg/get",
+            str(tmp_path),
+            RESUME_DIGEST,
+            "libgen",
+            config=config,
+        )
+
+        assert second.ranges == [f"bytes={RESUME_CUT}-"]
+        assert Path(result).read_bytes() == RESUME_BODY
+        assert not parked.exists()
+
+    @pytest.mark.asyncio
+    async def test_partial_below_the_resume_floor_is_discarded(self, tmp_path, mocker):
+        """Small transfers keep their pre-#135 behaviour: one attempt, no leftovers."""
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                    fail_after=RESUME_CUT,
+                )
+            ]
+        ).install(mocker)
+
+        with pytest.raises(ProviderResponseError) as excinfo:
+            await python_bridge._download_url_to_file(
+                "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+            )
+
+        assert excinfo.value.reason == "partial_transfer"
+        assert transport.ranges == [None], (
+            "a partial under the floor costs more to resume than to refetch"
+        )
+        assert not list(tmp_path.glob(".source-*"))
+
+    @pytest.mark.asyncio
+    async def test_stale_parked_partial_is_discarded_rather_than_resumed(
+        self, tmp_path, mocker, resumable
+    ):
+        """Nothing guarantees a day-old partial is a prefix of today's file."""
+        parked = tmp_path / f".source-{RESUME_DIGEST}.part"
+        parked.write_bytes(RESUME_BODY[:RESUME_CUT])
+        stale = time.time() - (python_bridge.RESUMABLE_PARTIAL_MAX_AGE_SECONDS + 60)
+        os.utime(parked, (stale, stale))
+
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=RESUME_BODY,
+                    headers={"content-type": "application/pdf"},
+                )
+            ]
+        ).install(mocker)
+
+        result = await python_bridge._download_url_to_file(
+            "https://mirror.example/get", str(tmp_path), RESUME_DIGEST, "libgen"
+        )
+
+        assert transport.ranges == [None]
+        assert Path(result).read_bytes() == RESUME_BODY
+
+    @pytest.mark.asyncio
+    async def test_large_transfer_resumes_at_the_production_floor(
+        self, tmp_path, mocker, monkeypatch
+    ):
+        """The shipped constants, not lowered ones, recover a >1 MiB transfer.
+
+        Every other test here lowers `RESUMABLE_PARTIAL_MIN_BYTES` so a small
+        scripted body reaches the resume path. This one does not, so it is the
+        check that the defaults an operator actually runs would have saved the
+        transfers #135 reports.
+        """
+        monkeypatch.setattr(python_bridge, "RESUME_BACKOFF_SECONDS", 0)
+        body = b"%PDF-1.7 " + os.urandom(3 << 20)
+        digest = hashlib.md5(body).hexdigest()
+        cut = 3 << 19  # 1.5 MiB, above the 1 MiB floor
+
+        transport = ScriptedTransport(
+            [
+                ScriptedResponse(
+                    body=body,
+                    headers={"content-type": "application/pdf"},
+                    fail_after=cut,
+                ),
+                ScriptedResponse(
+                    body=body[cut:],
+                    status_code=206,
+                    headers={
+                        "content-type": "application/pdf",
+                        "content-range": content_range(cut, len(body)),
+                    },
+                ),
+            ]
+        ).install(mocker)
+
+        result = await python_bridge._download_url_to_file(
+            "https://mirror.example/get", str(tmp_path), digest, "libgen"
+        )
+
+        assert transport.ranges == [None, f"bytes={cut}-"]
+        assert Path(result).stat().st_size == len(body)
+        assert hashlib.md5(Path(result).read_bytes()).hexdigest() == digest

--- a/docs/RETRY_CONFIGURATION.md
+++ b/docs/RETRY_CONFIGURATION.md
@@ -40,6 +40,7 @@ the outer Node budget must remain larger than the worst-case inner provider walk
 | `BOOK_SOURCE_READ_TIMEOUT` | `30` | Response-read budget per phase, in seconds |
 | `BOOK_SOURCE_TOTAL_TIMEOUT` | `45` | Wall-clock budget for one provider operation, in seconds |
 | `BOOK_SOURCE_DOWNLOAD_TIMEOUT` | `1500` | One wall-clock budget for the complete source candidate walk (resolution plus full-transfer attempts), in seconds |
+| `BOOK_SOURCE_DOWNLOAD_RESUME_ATTEMPTS` | `2` | Extra attempts, per resolved URL, that re-request the remainder with a `Range` header after a transfer dies part-way through the body. `0` disables resume |
 | `BOOK_SOURCE_PREFLIGHT` | `true` | Probe DNS and TCP before a provider request |
 | `BOOK_SOURCE_PREFLIGHT_TIMEOUT` | `5` | Budget per DNS or TCP probe phase, in seconds |
 | `PYTHON_BRIDGE_TIMEOUT` | `240000` | Ordinary Python bridge wall-clock budget, in milliseconds |
@@ -69,6 +70,21 @@ long bridge default composes worst-case LibGen resolution
 (`600s`), and finalization headroom (`135s`). If any component is overridden,
 keep `PYTHON_BRIDGE_LONG_TIMEOUT` at least as large as their sum after converting
 milliseconds to seconds.
+
+A transfer that dies part-way through the body is retried with a `Range` request
+for the remainder rather than from byte zero, up to
+`BOOK_SOURCE_DOWNLOAD_RESUME_ATTEMPTS` times per resolved URL. Those attempts run
+**inside** `BOOK_SOURCE_DOWNLOAD_TIMEOUT`, so resume adds no wall clock — raising
+the attempt count buys more tries within the same budget, not a longer one. When
+they are exhausted the candidate walk moves to the next mirror, which resolves to
+a different CDN node, and the bytes already staged are carried across to it.
+
+Staging for a partial transfer is a hidden `.source-<md5>.part` file in the
+output directory, and it is the only record that a resumable partial exists —
+the bridge is a fresh process per call, so nothing about it can be held in
+memory. A partial smaller than 1 MiB, older than 24 hours, or beginning with an
+HTML error page is discarded rather than resumed, and every resumed file is
+re-digested whole against the catalog MD5 before it is published.
 
 LibGen download resolution inspects at most the first 2 KiB of a candidate
 response. Some CDNs ignore `Range` and answer `200`; the probe streams and closes

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -4,8 +4,9 @@ import os
 import json
 import hashlib
 import re
-import tempfile
+import time
 import traceback
+import uuid
 from typing import Optional
 from email.message import Message
 from urllib.parse import unquote, urlsplit
@@ -850,6 +851,219 @@ def _md5_digest():
         return hashlib.md5()
 
 
+# --- Partial-transfer recovery (#135) ---------------------------------------
+#
+# A CDN node behind a LibGen mirror drops connections part-way through large
+# transfers at varying offsets. Restarting from byte zero throws away every
+# byte already on disk, and on a node that keeps dropping it never converges.
+# What follows lets an attempt pick up where the last one stopped.
+#
+# The state this needs cannot live in a module global: the bridge is a fresh
+# process per MCP call, so anything held in memory is gone before the next
+# attempt. The ONLY record that a partial exists is the parked staging file
+# itself — its name carries the md5 it belongs to, its size carries how far the
+# transfer got, and its mtime carries how old that progress is. There is no
+# sidecar, so there is nothing that can fall out of step with the bytes.
+#
+# Correctness rests on the whole-file digest, not on the resume bookkeeping: a
+# resumed file is re-read from disk end to end and compared against the catalog
+# md5 before it is published. A resume that concatenated a different file — a
+# fresh key, another mirror, an error page — fails there.
+
+# Below this, a partial is not worth carrying: the round-trip to resume it
+# costs more than re-fetching it, and keeping every stub of a failed transfer
+# would litter the download directory. It also keeps small transfers behaving
+# exactly as they did before this existed.
+RESUMABLE_PARTIAL_MIN_BYTES = 1 << 20
+
+# A parked partial older than this is discarded rather than resumed. Nothing
+# guarantees the catalog still serves identical bytes for an md5 a day later,
+# and an un-resumable partial that never expires would be a permanent trap.
+RESUMABLE_PARTIAL_MAX_AGE_SECONDS = 24 * 60 * 60
+
+# Pause before re-requesting the remainder. The cause of the observed drops is
+# unconfirmed, so this is deliberately small: enough that a resume is not an
+# instant re-hammer, not enough to matter against the transfer budget.
+RESUME_BACKOFF_SECONDS = 1.0
+
+# RFC 7233 single-range response header, e.g. `bytes 1048576-5242879/5242880`.
+_CONTENT_RANGE_RE = re.compile(r"\s*bytes\s+(\d+)-(\d+)/(\d+|\*)\s*$", re.IGNORECASE)
+
+
+class _PartialTransfer(Exception):
+    """The body stopped early with usable bytes already staged on disk."""
+
+    def __init__(self, written: int, detail: str):
+        self.written = written
+        self.detail = detail
+        super().__init__(detail)
+
+
+class _RestartFresh(Exception):
+    """The staged bytes cannot be resumed; this transfer must start over."""
+
+
+def _staging_token() -> str:
+    """Unique component of one attempt's staging filename.
+
+    Every attempt writes to its own path so two bridge processes downloading
+    the same book into the same directory can never append to one file.
+    """
+    return uuid.uuid4().hex
+
+
+def _parked_partial_path(output_path: Path, expected_md5: str) -> Path:
+    """Where a resumable partial for this md5 waits between attempts."""
+    return output_path / f".source-{expected_md5}.part"
+
+
+def _file_head(path: Path, size: int = 4096) -> bytes:
+    """Leading bytes of a staged file, or b'' if it cannot be read."""
+    try:
+        with open(path, "rb") as handle:
+            return handle.read(size)
+    except OSError:
+        return b""
+
+
+def _digest_and_head(path: Path, head_size: int = 4096) -> tuple[str, bytes]:
+    """Digest a staged file whole and return its leading bytes.
+
+    Read back from disk rather than accumulated while streaming. A resumed
+    transfer only ever sees the bytes of its own range, so a digest built from
+    what this attempt received would cover a suffix and attest to nothing —
+    which is exactly how a resume that spliced in a different file would come
+    to report success.
+    """
+    digest = _md5_digest()
+    head = b""
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            if len(head) < head_size:
+                head += chunk[: head_size - len(head)]
+            digest.update(chunk)
+    return digest.hexdigest(), head
+
+
+def _truncate_to(path: Path, size: int) -> None:
+    """Drop everything a staged file holds beyond `size`."""
+    try:
+        with open(path, "r+b") as handle:
+            handle.truncate(size)
+    except OSError:
+        pass
+
+
+def _claim_parked_partial(parked: Path, working: Path) -> int:
+    """Take ownership of a resumable partial, returning its byte count.
+
+    The claim is a rename, and a rename is atomic: two processes cannot both
+    end up appending to one file, and the loser simply starts from zero on its
+    own uniquely-named attempt. Nothing blocks, and a process that dies holding
+    a claim leaves a working file that ages out rather than a lock nobody can
+    release.
+
+    Returns:
+        Bytes already staged and now owned by `working`, or 0 to start fresh.
+    """
+    try:
+        stat = parked.stat()
+    except OSError:
+        return 0
+    if (
+        stat.st_size < RESUMABLE_PARTIAL_MIN_BYTES
+        or (time.time() - stat.st_mtime) > RESUMABLE_PARTIAL_MAX_AGE_SECONDS
+    ):
+        parked.unlink(missing_ok=True)
+        return 0
+    try:
+        os.rename(parked, working)
+        return working.stat().st_size
+    except OSError:
+        return 0
+
+
+def _park_partial(working: Path, parked: Path) -> None:
+    """Keep a failed transfer's bytes for the next attempt, or discard them.
+
+    Called on every exit from a transfer, successful or not: a published
+    transfer has already consumed its working file, so this is a no-op there.
+    Everything that survives to here is a contiguous prefix of the requested
+    file — each failure path either truncates back to a verified offset or
+    deletes the file outright — so the only judgment left is whether the prefix
+    is worth keeping.
+    """
+    try:
+        size = working.stat().st_size
+    except OSError:
+        return
+    if size < RESUMABLE_PARTIAL_MIN_BYTES or _looks_like_html(_file_head(working)):
+        working.unlink(missing_ok=True)
+        return
+    try:
+        if parked.exists() and parked.stat().st_size >= size:
+            # Another attempt parked at least as much. Two prefixes of the same
+            # file are interchangeable, so keep the longer one.
+            working.unlink(missing_ok=True)
+            return
+    except OSError:
+        pass
+    try:
+        os.replace(working, parked)
+    except OSError:
+        working.unlink(missing_ok=True)
+
+
+def _declared_length(headers) -> Optional[int]:
+    """Body length a response declares, when it can be compared to disk bytes.
+
+    Ignored under a transfer encoding: `Content-Length` then counts encoded
+    bytes while the client writes decoded ones, and comparing the two would
+    report a complete transfer as truncated.
+    """
+    if _content_encoded(headers):
+        return None
+    try:
+        value = int(str(headers.get("content-length", "")).strip())
+    except (AttributeError, TypeError, ValueError):
+        return None
+    return value if value >= 0 else None
+
+
+def _content_encoded(headers) -> bool:
+    """Whether a response body is encoded rather than served as stored."""
+    try:
+        encoding = str(headers.get("content-encoding", "")).strip().lower()
+    except AttributeError:
+        return False
+    return bool(encoding) and encoding != "identity"
+
+
+def _resume_window(headers, start_at: int) -> tuple[Optional[int], Optional[int]]:
+    """Offset and total size a 206 response actually grants.
+
+    Returns (None, None) when the response cannot be appended to what is
+    already staged — a range starting somewhere other than where we asked, an
+    unparseable header, or an encoded body whose offsets do not correspond to
+    the bytes on disk. The caller discards the partial in that case rather than
+    guessing, because a mis-offset append is a corrupt file that would still
+    carry a plausible size.
+    """
+    if _content_encoded(headers):
+        return None, None
+    try:
+        raw = str(headers.get("content-range", ""))
+    except AttributeError:
+        return None, None
+    match = _CONTENT_RANGE_RE.match(raw)
+    if not match:
+        return None, None
+    first, _last, total = match.groups()
+    if int(first) != start_at:
+        return None, None
+    return start_at, (None if total == "*" else int(total))
+
+
 def _publish_no_replace(source: Path, destination: Path) -> None:
     """Atomically publish one owned file without replacing an existing path."""
     os.link(source, destination)
@@ -918,8 +1132,17 @@ async def _download_url_to_file(
     any source, so this is the only piece that had to exist for LibGen and
     Anna's results to become downloadable.
 
-    Guards against the two ways these CDNs fail without erroring: an HTML
-    error/interstitial page served with HTTP 200, and a truncated body.
+    Guards against the three ways these CDNs fail without erroring: an HTML
+    error/interstitial page served with HTTP 200, a truncated body, and — the
+    one this function used to lose the whole transfer to — a connection that
+    dies part-way through a large file. A body that stops early is retried with
+    a `Range` request for the remainder instead of from byte zero, and whatever
+    it managed to stage is parked for the next attempt, which may be the next
+    mirror in the candidate walk (#135).
+
+    Resuming buys no extra wall clock. The retries run inside the same
+    `download_timeout` the whole transfer already had, so a URL that keeps
+    dying still ends when that budget does.
     """
     import httpx
 
@@ -932,11 +1155,19 @@ async def _download_url_to_file(
 
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
-    descriptor, attempt_name = tempfile.mkstemp(
-        prefix=".source-", suffix=".part", dir=output_path
-    )
-    os.close(descriptor)
-    attempt_path = Path(attempt_name)
+
+    # The parked path is addressed by md5 so a later attempt — including one in
+    # a later bridge process — can find it. The working path is unique per
+    # attempt, and ownership of the parked bytes is taken by renaming one onto
+    # the other, which is atomic.
+    parked_path = _parked_partial_path(output_path, expected_md5)
+    # The token is joined with a dash, not a dot: the published name is this
+    # path with its suffix replaced, and a dotted token would survive that as
+    # a bogus extension on an artifact whose type could not be determined.
+    attempt_path = output_path / f".source-{expected_md5}-{_staging_token()}.part"
+    resume_from = _claim_parked_partial(parked_path, attempt_path)
+    if not resume_from:
+        os.close(os.open(attempt_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
 
     # LIBGEN_USER_AGENT is scoped to LibGen. This function is source-agnostic,
     # so sending an operator's LibGen-specific string to Anna's host would both
@@ -957,97 +1188,236 @@ async def _download_url_to_file(
     # from one object and move the file with another (Codex on #146).
     config = config or get_source_config()
 
-    async def stream_to_disk() -> tuple[int, str]:
+    async def transfer_once(client, start_at: int) -> tuple[int, "_DownloadedPath"]:
+        """Issue one request and stage its body, appending from `start_at`.
+
+        Every exit leaves `attempt_path` holding a contiguous prefix of the
+        requested file or nothing at all — appended bytes that turn out to be
+        an error page are truncated away, and anything that condemns the whole
+        staged file deletes it. That invariant is what makes parking the
+        survivor safe.
+        """
         nonlocal active_host
-        try:
-            # The admitted UA is load-bearing: libgen's hosts serve an HTML
-            # stub to blocklisted tool UAs including python-httpx's default
-            # (#124), which the HTML guard below then misreads as an expired
-            # key — the adapter verifies the URL with the right UA and the
-            # transfer dies here with the wrong one.
-            #
-            # Resolved from `config`, not the module constant: an operator who
-            # sets LIBGEN_USER_AGENT because the default went onto the
-            # blocklist would otherwise have search and key resolution honour
-            # the override while this transfer — the one request that moves the
-            # file — kept sending the blocked default (Codex on #146).
-            async with httpx.AsyncClient(
-                timeout=build_timeout(config),
-                follow_redirects=True,
-                headers={"User-Agent": user_agent},
-            ) as client:
-                async with client.stream("GET", url) as response:
-                    response_url = getattr(response, "url", None)
-                    if response_url is not None:
-                        active_host = (
-                            urlsplit(str(response_url)).hostname or active_host
-                        ).lower()
-                    if host_observer is not None:
-                        host_observer(active_host)
-                    response.raise_for_status()
 
-                    content_type = response.headers.get("content-type", "")
-                    if "text/html" in content_type:
+        # Only sent when resuming, so a fresh transfer issues exactly the
+        # request it always did.
+        stream_kwargs = {"headers": {"Range": f"bytes={start_at}-"}} if start_at else {}
+        async with client.stream("GET", url, **stream_kwargs) as response:
+            response_url = getattr(response, "url", None)
+            if response_url is not None:
+                active_host = (
+                    urlsplit(str(response_url)).hostname or active_host
+                ).lower()
+            if host_observer is not None:
+                host_observer(active_host)
+
+            status = int(getattr(response, "status_code", 200) or 200)
+            write_offset = start_at
+            expected_total: Optional[int] = None
+
+            if start_at:
+                if status == 416:
+                    # The server says our offset is past the end of the file,
+                    # so the staged bytes are not a prefix of what it serves.
+                    # Discarding them is what stops an unusable partial from
+                    # failing every future attempt for this md5.
+                    attempt_path.unlink(missing_ok=True)
+                    raise _RestartFresh(
+                        f"resume from byte {start_at} was rejected as unsatisfiable"
+                    )
+                response.raise_for_status()
+                if status == 206:
+                    write_offset, expected_total = _resume_window(
+                        response.headers, start_at
+                    )
+                    if write_offset is None:
+                        attempt_path.unlink(missing_ok=True)
                         raise ProviderResponseError(
                             provider,
                             active_host,
-                            f"HTML response for {md5}; download key may have expired",
+                            f"resume of {md5} from byte {start_at} answered 206 "
+                            f"with a Content-Range that does not continue it: "
+                            f"{response.headers.get('content-range', '')!r}",
                             reason="protocol_error",
                         )
+                else:
+                    # Range was not honoured — the body is the whole file, so
+                    # write it from the top rather than appending it to a
+                    # prefix it already contains.
+                    logger.info(
+                        "%s did not honour a Range request for %s (HTTP %d); "
+                        "restarting the transfer from the beginning",
+                        active_host,
+                        md5,
+                        status,
+                    )
+                    write_offset = 0
+            else:
+                response.raise_for_status()
 
-                    written = 0
-                    digest = _md5_digest()
-                    signature = bytearray()
-                    with open(attempt_path, "wb") as handle:
-                        async for chunk in response.aiter_bytes(65536):
-                            handle.write(chunk)
-                            digest.update(chunk)
-                            if len(signature) < 4096:
-                                signature.extend(chunk[: 4096 - len(signature)])
-                            written += len(chunk)
-                    if _looks_like_html(bytes(signature)):
-                        raise ProviderResponseError(
-                            provider,
-                            active_host,
-                            f"HTML body for {md5}; download key may have expired",
-                            reason="protocol_error",
-                        )
-                    actual_md5 = digest.hexdigest()
-                    if actual_md5 != expected_md5:
-                        raise ProviderResponseError(
-                            provider,
-                            active_host,
-                            f"expected={expected_md5} actual={actual_md5}",
-                            reason="integrity_mismatch",
-                        )
+            content_type = response.headers.get("content-type", "")
+            if "text/html" in content_type:
+                raise ProviderResponseError(
+                    provider,
+                    active_host,
+                    f"HTML response for {md5}; download key may have expired",
+                    reason="protocol_error",
+                )
 
-                    extension, extension_evidence = _response_extension(
-                        response.headers, str(response_url or url), bytes(signature)
+            if expected_total is None and write_offset == 0:
+                expected_total = _declared_length(response.headers)
+
+            new_signature = bytearray()
+            written_now = 0
+            try:
+                # Opened for update WITHOUT truncation, and created if a
+                # previous attempt in this loop discarded it — the seek and
+                # explicit truncate below set the length, so an implicit one
+                # here would silently drop a prefix we mean to keep.
+                descriptor = os.open(attempt_path, os.O_CREAT | os.O_RDWR, 0o600)
+                with open(descriptor, "r+b") as handle:
+                    handle.seek(write_offset)
+                    handle.truncate(write_offset)
+                    async for chunk in response.aiter_bytes(65536):
+                        handle.write(chunk)
+                        if len(new_signature) < 4096:
+                            new_signature.extend(chunk[: 4096 - len(new_signature)])
+                        written_now += len(chunk)
+            except Exception as exc:
+                # Bytes already on disk are worth resuming; a request that
+                # produced none tells us nothing about the transfer and belongs
+                # to the ordinary transport classifier below.
+                if written_now:
+                    raise _PartialTransfer(
+                        write_offset + written_now,
+                        f"transfer from {active_host} stopped after "
+                        f"{write_offset + written_now} bytes "
+                        f"({type(exc).__name__})",
+                    ) from exc
+                raise
+
+            written_total = write_offset + written_now
+
+            if _looks_like_html(bytes(new_signature)):
+                # An interstitial served in place of the remainder. The prefix
+                # staged before this request is untouched by it.
+                _truncate_to(attempt_path, write_offset)
+                raise ProviderResponseError(
+                    provider,
+                    active_host,
+                    f"HTML body for {md5}; download key may have expired",
+                    reason="protocol_error",
+                )
+
+            if expected_total is not None and written_total != expected_total:
+                if written_total < expected_total:
+                    raise _PartialTransfer(
+                        written_total,
+                        f"{active_host} sent {written_total} of "
+                        f"{expected_total} bytes for {md5}",
                     )
-                    completed_path = attempt_path.with_suffix(
-                        f".{extension}" if extension else ""
+                attempt_path.unlink(missing_ok=True)
+                raise ProviderResponseError(
+                    provider,
+                    active_host,
+                    f"body for {md5} ran past its declared "
+                    f"{expected_total} bytes to {written_total}",
+                    reason="protocol_error",
+                )
+
+            # Whole-file, from disk. A resumed transfer received only its own
+            # range, so this is the only check that covers the bytes an earlier
+            # attempt (or an earlier mirror) contributed.
+            actual_md5, signature = _digest_and_head(attempt_path)
+            if _looks_like_html(signature):
+                attempt_path.unlink(missing_ok=True)
+                raise ProviderResponseError(
+                    provider,
+                    active_host,
+                    f"HTML body for {md5}; download key may have expired",
+                    reason="protocol_error",
+                )
+            if actual_md5 != expected_md5:
+                attempt_path.unlink(missing_ok=True)
+                raise ProviderResponseError(
+                    provider,
+                    active_host,
+                    f"expected={expected_md5} actual={actual_md5}",
+                    reason="integrity_mismatch",
+                )
+
+            extension, extension_evidence = _response_extension(
+                response.headers, str(response_url or url), signature
+            )
+            completed_path = attempt_path.with_suffix(
+                f".{extension}" if extension else ""
+            )
+            try:
+                _publish_no_replace(attempt_path, completed_path)
+            except OSError:
+                attempt_path.unlink(missing_ok=True)
+                raise
+            return written_total, _DownloadedPath(
+                str(completed_path), extension_evidence
+            )
+
+    async def transfer() -> tuple[int, "_DownloadedPath"]:
+        """Run attempts against this URL until one completes or they run out."""
+        attempts = 1 + max(0, int(getattr(config, "download_resume_attempts", 0) or 0))
+        start_at = resume_from
+        staged = resume_from
+        detail = "transfer did not start"
+
+        async with httpx.AsyncClient(
+            timeout=build_timeout(config),
+            follow_redirects=True,
+            headers={"User-Agent": user_agent},
+        ) as client:
+            for attempt in range(attempts):
+                if attempt:
+                    await asyncio.sleep(RESUME_BACKOFF_SECONDS)
+                try:
+                    return await transfer_once(client, start_at)
+                except _RestartFresh as restart:
+                    detail = str(restart)
+                    start_at = 0
+                    staged = 0
+                except _PartialTransfer as partial:
+                    detail = partial.detail
+                    progressed = partial.written > start_at
+                    start_at = partial.written
+                    staged = partial.written
+                    if not progressed or start_at < RESUMABLE_PARTIAL_MIN_BYTES:
+                        # No forward progress, or too little staged to be worth
+                        # a round trip. Stop spending this URL's share of the
+                        # budget and let the caller try the next mirror, which
+                        # resolves to a different CDN node.
+                        break
+                    logger.warning(
+                        "Resuming %s from byte %d after a partial transfer: %s",
+                        md5,
+                        start_at,
+                        detail,
                     )
-                    _publish_no_replace(attempt_path, completed_path)
-                    return written, _DownloadedPath(
-                        str(completed_path), extension_evidence
-                    )
-        except BaseException:
-            # Cancellation and every classified failure must leave no partial
-            # artifact for a later retry to mistake for a completed download.
-            attempt_path.unlink(missing_ok=True)
-            raise
+
+        raise ProviderResponseError(
+            provider,
+            active_host,
+            f"{detail}; {staged} bytes staged for resume",
+            reason="partial_transfer",
+        )
 
     try:
         if enforce_timeout:
             written, completed_path = await bounded_await(
-                stream_to_disk(),
+                transfer(),
                 config.download_timeout,
                 provider=provider,
                 host=original_host,
                 operation="download",
             )
         else:
-            written, completed_path = await stream_to_disk()
+            written, completed_path = await transfer()
     except SourceError as exc:
         if isinstance(exc, ProviderTimeoutError) and exc.reason == "search_timeout":
             raise ProviderTimeoutError(
@@ -1086,6 +1456,12 @@ async def _download_url_to_file(
             else ProviderResponseError
         )
         raise error_type(provider, failure_host, detail, reason=reason) from exc
+    finally:
+        # Cancellation and every classified failure leave the staged prefix
+        # here. `_park_partial` keeps it only if it is large enough to be worth
+        # resuming and does not start with an error page; a published transfer
+        # has already consumed the file, so this is a no-op on success.
+        _park_partial(attempt_path, parked_path)
 
     if written == 0:
         Path(completed_path).unlink(missing_ok=True)

--- a/lib/sources/config.py
+++ b/lib/sources/config.py
@@ -10,6 +10,7 @@ Environment variables:
     BOOK_SOURCE_READ_TIMEOUT: Response-read budget, seconds (default: 30)
     BOOK_SOURCE_TOTAL_TIMEOUT: Per-provider wall-clock budget, seconds (default: 45)
     BOOK_SOURCE_DOWNLOAD_TIMEOUT: Full source-file transfer budget, seconds (default: 1500)
+    BOOK_SOURCE_DOWNLOAD_RESUME_ATTEMPTS: Range-resume retries per URL (default: 2)
     BOOK_SOURCE_PREFLIGHT: Probe host reachability before searching (default: true)
     BOOK_SOURCE_PREFLIGHT_TIMEOUT: Budget per probe phase, seconds (default: 5)
 """
@@ -42,6 +43,18 @@ DEFAULT_TOTAL_TIMEOUT = 45.0
 # TypeScript constant.
 DEFAULT_DOWNLOAD_TIMEOUT = 1500.0
 DEFAULT_PREFLIGHT_TIMEOUT = 5.0
+
+# Extra attempts, per resolved URL, that a transfer gets after it dies part-way
+# through the body. Each one re-requests the remainder with a Range header
+# rather than starting over, so the cost of a retry is the bytes still missing
+# instead of the whole file (#135).
+#
+# This buys no extra wall clock: the resume attempts run INSIDE the existing
+# `download_timeout` budget, so a transfer that keeps dying still ends when
+# that budget does — it just ends further along. Two is deliberately small;
+# after that the candidate walk moves to the next mirror, which is the other
+# half of the fix and reaches a different CDN node.
+DEFAULT_DOWNLOAD_RESUME_ATTEMPTS = 2
 
 # Hosts operated by the Anna's Archive project, per the mirror list the live
 # site itself advertises (verified 2026-07-24: .gl/.pk/.gd serve real search
@@ -121,6 +134,7 @@ class SourceConfig:
         read_timeout: Seconds allowed to read a response
         total_timeout: Seconds allowed for a whole provider operation
         download_timeout: Seconds allowed for a complete source-file transfer
+        download_resume_attempts: Range-resume retries after a partial transfer
         preflight_enabled: Probe host reachability before the real request
         preflight_timeout: Seconds allowed for each probe phase
     """
@@ -135,6 +149,7 @@ class SourceConfig:
     read_timeout: float = DEFAULT_READ_TIMEOUT
     total_timeout: float = DEFAULT_TOTAL_TIMEOUT
     download_timeout: float = DEFAULT_DOWNLOAD_TIMEOUT
+    download_resume_attempts: int = DEFAULT_DOWNLOAD_RESUME_ATTEMPTS
     preflight_enabled: bool = True
     preflight_timeout: float = DEFAULT_PREFLIGHT_TIMEOUT
 
@@ -159,6 +174,23 @@ def _positive_float(name: str, default: float) -> float:
     except ValueError:
         return default
     return value if math.isfinite(value) and value > 0 else default
+
+
+def _non_negative_int(name: str, default: int) -> int:
+    """Read a count from the environment, falling back on nonsense.
+
+    Zero is a legitimate value — it turns resume off — so unlike the timeout
+    reader this accepts it. Anything unparseable or negative falls back to the
+    default rather than to an unbounded retry count.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return default
+    return value if value >= 0 else default
 
 
 def get_source_config() -> SourceConfig:
@@ -186,6 +218,9 @@ def get_source_config() -> SourceConfig:
         ),
         download_timeout=_positive_float(
             "BOOK_SOURCE_DOWNLOAD_TIMEOUT", DEFAULT_DOWNLOAD_TIMEOUT
+        ),
+        download_resume_attempts=_non_negative_int(
+            "BOOK_SOURCE_DOWNLOAD_RESUME_ATTEMPTS", DEFAULT_DOWNLOAD_RESUME_ATTEMPTS
         ),
         preflight_enabled=os.environ.get("BOOK_SOURCE_PREFLIGHT", "true").lower()
         == "true",

--- a/lib/sources/errors.py
+++ b/lib/sources/errors.py
@@ -28,6 +28,7 @@ REASON_TEXT = {
     "http_error": "returned an HTTP error",
     "quota_exhausted": "has no downloads left on this account today",
     "protocol_error": "returned a malformed response",
+    "partial_transfer": "stopped sending the file part-way through the transfer",
     "integrity_mismatch": "returned bytes that did not match the requested digest",
     "configuration_error": "cannot run with the supplied configuration",
     "unknown": "failed for an unclassified reason",


### PR DESCRIPTION
Closes #135

## What this implements

**Both fixes the issue names.** They compose, and the second falls out of the first
almost for free.

**1. Range-based resume.** A transfer that stops part-way through the body now
re-requests only the remainder with `Range: bytes=N-` instead of starting over,
up to `BOOK_SOURCE_DOWNLOAD_RESUME_ATTEMPTS` times (default 2) per resolved URL.

**2. Mirror rotation on repeated partial failure.** The candidate walk in
`_fetch_from_source` already advanced to the next mirror on a failed transfer;
what it lost was the bytes. The staged partial now survives that hand-off, so
rotating to a different `cdnN` node costs the remainder rather than the whole
file. Mid-transfer death also gets its own reason code in the #106 envelopes —
`partial_transfer` — so an operator can tell a host that truncates from one that
never answered. This is one new code in the existing vocabulary, not a new
vocabulary.

## The design decision the issue did not specify

**Where the resume state lives.** Every MCP operation spawns a fresh
`python_bridge.py`, so nothing about a partial can survive in a module global.
Rather than add a sidecar, the staging file **is** the state: `.source-<md5>.part`
in the output directory, its name carrying the md5 it belongs to, its size
carrying the progress, its mtime carrying the age. Nothing can fall out of step
with the bytes because there is nothing else to keep in step. This also makes
resume work across MCP calls, not only across mirrors within one call.

Concurrency falls out of that choice and is handled by naming: each attempt
writes to a uniquely-named working file and claims the parked one by `os.rename`,
which is atomic. Two processes downloading the same book into the same directory
cannot interleave writes — the loser simply starts from zero on its own file.

**A 1 MiB floor and a 24-hour expiry.** A partial smaller than 1 MiB is discarded
rather than parked: resuming it costs more than re-fetching it, and the floor
keeps every small transfer behaving exactly as it did before this change. A
partial older than 24 hours is discarded because nothing guarantees the catalog
still serves identical bytes for an md5 a day later.

## Guarding against the worst outcome

A resume that concatenates a different file and reports success would be worse
than the bug. Four things stop it:

- The staged file is **re-digested whole, from disk**, against the catalog md5
  before publication. A resumed attempt only ever receives its own range, so a
  digest accumulated while streaming would attest to a suffix and nothing else.
- A resume is refused unless the server answers **206** with a `Content-Range`
  that starts at exactly the staged offset; an unparseable range, a different
  start, or a non-identity `Content-Encoding` destroys the partial rather than
  guessing.
- A **200** answer to a Range request is the whole file, so the transfer restarts
  from the top instead of appending to a prefix the body already repeats.
- A **416**, an over-long body, or an HTML interstitial in the appended bytes is
  handled explicitly, so an unusable partial cannot become a permanent trap that
  fails every future attempt for that md5.

## Budget

Resume adds **no wall clock**. The attempts run inside the existing
`download_timeout` that already bounded the transfer, so a URL that keeps dying
still ends when that budget does — it just ends further along. The diff
deliberately does not touch the mirror-walk budget arithmetic in `router.py`
that #153 is changing; the only `config.py` change is one additive field and its
env reader, away from that arithmetic.

## What I verified, and what I did not

Verified by running it:

- Full Python suite (`-m "not slow and not integration and not performance"`):
  **1346 passed on `origin/master` → 1359 passed on this branch**, 3 skipped
  (Tesseract absent), 7 xfailed. The delta is exactly the 13 new tests.
- **All 13 new tests fail on `origin/master`** and pass here — checked by
  stashing only `lib/` and re-running.
- `ruff check` and `ruff format --check` clean on all four changed source files
  (the repo has 127 pre-existing `ruff check` findings in other files;
  `python_bridge.py` was clean before and is clean after).

The new tests mock the transport entirely — a scripted response that yields N
bytes and then raises — and assert the retry issues `Range: bytes=N-`, that the
assembled file matches the expected content, size and md5, and that the
server-ignores-Range (200), wrong-content, unparseable-206, gzip, 416,
clean-short-body, HTML-interstitial, stale-partial and below-floor cases each
behave as described above. One test runs the whole resume path at the **shipped**
constants rather than lowered ones.

**Not verified — and not claimed:**

- **No real CDN drop was reproduced.** I made no live requests to LibGen or
  Anna's while working on this. Every failure above is simulated. Whether this
  actually recovers the transfers observed on 2026-08-17 depends on whether
  `cdn3.booksdl.lc` honours `Range` on the `get.php` redirect target under the
  conditions that produce the drops — the doctor probe's Range requests succeed
  against these hosts, which is suggestive, not the same measurement.
- **The cause of the drops remains unconfirmed** (node flakiness vs
  anti-hammering). Nothing in the code or comments asserts one. The 1-second
  pause before a resume is deliberately small and is not evidence of a
  conclusion either way.
- The Node/Jest suite was **not** run: this worktree has no `node_modules`, and
  the change is Python-only.
- Commit hooks were bypassed for the same reason (no `node_modules` for
  lint-staged); `ruff check` and `ruff format` were run by hand instead.

## Behaviour changes a reviewer should look at

- A body that dies **after delivering bytes** is now `partial_transfer` rather
  than its transport classification (`read_timeout` and the like). One existing
  test asserted the old reason and was updated; its actual subject — that the
  redirected CDN host owns the failure — still holds and is still asserted. A
  stall that delivers **nothing** is unchanged.
- A failed download can now leave a hidden `.source-<md5>.part` in the output
  directory. That is the feature, and it is bounded by the 1 MiB floor and the
  24-hour expiry.
- The staging filename gained the md5 and a dash-joined token
  (`.source-<md5>-<token>.part`). One existing test pinned the old name through
  `tempfile.mkstemp` and now pins it through a `_staging_token` seam instead.
